### PR TITLE
Add deployment script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /bin
 /default.etcd
 /kubeconfig
+/config

--- a/scripts/delete-federation.sh
+++ b/scripts/delete-federation.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+# Copyright 2018 The Federation v2 Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script removes the cluster registry and federation from the
+# current kubectl context.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+source "$(dirname "${BASH_SOURCE}")/util.sh"
+
+KCD="kubectl --ignore-not-found=true delete"
+
+# Remove the federation service account for the current context.
+CONTEXT="$(kubectl config current-context)"
+SA_NAME="${CONTEXT}-${CONTEXT}"
+${KCD} -n federation sa "${SA_NAME}"
+${KCD} -n federation clusterrole "federation-controller-manager:${SA_NAME}"
+${KCD} -n federation clusterrolebinding "federation-controller-manager:${SA_NAME}"
+
+# Remove federation
+${KCD} apiservice v1alpha1.federation.k8s.io
+${KCD} namespace federation
+
+# Remove cluster registry
+${KCD} clusterrolebinding federation-admin
+${KCD} apiservice v1alpha1.clusterregistry.k8s.io
+${KCD} namespace clusterregistry
+${KCD} clusterrole clusterregistry.k8s.io:apiserver
+${KCD} clusterrolebinding clusterregistry.k8s.io:apiserver
+${KCD} clusterrolebinding clusterregistry.k8s.io:apiserver-auth-delegator
+${KCD} -n kube-system rolebinding clusterregistry.k8s.io:extension-apiserver-authentication-reader
+
+# Wait for the namespaces to be removed
+function ns-deleted() {
+  kubectl get ns "${1}" &> /dev/null
+  [[ "$?" = "1" ]]
+}
+util::wait-for-condition "removal of namespace 'federation'" "ns-deleted federation" 120
+util::wait-for-condition "removal of namespace 'clusterregistry'" "ns-deleted clusterregistry" 120

--- a/scripts/deploy-federation.sh
+++ b/scripts/deploy-federation.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+
+# Copyright 2018 The Federation v2 Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script automates deployment of a federation - as documented in
+# the README - to the current kubectl context.  It also joins the
+# hosting cluster as a member of the federation.
+#
+# WARNING: The service account for the federation namespace will be
+# granted the cluster-admin role.  Until more restrictive permissions
+# are used, access to the federation namespace should be restricted to
+# trusted users.
+#
+# If using minikube, a cluster must be started prior to invoking this
+# script:
+#
+#   $ minikube start
+#
+# This script depends on crinit, kubectl, and apiserver-boot being
+# installed in the path.  These binaries can be installed via the
+# download-test-binaries.sh script, which downloads to ./bin:
+#
+#   $ ./scripts/download-test-binaries.sh
+#   $ export PATH=$(pwd)/bin:${PATH}
+#
+# To redeploy federation from scratch, prefix the deploy invocation with the deletion script:
+#
+#   # WARNING: The deletion script will remove federation and cluster registry data
+#   $ ./scripts/delete-federation.sh && ./scripts/deploy-federation.sh <image>
+#
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+source "$(dirname "${BASH_SOURCE}")/util.sh"
+
+NS=federation
+IMAGE_NAME="${1:-}"
+
+if [[ -z "${IMAGE_NAME}" ]]; then
+  >&2 echo "Usage: $0 <image>
+
+<image> should be in the form <containerregistry>/<username>/<imagename>:<tagname>
+
+Example: docker.io/<username>/federation-v2:test
+
+If intending to use the docker hub as the container registry to push
+the federation image to, make sure to login to the local docker daemon
+to ensure credentials are available for push:
+
+  $ docker login --username <username>
+"
+  exit 2
+fi
+
+# Wait for the storage provisioner to be ready.  If crinit is called
+# before dynamic provisioning is enabled, the pvc for etcd will never
+# be bound.
+function storage-provisioner-ready() {
+  local result="$(kubectl -n kube-system get pod storage-provisioner -o jsonpath='{.status.conditions[?(@.type == "Ready")].status}' 2> /dev/null)"
+  [[ "${result}" = "True" ]]
+}
+util::wait-for-condition "storage provisioner readiness" 'storage-provisioner-ready' 60
+
+crinit aggregated init mycr
+
+kubectl create ns "${NS}"
+
+apiserver-boot run in-cluster --name "${NS}" --namespace "${NS}" --image "${IMAGE_NAME}" --controller-args="-logtostderr,-v=4"
+
+# Create a permissive rolebinding to allow federation controllers to run.
+# TODO(marun) Make this more restrictive.
+kubectl create clusterrolebinding federation-admin --clusterrole=cluster-admin --serviceaccount="${NS}:default"
+
+# Increase the memory limit of the apiserver to ensure it can start.
+kubectl -n federation patch deploy federation -p '{"spec":{"template":{"spec":{"containers":[{"name":"apiserver","resources":{"limits":{"memory":"128Mi"},"requests":{"memory":"64Mi"}}}]}}}}'
+
+# Wait for the apiserver to become available so that join can be performed.
+function apiserver-available() {
+  # Being able to retrieve without error indicates the apiserver is available
+  kubectl get federatedcluster 2> /dev/null
+}
+util::wait-for-condition "apiserver availability" 'apiserver-available' 60
+
+# Join the host cluster
+go build -o bin/kubefnord cmd/kubefnord/kubefnord.go
+CONTEXT="$(kubectl config current-context)"
+./bin/kubefnord join "${CONTEXT}" --host-cluster-context "${CONTEXT}" --add-to-registry --v=2

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -1,6 +1,24 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-set -ex
+# Copyright 2018 The Federation v2 Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script validates that binaries can be built and that all tests pass.
+
+set -o errexit
+set -o nounset
+set -o pipefail
 
 # Make sure, we run in the root of the repo and
 # therefore run the tests on all packages
