### PR TITLE
Change scope of FederatedCluster to be Namespaced

### DIFF
--- a/pkg/apis/core/v1alpha1/federatedcluster_types.go
+++ b/pkg/apis/core/v1alpha1/federatedcluster_types.go
@@ -60,7 +60,6 @@ type FederatedClusterStatus struct {
 
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +genclient:nonNamespaced
 
 // FederatedCluster
 // +k8s:openapi-gen=true

--- a/pkg/apis/core/v1alpha1/zz_generated.kubebuilder.go
+++ b/pkg/apis/core/v1alpha1/zz_generated.kubebuilder.go
@@ -280,7 +280,7 @@ var (
 				Kind:   "FederatedCluster",
 				Plural: "federatedclusters",
 			},
-			Scope: "Cluster",
+			Scope: "Namespaced",
 			Validation: &v1beta1.CustomResourceValidation{
 				OpenAPIV3Schema: &v1beta1.JSONSchemaProps{
 					Properties: map[string]v1beta1.JSONSchemaProps{

--- a/pkg/client/clientset/versioned/typed/core/v1alpha1/core_client.go
+++ b/pkg/client/clientset/versioned/typed/core/v1alpha1/core_client.go
@@ -55,8 +55,8 @@ type CoreV1alpha1Client struct {
 	restClient rest.Interface
 }
 
-func (c *CoreV1alpha1Client) FederatedClusters() FederatedClusterInterface {
-	return newFederatedClusters(c)
+func (c *CoreV1alpha1Client) FederatedClusters(namespace string) FederatedClusterInterface {
+	return newFederatedClusters(c, namespace)
 }
 
 func (c *CoreV1alpha1Client) FederatedConfigMaps(namespace string) FederatedConfigMapInterface {

--- a/pkg/client/clientset/versioned/typed/core/v1alpha1/fake/fake_core_client.go
+++ b/pkg/client/clientset/versioned/typed/core/v1alpha1/fake/fake_core_client.go
@@ -28,8 +28,8 @@ type FakeCoreV1alpha1 struct {
 	*testing.Fake
 }
 
-func (c *FakeCoreV1alpha1) FederatedClusters() v1alpha1.FederatedClusterInterface {
-	return &FakeFederatedClusters{c}
+func (c *FakeCoreV1alpha1) FederatedClusters(namespace string) v1alpha1.FederatedClusterInterface {
+	return &FakeFederatedClusters{c, namespace}
 }
 
 func (c *FakeCoreV1alpha1) FederatedConfigMaps(namespace string) v1alpha1.FederatedConfigMapInterface {

--- a/pkg/client/clientset/versioned/typed/core/v1alpha1/fake/fake_federatedcluster.go
+++ b/pkg/client/clientset/versioned/typed/core/v1alpha1/fake/fake_federatedcluster.go
@@ -31,6 +31,7 @@ import (
 // FakeFederatedClusters implements FederatedClusterInterface
 type FakeFederatedClusters struct {
 	Fake *FakeCoreV1alpha1
+	ns   string
 }
 
 var federatedclustersResource = schema.GroupVersionResource{Group: "core.federation.k8s.io", Version: "v1alpha1", Resource: "federatedclusters"}
@@ -40,7 +41,8 @@ var federatedclustersKind = schema.GroupVersionKind{Group: "core.federation.k8s.
 // Get takes name of the federatedCluster, and returns the corresponding federatedCluster object, and an error if there is any.
 func (c *FakeFederatedClusters) Get(name string, options v1.GetOptions) (result *v1alpha1.FederatedCluster, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewRootGetAction(federatedclustersResource, name), &v1alpha1.FederatedCluster{})
+		Invokes(testing.NewGetAction(federatedclustersResource, c.ns, name), &v1alpha1.FederatedCluster{})
+
 	if obj == nil {
 		return nil, err
 	}
@@ -50,7 +52,8 @@ func (c *FakeFederatedClusters) Get(name string, options v1.GetOptions) (result 
 // List takes label and field selectors, and returns the list of FederatedClusters that match those selectors.
 func (c *FakeFederatedClusters) List(opts v1.ListOptions) (result *v1alpha1.FederatedClusterList, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewRootListAction(federatedclustersResource, federatedclustersKind, opts), &v1alpha1.FederatedClusterList{})
+		Invokes(testing.NewListAction(federatedclustersResource, federatedclustersKind, c.ns, opts), &v1alpha1.FederatedClusterList{})
+
 	if obj == nil {
 		return nil, err
 	}
@@ -71,13 +74,15 @@ func (c *FakeFederatedClusters) List(opts v1.ListOptions) (result *v1alpha1.Fede
 // Watch returns a watch.Interface that watches the requested federatedClusters.
 func (c *FakeFederatedClusters) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
-		InvokesWatch(testing.NewRootWatchAction(federatedclustersResource, opts))
+		InvokesWatch(testing.NewWatchAction(federatedclustersResource, c.ns, opts))
+
 }
 
 // Create takes the representation of a federatedCluster and creates it.  Returns the server's representation of the federatedCluster, and an error, if there is any.
 func (c *FakeFederatedClusters) Create(federatedCluster *v1alpha1.FederatedCluster) (result *v1alpha1.FederatedCluster, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewRootCreateAction(federatedclustersResource, federatedCluster), &v1alpha1.FederatedCluster{})
+		Invokes(testing.NewCreateAction(federatedclustersResource, c.ns, federatedCluster), &v1alpha1.FederatedCluster{})
+
 	if obj == nil {
 		return nil, err
 	}
@@ -87,7 +92,8 @@ func (c *FakeFederatedClusters) Create(federatedCluster *v1alpha1.FederatedClust
 // Update takes the representation of a federatedCluster and updates it. Returns the server's representation of the federatedCluster, and an error, if there is any.
 func (c *FakeFederatedClusters) Update(federatedCluster *v1alpha1.FederatedCluster) (result *v1alpha1.FederatedCluster, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewRootUpdateAction(federatedclustersResource, federatedCluster), &v1alpha1.FederatedCluster{})
+		Invokes(testing.NewUpdateAction(federatedclustersResource, c.ns, federatedCluster), &v1alpha1.FederatedCluster{})
+
 	if obj == nil {
 		return nil, err
 	}
@@ -98,7 +104,8 @@ func (c *FakeFederatedClusters) Update(federatedCluster *v1alpha1.FederatedClust
 // Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 func (c *FakeFederatedClusters) UpdateStatus(federatedCluster *v1alpha1.FederatedCluster) (*v1alpha1.FederatedCluster, error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewRootUpdateSubresourceAction(federatedclustersResource, "status", federatedCluster), &v1alpha1.FederatedCluster{})
+		Invokes(testing.NewUpdateSubresourceAction(federatedclustersResource, "status", c.ns, federatedCluster), &v1alpha1.FederatedCluster{})
+
 	if obj == nil {
 		return nil, err
 	}
@@ -108,13 +115,14 @@ func (c *FakeFederatedClusters) UpdateStatus(federatedCluster *v1alpha1.Federate
 // Delete takes name of the federatedCluster and deletes it. Returns an error if one occurs.
 func (c *FakeFederatedClusters) Delete(name string, options *v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewRootDeleteAction(federatedclustersResource, name), &v1alpha1.FederatedCluster{})
+		Invokes(testing.NewDeleteAction(federatedclustersResource, c.ns, name), &v1alpha1.FederatedCluster{})
+
 	return err
 }
 
 // DeleteCollection deletes a collection of objects.
 func (c *FakeFederatedClusters) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewRootDeleteCollectionAction(federatedclustersResource, listOptions)
+	action := testing.NewDeleteCollectionAction(federatedclustersResource, c.ns, listOptions)
 
 	_, err := c.Fake.Invokes(action, &v1alpha1.FederatedClusterList{})
 	return err
@@ -123,7 +131,8 @@ func (c *FakeFederatedClusters) DeleteCollection(options *v1.DeleteOptions, list
 // Patch applies the patch and returns the patched federatedCluster.
 func (c *FakeFederatedClusters) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1alpha1.FederatedCluster, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewRootPatchSubresourceAction(federatedclustersResource, name, data, subresources...), &v1alpha1.FederatedCluster{})
+		Invokes(testing.NewPatchSubresourceAction(federatedclustersResource, c.ns, name, data, subresources...), &v1alpha1.FederatedCluster{})
+
 	if obj == nil {
 		return nil, err
 	}

--- a/pkg/client/clientset/versioned/typed/core/v1alpha1/federatedcluster.go
+++ b/pkg/client/clientset/versioned/typed/core/v1alpha1/federatedcluster.go
@@ -30,7 +30,7 @@ import (
 // FederatedClustersGetter has a method to return a FederatedClusterInterface.
 // A group's client should implement this interface.
 type FederatedClustersGetter interface {
-	FederatedClusters() FederatedClusterInterface
+	FederatedClusters(namespace string) FederatedClusterInterface
 }
 
 // FederatedClusterInterface has methods to work with FederatedCluster resources.
@@ -50,12 +50,14 @@ type FederatedClusterInterface interface {
 // federatedClusters implements FederatedClusterInterface
 type federatedClusters struct {
 	client rest.Interface
+	ns     string
 }
 
 // newFederatedClusters returns a FederatedClusters
-func newFederatedClusters(c *CoreV1alpha1Client) *federatedClusters {
+func newFederatedClusters(c *CoreV1alpha1Client, namespace string) *federatedClusters {
 	return &federatedClusters{
 		client: c.RESTClient(),
+		ns:     namespace,
 	}
 }
 
@@ -63,6 +65,7 @@ func newFederatedClusters(c *CoreV1alpha1Client) *federatedClusters {
 func (c *federatedClusters) Get(name string, options v1.GetOptions) (result *v1alpha1.FederatedCluster, err error) {
 	result = &v1alpha1.FederatedCluster{}
 	err = c.client.Get().
+		Namespace(c.ns).
 		Resource("federatedclusters").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -75,6 +78,7 @@ func (c *federatedClusters) Get(name string, options v1.GetOptions) (result *v1a
 func (c *federatedClusters) List(opts v1.ListOptions) (result *v1alpha1.FederatedClusterList, err error) {
 	result = &v1alpha1.FederatedClusterList{}
 	err = c.client.Get().
+		Namespace(c.ns).
 		Resource("federatedclusters").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Do().
@@ -86,6 +90,7 @@ func (c *federatedClusters) List(opts v1.ListOptions) (result *v1alpha1.Federate
 func (c *federatedClusters) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	opts.Watch = true
 	return c.client.Get().
+		Namespace(c.ns).
 		Resource("federatedclusters").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Watch()
@@ -95,6 +100,7 @@ func (c *federatedClusters) Watch(opts v1.ListOptions) (watch.Interface, error) 
 func (c *federatedClusters) Create(federatedCluster *v1alpha1.FederatedCluster) (result *v1alpha1.FederatedCluster, err error) {
 	result = &v1alpha1.FederatedCluster{}
 	err = c.client.Post().
+		Namespace(c.ns).
 		Resource("federatedclusters").
 		Body(federatedCluster).
 		Do().
@@ -106,6 +112,7 @@ func (c *federatedClusters) Create(federatedCluster *v1alpha1.FederatedCluster) 
 func (c *federatedClusters) Update(federatedCluster *v1alpha1.FederatedCluster) (result *v1alpha1.FederatedCluster, err error) {
 	result = &v1alpha1.FederatedCluster{}
 	err = c.client.Put().
+		Namespace(c.ns).
 		Resource("federatedclusters").
 		Name(federatedCluster.Name).
 		Body(federatedCluster).
@@ -120,6 +127,7 @@ func (c *federatedClusters) Update(federatedCluster *v1alpha1.FederatedCluster) 
 func (c *federatedClusters) UpdateStatus(federatedCluster *v1alpha1.FederatedCluster) (result *v1alpha1.FederatedCluster, err error) {
 	result = &v1alpha1.FederatedCluster{}
 	err = c.client.Put().
+		Namespace(c.ns).
 		Resource("federatedclusters").
 		Name(federatedCluster.Name).
 		SubResource("status").
@@ -132,6 +140,7 @@ func (c *federatedClusters) UpdateStatus(federatedCluster *v1alpha1.FederatedClu
 // Delete takes name of the federatedCluster and deletes it. Returns an error if one occurs.
 func (c *federatedClusters) Delete(name string, options *v1.DeleteOptions) error {
 	return c.client.Delete().
+		Namespace(c.ns).
 		Resource("federatedclusters").
 		Name(name).
 		Body(options).
@@ -142,6 +151,7 @@ func (c *federatedClusters) Delete(name string, options *v1.DeleteOptions) error
 // DeleteCollection deletes a collection of objects.
 func (c *federatedClusters) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
 	return c.client.Delete().
+		Namespace(c.ns).
 		Resource("federatedclusters").
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Body(options).
@@ -153,6 +163,7 @@ func (c *federatedClusters) DeleteCollection(options *v1.DeleteOptions, listOpti
 func (c *federatedClusters) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1alpha1.FederatedCluster, err error) {
 	result = &v1alpha1.FederatedCluster{}
 	err = c.client.Patch(pt).
+		Namespace(c.ns).
 		Resource("federatedclusters").
 		SubResource(subresources...).
 		Name(name).

--- a/pkg/client/informers/externalversions/core/v1alpha1/federatedcluster.go
+++ b/pkg/client/informers/externalversions/core/v1alpha1/federatedcluster.go
@@ -41,32 +41,33 @@ type FederatedClusterInformer interface {
 type federatedClusterInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
 	tweakListOptions internalinterfaces.TweakListOptionsFunc
+	namespace        string
 }
 
 // NewFederatedClusterInformer constructs a new informer for FederatedCluster type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewFederatedClusterInformer(client versioned.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
-	return NewFilteredFederatedClusterInformer(client, resyncPeriod, indexers, nil)
+func NewFederatedClusterInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return NewFilteredFederatedClusterInformer(client, namespace, resyncPeriod, indexers, nil)
 }
 
 // NewFilteredFederatedClusterInformer constructs a new informer for FederatedCluster type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewFilteredFederatedClusterInformer(client versioned.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
+func NewFilteredFederatedClusterInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
 	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.CoreV1alpha1().FederatedClusters().List(options)
+				return client.CoreV1alpha1().FederatedClusters(namespace).List(options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.CoreV1alpha1().FederatedClusters().Watch(options)
+				return client.CoreV1alpha1().FederatedClusters(namespace).Watch(options)
 			},
 		},
 		&core_v1alpha1.FederatedCluster{},
@@ -76,7 +77,7 @@ func NewFilteredFederatedClusterInformer(client versioned.Interface, resyncPerio
 }
 
 func (f *federatedClusterInformer) defaultInformer(client versioned.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredFederatedClusterInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	return NewFilteredFederatedClusterInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
 }
 
 func (f *federatedClusterInformer) Informer() cache.SharedIndexInformer {

--- a/pkg/client/informers/externalversions/core/v1alpha1/interface.go
+++ b/pkg/client/informers/externalversions/core/v1alpha1/interface.go
@@ -81,7 +81,7 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 
 // FederatedClusters returns a FederatedClusterInformer.
 func (v *version) FederatedClusters() FederatedClusterInformer {
-	return &federatedClusterInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
+	return &federatedClusterInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
 }
 
 // FederatedConfigMaps returns a FederatedConfigMapInformer.

--- a/pkg/client/listers/core/v1alpha1/expansion_generated.go
+++ b/pkg/client/listers/core/v1alpha1/expansion_generated.go
@@ -22,6 +22,10 @@ package v1alpha1
 // FederatedClusterLister.
 type FederatedClusterListerExpansion interface{}
 
+// FederatedClusterNamespaceListerExpansion allows custom methods to be added to
+// FederatedClusterNamespaceLister.
+type FederatedClusterNamespaceListerExpansion interface{}
+
 // FederatedConfigMapListerExpansion allows custom methods to be added to
 // FederatedConfigMapLister.
 type FederatedConfigMapListerExpansion interface{}

--- a/pkg/client/listers/core/v1alpha1/federatedcluster.go
+++ b/pkg/client/listers/core/v1alpha1/federatedcluster.go
@@ -29,8 +29,8 @@ import (
 type FederatedClusterLister interface {
 	// List lists all FederatedClusters in the indexer.
 	List(selector labels.Selector) (ret []*v1alpha1.FederatedCluster, err error)
-	// Get retrieves the FederatedCluster from the index for a given name.
-	Get(name string) (*v1alpha1.FederatedCluster, error)
+	// FederatedClusters returns an object that can list and get FederatedClusters.
+	FederatedClusters(namespace string) FederatedClusterNamespaceLister
 	FederatedClusterListerExpansion
 }
 
@@ -52,9 +52,38 @@ func (s *federatedClusterLister) List(selector labels.Selector) (ret []*v1alpha1
 	return ret, err
 }
 
-// Get retrieves the FederatedCluster from the index for a given name.
-func (s *federatedClusterLister) Get(name string) (*v1alpha1.FederatedCluster, error) {
-	obj, exists, err := s.indexer.GetByKey(name)
+// FederatedClusters returns an object that can list and get FederatedClusters.
+func (s *federatedClusterLister) FederatedClusters(namespace string) FederatedClusterNamespaceLister {
+	return federatedClusterNamespaceLister{indexer: s.indexer, namespace: namespace}
+}
+
+// FederatedClusterNamespaceLister helps list and get FederatedClusters.
+type FederatedClusterNamespaceLister interface {
+	// List lists all FederatedClusters in the indexer for a given namespace.
+	List(selector labels.Selector) (ret []*v1alpha1.FederatedCluster, err error)
+	// Get retrieves the FederatedCluster from the indexer for a given namespace and name.
+	Get(name string) (*v1alpha1.FederatedCluster, error)
+	FederatedClusterNamespaceListerExpansion
+}
+
+// federatedClusterNamespaceLister implements the FederatedClusterNamespaceLister
+// interface.
+type federatedClusterNamespaceLister struct {
+	indexer   cache.Indexer
+	namespace string
+}
+
+// List lists all FederatedClusters in the indexer for a given namespace.
+func (s federatedClusterNamespaceLister) List(selector labels.Selector) (ret []*v1alpha1.FederatedCluster, err error) {
+	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
+		ret = append(ret, m.(*v1alpha1.FederatedCluster))
+	})
+	return ret, err
+}
+
+// Get retrieves the FederatedCluster from the indexer for a given namespace and name.
+func (s federatedClusterNamespaceLister) Get(name string) (*v1alpha1.FederatedCluster, error) {
+	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/federatedcluster/controller.go
+++ b/pkg/controller/federatedcluster/controller.go
@@ -82,10 +82,10 @@ func newClusterController(fedClient fedclientset.Interface, kubeClient kubeclien
 	_, cc.clusterController = cache.NewInformer(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
-				return cc.fedClient.CoreV1alpha1().FederatedClusters().List(options)
+				return cc.fedClient.CoreV1alpha1().FederatedClusters(util.FederationSystemNamespace).List(options)
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-				return cc.fedClient.CoreV1alpha1().FederatedClusters().Watch(options)
+				return cc.fedClient.CoreV1alpha1().FederatedClusters(util.FederationSystemNamespace).Watch(options)
 			},
 		},
 		&fedv1a1.FederatedCluster{},
@@ -156,7 +156,7 @@ func (cc *ClusterController) Run(stopChan <-chan struct{}) {
 
 // updateClusterStatus checks cluster status and get the metrics from cluster's restapi
 func (cc *ClusterController) updateClusterStatus() error {
-	clusters, err := cc.fedClient.CoreV1alpha1().FederatedClusters().List(metav1.ListOptions{})
+	clusters, err := cc.fedClient.CoreV1alpha1().FederatedClusters(util.FederationSystemNamespace).List(metav1.ListOptions{})
 	if err != nil {
 		return err
 	}
@@ -218,7 +218,7 @@ func (cc *ClusterController) updateClusterStatus() error {
 		cc.clusterClusterStatusMap[cluster.Name] = *clusterStatusNew
 		cc.mu.Unlock()
 		cluster.Status = *clusterStatusNew
-		cluster, err := cc.fedClient.CoreV1alpha1().FederatedClusters().UpdateStatus(&cluster)
+		cluster, err := cc.fedClient.CoreV1alpha1().FederatedClusters(util.FederationSystemNamespace).UpdateStatus(&cluster)
 		if err != nil {
 			glog.Warningf("Failed to update the status of cluster: %v ,error is : %v", cluster.Name, err)
 			// Don't return err here, as we want to continue processing remaining clusters.

--- a/pkg/controller/util/federated_informer.go
+++ b/pkg/controller/util/federated_informer.go
@@ -176,10 +176,10 @@ func NewFederatedInformer(
 	federatedInformer.clusterInformer.store, federatedInformer.clusterInformer.controller = cache.NewInformer(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (pkgruntime.Object, error) {
-				return fedClient.CoreV1alpha1().FederatedClusters().List(options)
+				return fedClient.CoreV1alpha1().FederatedClusters(FederationSystemNamespace).List(options)
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-				return fedClient.CoreV1alpha1().FederatedClusters().Watch(options)
+				return fedClient.CoreV1alpha1().FederatedClusters(FederationSystemNamespace).Watch(options)
 			},
 		},
 		&fedv1a1.FederatedCluster{},
@@ -383,7 +383,8 @@ func (f *federatedInformerImpl) GetReadyCluster(name string) (*fedv1a1.Federated
 }
 
 func (f *federatedInformerImpl) getReadyClusterUnlocked(name string) (*fedv1a1.FederatedCluster, bool, error) {
-	if obj, exist, err := f.clusterInformer.store.GetByKey(name); exist && err == nil {
+	key := fmt.Sprintf("%s/%s", FederationSystemNamespace, name)
+	if obj, exist, err := f.clusterInformer.store.GetByKey(key); exist && err == nil {
 		if cluster, ok := obj.(*fedv1a1.FederatedCluster); ok {
 			if isClusterReady(cluster) {
 				return cluster, true, nil

--- a/pkg/kubefnord/join.go
+++ b/pkg/kubefnord/join.go
@@ -363,7 +363,7 @@ func createFederatedCluster(fedClientset *fedclient.Clientset, joiningClusterNam
 		return fedCluster, nil
 	}
 
-	fedCluster, err := fedClientset.CoreV1alpha1().FederatedClusters().Create(fedCluster)
+	fedCluster, err := fedClientset.CoreV1alpha1().FederatedClusters(controllerutil.FederationSystemNamespace).Create(fedCluster)
 
 	if err != nil {
 		return fedCluster, err

--- a/test/e2e/framework/unmanaged.go
+++ b/test/e2e/framework/unmanaged.go
@@ -223,7 +223,7 @@ func (f *UnmanagedFramework) ClusterConfigs(userAgent string) map[string]*restcl
 
 	By("Obtaining a list of federated clusters")
 	fedClient := f.FedClient(userAgent)
-	clusterList, err := fedClient.CoreV1alpha1().FederatedClusters().List(metav1.ListOptions{})
+	clusterList, err := fedClient.CoreV1alpha1().FederatedClusters(util.FederationSystemNamespace).List(metav1.ListOptions{})
 	ExpectNoError(err, fmt.Sprintf("Error retrieving list of federated clusters: %+v", err))
 
 	if len(clusterList.Items) == 0 {
@@ -323,7 +323,7 @@ func loadConfig(configPath, context string) (*restclient.Config, *clientcmdapi.C
 // without error.
 func waitForApiserver(client fedclientset.Interface) error {
 	return wait.PollImmediate(time.Second, 1*time.Minute, func() (bool, error) {
-		_, err := client.CoreV1alpha1().FederatedClusters().List(metav1.ListOptions{})
+		_, err := client.CoreV1alpha1().FederatedClusters(util.FederationSystemNamespace).List(metav1.ListOptions{})
 		if err != nil {
 			return false, nil
 		}
@@ -379,7 +379,7 @@ func ClusterIsReadyOrFail(client fedclientset.Interface, cluster *fedv1a1.Federa
 			}
 		}
 		var err error
-		cluster, err = client.CoreV1alpha1().FederatedClusters().Get(clusterName, metav1.GetOptions{})
+		cluster, err = client.CoreV1alpha1().FederatedClusters(util.FederationSystemNamespace).Get(clusterName, metav1.GetOptions{})
 		if err != nil {
 			return false, err
 		}

--- a/test/e2e/servicedns.go
+++ b/test/e2e/servicedns.go
@@ -29,6 +29,7 @@ import (
 	fedv1a1 "github.com/kubernetes-sigs/federation-v2/pkg/apis/core/v1alpha1"
 	dnsv1a1 "github.com/kubernetes-sigs/federation-v2/pkg/apis/multiclusterdns/v1alpha1"
 	fedclientset "github.com/kubernetes-sigs/federation-v2/pkg/client/clientset/versioned"
+	"github.com/kubernetes-sigs/federation-v2/pkg/controller/util"
 	"github.com/kubernetes-sigs/federation-v2/test/common"
 	"github.com/kubernetes-sigs/federation-v2/test/e2e/framework"
 
@@ -48,7 +49,7 @@ var _ = Describe("MultiClusterServiceDNS", func() {
 
 	BeforeEach(func() {
 		fedClient = f.FedClient(userAgent)
-		federatedClusters, err := fedClient.CoreV1alpha1().FederatedClusters().List(metav1.ListOptions{})
+		federatedClusters, err := fedClient.CoreV1alpha1().FederatedClusters(util.FederationSystemNamespace).List(metav1.ListOptions{})
 		framework.ExpectNoError(err, "Error listing federated clusters")
 		clusterRegionZones = make(map[string]fedv1a1.FederatedClusterStatus)
 		for _, cluster := range federatedClusters.Items {

--- a/test/integration/framework/federation.go
+++ b/test/integration/framework/federation.go
@@ -201,7 +201,7 @@ func (f *FederationFixture) createSecret(tl common.TestLogger, clusterFixture *K
 // associates the cluster and secret.
 func (f *FederationFixture) createFederatedCluster(tl common.TestLogger, clusterName, secretName string) {
 	fedClient := f.NewFedClient(tl, userAgent)
-	_, err := fedClient.CoreV1alpha1().FederatedClusters().Create(&fedv1a1.FederatedCluster{
+	_, err := fedClient.CoreV1alpha1().FederatedClusters(util.FederationSystemNamespace).Create(&fedv1a1.FederatedCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: clusterName,
 		},

--- a/test/integration/replicaschedulingpreference_test.go
+++ b/test/integration/replicaschedulingpreference_test.go
@@ -23,6 +23,7 @@ import (
 	fedv1a1 "github.com/kubernetes-sigs/federation-v2/pkg/apis/core/v1alpha1"
 	fedschedulingv1a1 "github.com/kubernetes-sigs/federation-v2/pkg/apis/scheduling/v1alpha1"
 	clientset "github.com/kubernetes-sigs/federation-v2/pkg/client/clientset/versioned"
+	"github.com/kubernetes-sigs/federation-v2/pkg/controller/util"
 	"github.com/kubernetes-sigs/federation-v2/test/common"
 	"github.com/kubernetes-sigs/federation-v2/test/integration/framework"
 	appsv1 "k8s.io/api/apps/v1"
@@ -265,7 +266,7 @@ func waitForMatchingOverride(fedClient clientset.Interface, name, namespace, tar
 func getClusterNames(fedClient clientset.Interface) []string {
 	clusters := []string{}
 
-	clusterList, err := fedClient.CoreV1alpha1().FederatedClusters().List(metav1.ListOptions{})
+	clusterList, err := fedClient.CoreV1alpha1().FederatedClusters(util.FederationSystemNamespace).List(metav1.ListOptions{})
 	if err != nil || clusterList == nil {
 		return clusters
 	}

--- a/test/integration/servicedns_test.go
+++ b/test/integration/servicedns_test.go
@@ -32,6 +32,7 @@ import (
 	dnsv1a1 "github.com/kubernetes-sigs/federation-v2/pkg/apis/multiclusterdns/v1alpha1"
 	fedclientset "github.com/kubernetes-sigs/federation-v2/pkg/client/clientset/versioned"
 	"github.com/kubernetes-sigs/federation-v2/pkg/controller/servicedns"
+	"github.com/kubernetes-sigs/federation-v2/pkg/controller/util"
 	"github.com/kubernetes-sigs/federation-v2/test/common"
 	"github.com/kubernetes-sigs/federation-v2/test/integration/framework"
 )
@@ -172,12 +173,12 @@ func newServiceDNSTestFixture(tl common.TestLogger, fedFixture *framework.Federa
 		}
 		f.clusterRegionZones[clusterName] = regionZones
 
-		federatedCluster, err := f.client.CoreV1alpha1().FederatedClusters().Get(clusterName, metav1.GetOptions{})
+		federatedCluster, err := f.client.CoreV1alpha1().FederatedClusters(util.FederationSystemNamespace).Get(clusterName, metav1.GetOptions{})
 		if err != nil {
 			tl.Fatal("Error retrieving federated cluster %q: %v", clusterName, err)
 		}
 		federatedCluster.Status = f.clusterRegionZones[clusterName]
-		_, err = f.client.CoreV1alpha1().FederatedClusters().UpdateStatus(federatedCluster)
+		_, err = f.client.CoreV1alpha1().FederatedClusters(util.FederationSystemNamespace).UpdateStatus(federatedCluster)
 		if err != nil {
 			tl.Fatal("Error updating federated cluster status %q: %v", clusterName, err)
 		}


### PR DESCRIPTION
This is to align with the switch of cluster-registry's Cluster resource's scope.  FederatedCluster resources will be stored in the `federation-system` namespace (where the secrets holding the auth credentials for the clusters are already stored).

Fixes ~#107~ #110.