### PR TITLE
Workaround ns version handling issue

### DIFF
--- a/pkg/controller/sync/controller.go
+++ b/pkg/controller/sync/controller.go
@@ -496,8 +496,13 @@ func (s *FederationSyncController) reconcile(qualifiedName federatedtypes.Qualif
 	}.String()
 	// TODO(marun) LOCK!
 	if s.pendingVersionUpdates.Has(propagatedVersionKey) {
-		// A status update is pending
-		return statusNeedsRecheck
+		// TODO(marun) Need to revisit how namespace deletion affects
+		// the version cache.  Ignoring may cause some unnecessary
+		// updates, but that's better than looping endlessly.
+		if kind != federatedtypes.NamespaceKind {
+			// A status update is pending
+			return statusNeedsRecheck
+		}
 	}
 	propagatedVersionFromCache, err := s.objFromCache(s.propagatedVersionStore,
 		"PropagatedVersion", propagatedVersionKey)


### PR DESCRIPTION
I traced #64 to the version cache.  I'll pursue a proper fix on Monday, but disabling the check for namespaces fixes the problem (at the cost of potentially performing some unnecessary updates).

cc: @font @onyiny-ang 