@@ -13,11 +31,11 @@ cd "$base_dir" || {
 
 rc=0
 
-echo "Installing test and build binaries"
-./scripts/download-test-binaries.sh
+echo "Downloading binary dependencies"
+./scripts/download-binaries.sh
 rc=$((rc || $?))
 
-echo "Building binaries"
+echo "Building federation binaries"
 PATH="${base_dir}/bin:${PATH}" apiserver-boot build executables
 go build -o bin/kubefnord cmd/kubefnord/kubefnord.go
 

--- a/scripts/util.sh
+++ b/scripts/util.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+# Copyright 2018 The Federation v2 Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This library holds bash utility functions.
+
+# util::wait-for-condition blocks until the provided condition becomes true
+#
+# Globals:
+#  None
+# Arguments:
+#  - 1: message indicating what conditions is being waited for (e.g. 'config to be written')
+#  - 2: a string representing an eval'able condition.  When eval'd it should not output
+#       anything to stdout or stderr.
+#  - 3: optional timeout in seconds.  If not provided, waits forever.
+# Returns:
+#  1 if the condition is not met before the timeout
+function util::wait-for-condition() {
+  local msg=$1
+  # condition should be a string that can be eval'd.
+  local condition=$2
+  local timeout=${3:-}
+
+  local start_msg="Waiting for ${msg}"
+  local error_msg="[ERROR] Timeout waiting for ${msg}"
+
+  local counter=0
+  while ! ${condition}; do
+    if [[ "${counter}" = "0" ]]; then
+      echo -n "${start_msg}"
+    fi
+
+    if [[ -z "${timeout}" || "${counter}" -lt "${timeout}" ]]; then
+      counter=$((counter + 1))
+      if [[ -n "${timeout}" ]]; then
+        echo -n '.'
+      fi
+      sleep 1
+    else
+      echo -e "\n${error_msg}"
+      return 1
+    fi
+  done
+
+  if [[ "${counter}" != "0" && -n "${timeout}" ]]; then
+    echo ' done'
+  fi
+}
+readonly -f util::wait-for-condition


### PR DESCRIPTION
The included scripts automate deployment and deletion of a federation (cr api + fedv2 api + fedv2 controllers) that was documented in #36.  The active kubectl context is targeted, so theoretically this will work with more than just minikube, but it's only been tested with minikube.

