### PR TITLE
Rename kubefnord to kubefed and implement simple kubefed version

### DIFF
--- a/cmd/kubefed2/kubefed2.go
+++ b/cmd/kubefed2/kubefed2.go
@@ -14,14 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// kubefnord is a tool for managing clusters in a federation.
+// kubefed2 is a tool for managing clusters in a federation.
 package main
 
 import (
 	"fmt"
 	"os"
 
-	"github.com/kubernetes-sigs/federation-v2/pkg/kubefnord"
+	"github.com/kubernetes-sigs/federation-v2/pkg/kubefed2"
 	"k8s.io/apiserver/pkg/util/logs"
 	_ "k8s.io/client-go/plugin/pkg/client/auth" // Load all client auth plugins for GCP, Azure, etc
 )
@@ -30,7 +30,7 @@ func main() {
 	logs.InitLogs()
 	defer logs.FlushLogs()
 
-	err := kubefnord.NewKubeFnordCommand(os.Stdout).Execute()
+	err := kubefed2.NewKubeFed2Command(os.Stdout).Execute()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)

--- a/docs/userguide.md
+++ b/docs/userguide.md
@@ -174,18 +174,18 @@ can proceed to join clusters.
 
 ### Join Clusters
 
-Next, you'll want to use the `kubefnord` tool to join all your
+Next, you'll want to use the `kubefed2` tool to join all your
 clusters that you want to test against.
 
-1. Build kubefnord
+1. Build kubefed2
     ```bash
-    go build -o bin/kubefnord cmd/kubefnord/kubefnord.go
+    go build -o bin/kubefed2 cmd/kubefed2/kubefed2.go
 
     ```
 1. Join Cluster(s)
     ```bash
-    ./bin/kubefnord join cluster1 --host-cluster-context cluster1 --add-to-registry --v=2
-    ./bin/kubefnord join cluster2 --host-cluster-context cluster1 --add-to-registry --v=2
+    ./bin/kubefed2 join cluster1 --host-cluster-context cluster1 --add-to-registry --v=2
+    ./bin/kubefed2 join cluster2 --host-cluster-context cluster1 --add-to-registry --v=2
     ```
 You can repeat these steps to join any additional clusters.
 
@@ -292,7 +292,7 @@ kubectl delete ns test-namespace
 
 In order to unjoin, you will have to manually or script an unjoin
 operation by deleting all the relevant objects. The ability to unjoin via
