### PR TITLE
Use meta accessor instead of adapter accessors.

### DIFF
--- a/pkg/controller/util/cluster_util.go
+++ b/pkg/controller/util/cluster_util.go
@@ -25,6 +25,7 @@ import (
 	fedv1a1 "github.com/kubernetes-sigs/federation-v2/pkg/apis/federation/v1alpha1"
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	pkgruntime "k8s.io/apimachinery/pkg/runtime"
 	utilnet "k8s.io/apimachinery/pkg/util/net"
 	kubeclientset "k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
@@ -141,6 +142,8 @@ var KubeconfigGetterForSecret = func(secret *apiv1.Secret) clientcmd.KubeconfigG
 // primary cluster by checking if the UIDs match for both ObjectMetas passed
 // in.
 // TODO (font): Need to revisit this when cluster ID is available.
-func IsPrimaryCluster(federatedMeta, clusterMeta *metav1.ObjectMeta) bool {
-	return federatedMeta.UID == clusterMeta.UID
+func IsPrimaryCluster(obj, clusterObj pkgruntime.Object) bool {
+	meta := MetaAccessor(obj)
+	clusterMeta := MetaAccessor(clusterObj)
+	return meta.GetUID() == clusterMeta.GetUID()
 }

--- a/pkg/controller/util/propagatedversion.go
+++ b/pkg/controller/util/propagatedversion.go
@@ -34,8 +34,8 @@ const (
 )
 
 type ComparisonHelper interface {
-	GetVersion(objectMeta *metav1.ObjectMeta) string
-	Equivalent(objMeta1, objectMeta2 *metav1.ObjectMeta) bool
+	GetVersion(objectMeta metav1.Object) string
+	Equivalent(objMeta1, objectMeta2 metav1.Object) bool
 }
 
 // NewComparisonHelper instantiates and returns a Resource or Generation Helper
@@ -57,14 +57,14 @@ type GenerationHelper struct{}
 // GetVersion returns a string containing the version in the resource's
 // ObjectMeta using the resource comparison type to perform for that
 // resource.
-func (GenerationHelper) GetVersion(objectMeta *metav1.ObjectMeta) string {
-	return strconv.FormatInt(objectMeta.Generation, 10)
+func (GenerationHelper) GetVersion(objectMeta metav1.Object) string {
+	return strconv.FormatInt(objectMeta.GetGeneration(), 10)
 }
 
 // Equivalent returns true if both object metas passed in are equivalent, false
 // otherwise.
-func (GenerationHelper) Equivalent(obj1Meta, obj2Meta *metav1.ObjectMeta) bool {
-	return ObjectMetaEquivalent(*obj1Meta, *obj2Meta)
+func (GenerationHelper) Equivalent(obj1Meta, obj2Meta metav1.Object) bool {
+	return ObjectMetaObjEquivalent(obj1Meta, obj2Meta)
 }
 
 type ResourceHelper struct{}
@@ -72,13 +72,13 @@ type ResourceHelper struct{}
 // GetVersion returns a string containing the version in the resource's
 // ObjectMeta using the resource comparison type to perform for that
 // resource.
-func (ResourceHelper) GetVersion(objectMeta *metav1.ObjectMeta) string {
-	return objectMeta.ResourceVersion
+func (ResourceHelper) GetVersion(objectMeta metav1.Object) string {
+	return objectMeta.GetResourceVersion()
 }
 
 // Equivalent returns true for ResourceVersion comparison as it doesn't require
 // comparing ObjectMeta.
-func (ResourceHelper) Equivalent(obj1Meta, obj2Meta *metav1.ObjectMeta) bool {
+func (ResourceHelper) Equivalent(obj1Meta, obj2Meta metav1.Object) bool {
 	return true
 }
 

--- a/pkg/federatedtypes/adapter.go
+++ b/pkg/federatedtypes/adapter.go
@@ -43,7 +43,6 @@ type FederatedTypeAdapter interface {
 
 type MetaAdapter interface {
 	Kind() string
-	ObjectMeta(pkgruntime.Object) *metav1.ObjectMeta
 	ObjectType() pkgruntime.Object
 }
 

--- a/pkg/federatedtypes/configmap.go
+++ b/pkg/federatedtypes/configmap.go
@@ -119,10 +119,6 @@ func (a *FederatedConfigMapTemplate) Kind() string {
 	return FederatedConfigMapKind
 }
 
-func (a *FederatedConfigMapTemplate) ObjectMeta(obj pkgruntime.Object) *metav1.ObjectMeta {
-	return &obj.(*fedv1a1.FederatedConfigMap).ObjectMeta
-}
-
 func (a *FederatedConfigMapTemplate) ObjectType() pkgruntime.Object {
 	return &fedv1a1.FederatedConfigMap{}
 }
@@ -163,10 +159,6 @@ func NewFederatedConfigMapPlacement(client fedclientset.Interface) PlacementAdap
 
 func (a *FederatedConfigMapPlacement) Kind() string {
 	return "FederatedConfigMapPlacement"
-}
-
-func (a *FederatedConfigMapPlacement) ObjectMeta(obj pkgruntime.Object) *metav1.ObjectMeta {
-	return &obj.(*fedv1a1.FederatedConfigMapPlacement).ObjectMeta
 }
 
 func (a *FederatedConfigMapPlacement) ObjectType() pkgruntime.Object {
@@ -225,10 +217,6 @@ func (a *FederatedConfigMapOverride) Kind() string {
 	return "FederatedConfigMapOverride"
 }
 
-func (a *FederatedConfigMapOverride) ObjectMeta(obj pkgruntime.Object) *metav1.ObjectMeta {
-	return &obj.(*fedv1a1.FederatedConfigMapOverride).ObjectMeta
-}
-
 func (a *FederatedConfigMapOverride) ObjectType() pkgruntime.Object {
 	return &fedv1a1.FederatedConfigMapOverride{}
 }
@@ -264,10 +252,6 @@ type ConfigMapAdapter struct {
 
 func (ConfigMapAdapter) Kind() string {
 	return ConfigMapKind
-}
-
-func (ConfigMapAdapter) ObjectMeta(obj pkgruntime.Object) *metav1.ObjectMeta {
-	return &obj.(*apiv1.ConfigMap).ObjectMeta
 }
 
 func (ConfigMapAdapter) ObjectType() pkgruntime.Object {

--- a/pkg/federatedtypes/deployment.go
+++ b/pkg/federatedtypes/deployment.go
@@ -118,10 +118,6 @@ func (a *FederatedDeploymentTemplate) Kind() string {
 	return FederatedDeploymentKind
 }
 
-func (a *FederatedDeploymentTemplate) ObjectMeta(obj pkgruntime.Object) *metav1.ObjectMeta {
-	return &obj.(*fedv1a1.FederatedDeployment).ObjectMeta
-}
-
 func (a *FederatedDeploymentTemplate) ObjectType() pkgruntime.Object {
 	return &fedv1a1.FederatedDeployment{}
 }
@@ -163,10 +159,6 @@ func NewFederatedDeploymentPlacement(client fedclientset.Interface) PlacementAda
 
 func (a *FederatedDeploymentPlacement) Kind() string {
 	return "FederatedDeploymentPlacement"
-}
-
-func (a *FederatedDeploymentPlacement) ObjectMeta(obj pkgruntime.Object) *metav1.ObjectMeta {
-	return &obj.(*fedv1a1.FederatedDeploymentPlacement).ObjectMeta
 }
 
 func (a *FederatedDeploymentPlacement) ObjectType() pkgruntime.Object {
@@ -225,10 +217,6 @@ func (a *FederatedDeploymentOverride) Kind() string {
 	return "FederatedDeploymentOverride"
 }
 
-func (a *FederatedDeploymentOverride) ObjectMeta(obj pkgruntime.Object) *metav1.ObjectMeta {
-	return &obj.(*fedv1a1.FederatedDeploymentOverride).ObjectMeta
-}
-
 func (a *FederatedDeploymentOverride) ObjectType() pkgruntime.Object {
 	return &fedv1a1.FederatedDeploymentOverride{}
 }
@@ -264,10 +252,6 @@ type DeploymentAdapter struct {
 
 func (DeploymentAdapter) Kind() string {
 	return DeploymentKind
-}
-
-func (DeploymentAdapter) ObjectMeta(obj pkgruntime.Object) *metav1.ObjectMeta {
-	return &obj.(*appsv1.Deployment).ObjectMeta
 }
 
 func (DeploymentAdapter) ObjectType() pkgruntime.Object {

--- a/pkg/federatedtypes/job.go
+++ b/pkg/federatedtypes/job.go
@@ -118,10 +118,6 @@ func (a *FederatedJobTemplate) Kind() string {
 	return FederatedJobKind
 }
 
-func (a *FederatedJobTemplate) ObjectMeta(obj pkgruntime.Object) *metav1.ObjectMeta {
-	return &obj.(*fedv1a1.FederatedJob).ObjectMeta
-}
-
 func (a *FederatedJobTemplate) ObjectType() pkgruntime.Object {
 	return &fedv1a1.FederatedJob{}
 }
@@ -163,10 +159,6 @@ func NewFederatedJobPlacement(client fedclientset.Interface) PlacementAdapter {
 
 func (a *FederatedJobPlacement) Kind() string {
 	return "FederatedJobPlacement"
-}
-
-func (a *FederatedJobPlacement) ObjectMeta(obj pkgruntime.Object) *metav1.ObjectMeta {
-	return &obj.(*fedv1a1.FederatedJobPlacement).ObjectMeta
 }
 
 func (a *FederatedJobPlacement) ObjectType() pkgruntime.Object {
@@ -225,10 +217,6 @@ func (a *FederatedJobOverride) Kind() string {
 	return "FederatedJobOverride"
 }
 
-func (a *FederatedJobOverride) ObjectMeta(obj pkgruntime.Object) *metav1.ObjectMeta {
-	return &obj.(*fedv1a1.FederatedJobOverride).ObjectMeta
-}
-
 func (a *FederatedJobOverride) ObjectType() pkgruntime.Object {
 	return &fedv1a1.FederatedJobOverride{}
 }
@@ -264,10 +252,6 @@ type JobAdapter struct {
 
 func (JobAdapter) Kind() string {
 	return JobKind
-}
-
-func (JobAdapter) ObjectMeta(obj pkgruntime.Object) *metav1.ObjectMeta {
-	return &obj.(*batchv1.Job).ObjectMeta
 }
 
 func (JobAdapter) ObjectType() pkgruntime.Object {

--- a/pkg/federatedtypes/namespace.go
+++ b/pkg/federatedtypes/namespace.go
@@ -114,10 +114,6 @@ func (a *FederatedNamespaceTemplate) Kind() string {
 	return NamespaceKind
 }
 
-func (a *FederatedNamespaceTemplate) ObjectMeta(obj pkgruntime.Object) *metav1.ObjectMeta {
-	return &obj.(*apiv1.Namespace).ObjectMeta
-}
-
 func (a *FederatedNamespaceTemplate) ObjectType() pkgruntime.Object {
 	return &apiv1.Namespace{}
 }
@@ -158,10 +154,6 @@ func NewFederatedNamespacePlacement(client fedclientset.Interface) PlacementAdap
 
 func (a *FederatedNamespacePlacement) Kind() string {
 	return FederatedNamespacePlacementKind
-}
-
-func (a *FederatedNamespacePlacement) ObjectMeta(obj pkgruntime.Object) *metav1.ObjectMeta {
-	return &obj.(*fedv1a1.FederatedNamespacePlacement).ObjectMeta
 }
 
 func (a *FederatedNamespacePlacement) ObjectType() pkgruntime.Object {
@@ -213,10 +205,6 @@ type NamespaceAdapter struct {
 
 func (NamespaceAdapter) Kind() string {
 	return NamespaceKind
-}
-
-func (NamespaceAdapter) ObjectMeta(obj pkgruntime.Object) *metav1.ObjectMeta {
-	return &obj.(*apiv1.Namespace).ObjectMeta
 }
 
 func (NamespaceAdapter) ObjectType() pkgruntime.Object {

--- a/pkg/federatedtypes/replicaset.go
+++ b/pkg/federatedtypes/replicaset.go
@@ -118,10 +118,6 @@ func (a *FederatedReplicaSetTemplate) Kind() string {
 	return FederatedReplicaSetKind
 }
 
-func (a *FederatedReplicaSetTemplate) ObjectMeta(obj pkgruntime.Object) *metav1.ObjectMeta {
-	return &obj.(*fedv1a1.FederatedReplicaSet).ObjectMeta
-}
-
 func (a *FederatedReplicaSetTemplate) ObjectType() pkgruntime.Object {
 	return &fedv1a1.FederatedReplicaSet{}
 }
@@ -163,10 +159,6 @@ func NewFederatedReplicaSetPlacement(client fedclientset.Interface) PlacementAda
 
 func (a *FederatedReplicaSetPlacement) Kind() string {
 	return "FederatedReplicaSetPlacement"
-}
-
-func (a *FederatedReplicaSetPlacement) ObjectMeta(obj pkgruntime.Object) *metav1.ObjectMeta {
-	return &obj.(*fedv1a1.FederatedReplicaSetPlacement).ObjectMeta
 }
 
 func (a *FederatedReplicaSetPlacement) ObjectType() pkgruntime.Object {
@@ -225,10 +217,6 @@ func (a *FederatedReplicaSetOverride) Kind() string {
 	return "FederatedReplicaSetOverride"
 }
 
-func (a *FederatedReplicaSetOverride) ObjectMeta(obj pkgruntime.Object) *metav1.ObjectMeta {
-	return &obj.(*fedv1a1.FederatedReplicaSetOverride).ObjectMeta
-}
-
 func (a *FederatedReplicaSetOverride) ObjectType() pkgruntime.Object {
 	return &fedv1a1.FederatedReplicaSetOverride{}
 }
@@ -264,10 +252,6 @@ type ReplicaSetAdapter struct {
 
 func (ReplicaSetAdapter) Kind() string {
 	return ReplicaSetKind
-}
-
-func (ReplicaSetAdapter) ObjectMeta(obj pkgruntime.Object) *metav1.ObjectMeta {
-	return &obj.(*appsv1.ReplicaSet).ObjectMeta
 }
 
 func (ReplicaSetAdapter) ObjectType() pkgruntime.Object {

--- a/pkg/federatedtypes/secret.go
+++ b/pkg/federatedtypes/secret.go
@@ -119,10 +119,6 @@ func (a *FederatedSecretTemplate) Kind() string {
 	return FederatedSecretKind
 }
 
-func (a *FederatedSecretTemplate) ObjectMeta(obj pkgruntime.Object) *metav1.ObjectMeta {
-	return &obj.(*fedv1a1.FederatedSecret).ObjectMeta
-}
-
 func (a *FederatedSecretTemplate) ObjectType() pkgruntime.Object {
 	return &fedv1a1.FederatedSecret{}
 }
@@ -163,10 +159,6 @@ func NewFederatedSecretPlacement(client fedclientset.Interface) PlacementAdapter
 
 func (a *FederatedSecretPlacement) Kind() string {
 	return "FederatedSecretPlacement"
-}
-
-func (a *FederatedSecretPlacement) ObjectMeta(obj pkgruntime.Object) *metav1.ObjectMeta {
-	return &obj.(*fedv1a1.FederatedSecretPlacement).ObjectMeta
 }
 
 func (a *FederatedSecretPlacement) ObjectType() pkgruntime.Object {
@@ -225,10 +217,6 @@ func (a *FederatedSecretOverride) Kind() string {
 	return "FederatedSecretOverride"
 }
 
-func (a *FederatedSecretOverride) ObjectMeta(obj pkgruntime.Object) *metav1.ObjectMeta {
-	return &obj.(*fedv1a1.FederatedSecretOverride).ObjectMeta
-}
-
 func (a *FederatedSecretOverride) ObjectType() pkgruntime.Object {
 	return &fedv1a1.FederatedSecretOverride{}
 }
@@ -264,10 +252,6 @@ type SecretAdapter struct {
 
 func (SecretAdapter) Kind() string {
 	return SecretKind
-}
-
-func (SecretAdapter) ObjectMeta(obj pkgruntime.Object) *metav1.ObjectMeta {
-	return &obj.(*corev1.Secret).ObjectMeta
 }
 
 func (SecretAdapter) ObjectType() pkgruntime.Object {

--- a/pkg/federatedtypes/service.go
+++ b/pkg/federatedtypes/service.go
@@ -126,10 +126,6 @@ func (a *FederatedServiceTemplate) Kind() string {
 	return FederatedServiceKind
 }
 
-func (a *FederatedServiceTemplate) ObjectMeta(obj pkgruntime.Object) *metav1.ObjectMeta {
-	return &obj.(*fedv1a1.FederatedService).ObjectMeta
-}
-
 func (a *FederatedServiceTemplate) ObjectType() pkgruntime.Object {
 	return &fedv1a1.FederatedService{}
 }
@@ -170,10 +166,6 @@ func NewFederatedServicePlacement(client fedclientset.Interface) PlacementAdapte
 
 func (a *FederatedServicePlacement) Kind() string {
 	return "FederatedServicePlacement"
-}
-
-func (a *FederatedServicePlacement) ObjectMeta(obj pkgruntime.Object) *metav1.ObjectMeta {
-	return &obj.(*fedv1a1.FederatedServicePlacement).ObjectMeta
 }
 
 func (a *FederatedServicePlacement) ObjectType() pkgruntime.Object {
@@ -225,10 +217,6 @@ type ServiceAdapter struct {
 
 func (ServiceAdapter) Kind() string {
 	return ServiceKind
-}
-
-func (ServiceAdapter) ObjectMeta(obj pkgruntime.Object) *metav1.ObjectMeta {
-	return &obj.(*corev1.Service).ObjectMeta
 }
 
 func (ServiceAdapter) ObjectType() pkgruntime.Object {


### PR DESCRIPTION
This is in support of unstructured resources which implement
the meta.Object but lacks the fields of meta.ObjectMeta.