-`kubefnord` will be added in the future.  For now you can run the following
+`kubefed2` will be added in the future.  For now you can run the following
 commands to take care of it:
 
 ```bash

--- a/pkg/kubefed2/join.go
+++ b/pkg/kubefed2/join.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package kubefnord
+package kubefed2
 
 import (
 	"fmt"
@@ -26,8 +26,8 @@ import (
 	fedv1a1 "github.com/kubernetes-sigs/federation-v2/pkg/apis/core/v1alpha1"
 	fedclient "github.com/kubernetes-sigs/federation-v2/pkg/client/clientset/versioned"
 	controllerutil "github.com/kubernetes-sigs/federation-v2/pkg/controller/util"
-	"github.com/kubernetes-sigs/federation-v2/pkg/kubefnord/options"
-	"github.com/kubernetes-sigs/federation-v2/pkg/kubefnord/util"
+	"github.com/kubernetes-sigs/federation-v2/pkg/kubefed2/options"
+	"github.com/kubernetes-sigs/federation-v2/pkg/kubefed2/util"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	corev1 "k8s.io/api/core/v1"
@@ -59,7 +59,7 @@ var (
 		# a valid RFC 1123 subdomain name. Cluster context
 		# must be specified if the cluster name is different
 		# than the cluster's context in the local kubeconfig.
-		kubefnord join foo --host-cluster-context=bar`
+		kubefed2 join foo --host-cluster-context=bar`
 )
 
 type joinFederation struct {

--- a/pkg/kubefed2/kubefed2.go
+++ b/pkg/kubefed2/kubefed2.go
@@ -14,26 +14,26 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package kubefnord
+package kubefed2
 
 import (
 	"flag"
 	"io"
 
-	"github.com/kubernetes-sigs/federation-v2/pkg/kubefnord/util"
+	"github.com/kubernetes-sigs/federation-v2/pkg/kubefed2/util"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	apiserverflag "k8s.io/apiserver/pkg/util/flag"
 	"k8s.io/client-go/tools/clientcmd"
 )
 
-// NewKubeFnordCommand creates the `kubefnord` command and its nested children.
-func NewKubeFnordCommand(out io.Writer) *cobra.Command {
+// NewKubeFnordCommand creates the `kubefed2` command and its nested children.
+func NewKubeFed2Command(out io.Writer) *cobra.Command {
 	// Parent command to which all subcommands are added.
 	rootCmd := &cobra.Command{
-		Use:   "kubefnord",
-		Short: "kubefnord controls a Kubernetes Cluster Federation",
-		Long:  "kubefnord controls a Kubernetes Cluster Federation. Find more information at https://github.com/kubernetes-sigs/federation-v2.",
+		Use:   "kubefed2",
+		Short: "kubefed2 controls a Kubernetes Cluster Federation",
+		Long:  "kubefed2 controls a Kubernetes Cluster Federation. Find more information at https://github.com/kubernetes-sigs/federation-v2.",
 
 		Run: runHelp,
 	}

--- a/pkg/kubefed2/kubefed2.go
+++ b/pkg/kubefed2/kubefed2.go
@@ -48,6 +48,7 @@ func NewKubeFed2Command(out io.Writer) *cobra.Command {
 	rootCmd.SetGlobalNormalizationFunc(apiserverflag.WarnWordSepNormalizeFunc)
 
 	rootCmd.AddCommand(NewCmdJoin(out, util.NewFedConfig(clientcmd.NewDefaultPathOptions())))
+	rootCmd.AddCommand(NewCmdVersion(out))
 	return rootCmd
 }
 

--- a/pkg/kubefed2/options/options.go
+++ b/pkg/kubefed2/options/options.go
@@ -24,7 +24,7 @@ import (
 )
 
 // SubcommandOptions holds the configuration required by the subcommands of
-// `kubefnord`.
+// `kubefed2`.
 type SubcommandOptions struct {
 	ClusterName         string
 	Host                string
@@ -51,7 +51,7 @@ func (o *SubcommandOptions) SetName(args []string) error {
 	// Hard-code the federation namespace until a canonical way of
 	// configuring federation (e.g. via configmap) exists.  In the
 	// absence of canonical configuration, allowing override of the
-	// system namespace for a kubefnord command is a likely source of
+	// system namespace for a kubefed2 command is a likely source of
 	// problems since only the hard-coded namespace is valid.
 	o.FederationNamespace = util.FederationSystemNamespace
 	o.ClusterName = args[0]

--- a/pkg/kubefed2/util/util.go
+++ b/pkg/kubefed2/util/util.go
@@ -39,7 +39,7 @@ type fedConfig struct {
 	pathOptions *clientcmd.PathOptions
 }
 
-// NewFedConfig creates a fedConfig for `kubefnord` commands.
+// NewFedConfig creates a fedConfig for `kubefed2` commands.
 func NewFedConfig(pathOptions *clientcmd.PathOptions) FedConfig {
 	return &fedConfig{
 		pathOptions: pathOptions,

--- a/pkg/kubefed2/version.go
+++ b/pkg/kubefed2/version.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubefed2
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+)
+
+const (
+	// TODO (irfanurrehman): Fix a versioning strategy consistent across federation binaries.
+	kubefedVersion = "v0.0.1-alpha.0"
+)
+
+var (
+	version_long = `
+		Version prints the version info of this command.`
+	version_example = `
+		# Print kubefed command version
+		kubefed version`
+)
+
+type versionInfo struct {
+	version string
+}
+
+// Get allows to enable getting command version from different sources
+// and appending suffixes like (clean/dirty+git hash).
+func (v *versionInfo) Get() string {
+	version := kubefedVersion
+	return version
+}
+
+// NewCmdVersion prints out the release version info for this command binary.
+func NewCmdVersion(out io.Writer) *cobra.Command {
+	version := &versionInfo{}
+	cmd := &cobra.Command{
+		Use:     "version",
+		Short:   "Print the version info",
+		Long:    version_long,
+		Example: version_example,
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Fprintf(out, "kubefed version: %s\n", version.Get())
+		},
+	}
+	return cmd
+}

--- a/scripts/deploy-federation.sh
+++ b/scripts/deploy-federation.sh
@@ -114,10 +114,10 @@ for filename in ./config/federatedtypes/*.yaml; do
 done
 
 # Join the host cluster
-go build -o bin/kubefnord cmd/kubefnord/kubefnord.go
+go build -o bin/kubefed2 cmd/kubefed2/kubefed2.go
 CONTEXT="$(kubectl config current-context)"
-./bin/kubefnord join "${CONTEXT}" --host-cluster-context "${CONTEXT}" --add-to-registry --v=2
+./bin/kubefed2 join "${CONTEXT}" --host-cluster-context "${CONTEXT}" --add-to-registry --v=2
 
 for c in ${JOIN_CLUSTERS}; do
-    ./bin/kubefnord join "${c}" --host-cluster-context "${CONTEXT}" --add-to-registry --v=2
+    ./bin/kubefed2 join "${c}" --host-cluster-context "${CONTEXT}" --add-to-registry --v=2
 done

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -33,7 +33,7 @@ rc=0
 
 echo "Building federation binaries"
 go build -o bin/controller-manager ./cmd/controller-manager
-go build -o bin/kubefnord ./cmd/kubefnord
+go build -o bin/kubefed2 ./cmd/kubefed2
 
 echo "Downloading test dependencies"
 ./scripts/download-binaries.sh


### PR DESCRIPTION
The version naming is suggestive and intended to trigger comments.