### PR TITLE
[WIP] Create single yaml to deploy federation

### DIFF
--- a/hack/install-latest.yaml
+++ b/hack/install-latest.yaml
@@ -9,6 +9,34 @@ metadata:
 spec: {}
 status: {}
 ---
+apiVersion: v1
+kind: Namespace
+metadata:
+  creationTimestamp: null
+  labels:
+    api: federation
+    kubebuilder.k8s.io: 0.1.12
+  name: kube-multicluster-public
+spec: {}
+status: {}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  name: federation-admin
+  resourceVersion: "261"
+  selfLink: /apis/rbac.authorization.k8s.io/v1/clusterrolebindings/federation-admin
+  uid: 2882fc75-8077-11e8-a5fe-5254003db9b1
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: federation-system
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -1180,3 +1208,268 @@ spec:
   updateStrategy: {}
 status:
   replicas: 0
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"apiextensions.k8s.io/v1beta1","kind":"CustomResourceDefinition","metadata":{"annotations":{},"creationTimestamp":null,"labels":{"api":"","kubebuilder.k8s.io":"0.1.10"},"name":"clusters.clusterregistry.k8s.io","namespace":""},"spec":{"group":"clusterregistry.k8s.io","names":{"kind":"Cluster","plural":"clusters"},"scope":"Namespaced","validation":{"openAPIV3Schema":{"properties":{"apiVersion":{"type":"string"},"kind":{"type":"string"},"metadata":{"type":"object"},"spec":{"properties":{"authInfo":{"properties":{"controller":{"properties":{"kind":{"type":"string"},"name":{"type":"string"},"namespace":{"type":"string"}},"type":"object"},"user":{"properties":{"kind":{"type":"string"},"name":{"type":"string"},"namespace":{"type":"string"}},"type":"object"}},"type":"object"},"kubernetesApiEndpoints":{"properties":{"caBundle":{"items":{"type":"byte"},"type":"string"},"serverEndpoints":{"items":{"properties":{"clientCIDR":{"type":"string"},"serverAddress":{"type":"string"}},"type":"object"},"type":"array"}},"type":"object"}},"type":"object"},"status":{"properties":{"conditions":{"items":{"properties":{"lastHeartbeatTime":{"format":"date-time","type":"string"},"lastTransitionTime":{"format":"date-time","type":"string"},"message":{"type":"string"},"reason":{"type":"string"},"status":{"type":"string"},"type":{"type":"string"}},"type":"object"},"type":"array"}},"type":"object"}},"type":"object"}},"version":"v1alpha1"},"status":{"acceptedNames":{"kind":"","plural":""},"conditions":null}}
+  creationTimestamp: 2018-07-05T17:18:43Z
+  generation: 1
+  labels:
+    api: ""
+    kubebuilder.k8s.io: 0.1.10
+  name: clusters.clusterregistry.k8s.io
+  resourceVersion: "347"
+  selfLink: /apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions/clusters.clusterregistry.k8s.io
+  uid: 77db2639-8077-11e8-a5fe-5254003db9b1
+spec:
+  group: clusterregistry.k8s.io
+  names:
+    kind: Cluster
+    listKind: ClusterList
+    plural: clusters
+    singular: cluster
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            authInfo:
+              properties:
+                controller:
+                  properties:
+                    kind:
+                      type: string
+                    name:
+                      type: string
+                    namespace:
+                      type: string
+                  type: object
+                user:
+                  properties:
+                    kind:
+                      type: string
+                    name:
+                      type: string
+                    namespace:
+                      type: string
+                  type: object
+              type: object
+            kubernetesApiEndpoints:
+              properties:
+                caBundle:
+                  items:
+                    type: byte
+                  type: string
+                serverEndpoints:
+                  items:
+                    properties:
+                      clientCIDR:
+                        type: string
+                      serverAddress:
+                        type: string
+                    type: object
+                  type: array
+              type: object
+          type: object
+        status:
+          properties:
+            conditions:
+              items:
+                properties:
+                  lastHeartbeatTime:
+                    format: date-time
+                    type: string
+                  lastTransitionTime:
+                    format: date-time
+                    type: string
+                  message:
+                    type: string
+                  reason:
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    type: string
+                type: object
+              type: array
+          type: object
+      type: object
+  version: v1alpha1
+status:
+  acceptedNames:
+    kind: Cluster
+    listKind: ClusterList
+    plural: clusters
+    singular: cluster
+  conditions:
+  - lastTransitionTime: 2018-07-05T17:18:43Z
+    message: no conflicts found
+    reason: NoConflicts
+    status: "True"
+    type: NamesAccepted
+  - lastTransitionTime: 2018-07-05T17:18:43Z
+    message: the initial names have been accepted
+    reason: InitialNamesAccepted
+    status: "True"
+    type: Established
+---
+apiVersion: core.federation.k8s.io/v1alpha1
+kind: FederatedTypeConfig
+metadata:
+  name: configmaps
+spec:
+  target:
+    version: v1
+    kind: ConfigMap
+  namespaced: true
+  comparisonField: ResourceVersion
+  propagationEnabled: true
+  template:
+    group: core.federation.k8s.io
+    version: v1alpha1
+    kind: FederatedConfigMap
+  placement:
+    kind: FederatedConfigMapPlacement
+  override:
+    kind: FederatedConfigMapOverride
+  overridePath:
+    - data
+---
+apiVersion: core.federation.k8s.io/v1alpha1
+kind: FederatedTypeConfig
+metadata:
+  name: secrets
+spec:
+  target:
+    version: v1
+    kind: Secret
+  namespaced: true
+  comparisonField: ResourceVersion
+  propagationEnabled: true
+  template:
+    group: core.federation.k8s.io
+    version: v1alpha1
+    kind: FederatedSecret
+  placement:
+    kind: FederatedSecretPlacement
+  override:
+    kind: FederatedSecretOverride
+  overridePath:
+    - data
+---
+apiVersion: core.federation.k8s.io/v1alpha1
+kind: FederatedTypeConfig
+metadata:
+  name: namespaces
+spec:
+  target:
+    version: v1
+    kind: Namespace
+  namespaced: false
+  comparisonField: ResourceVersion
+  propagationEnabled: true
+  template:
+    version: v1
+    kind: Namespace
+  placement:
+    group: core.federation.k8s.io
+    version: v1alpha1
+    kind: FederatedNamespacePlacement
+---
+apiVersion: core.federation.k8s.io/v1alpha1
+kind: FederatedTypeConfig
+metadata:
+  name: deployments.apps
+spec:
+  target:
+    version: v1
+    kind: Deployment
+  namespaced: true
+  comparisonField: Generation
+  propagationEnabled: true
+  template:
+    group: core.federation.k8s.io
+    version: v1alpha1
+    kind: FederatedDeployment
+  placement:
+    kind: FederatedDeploymentPlacement
+  override:
+    kind: FederatedDeploymentOverride
+  overridePath:
+    - spec
+    - replicas
+---
+apiVersion: core.federation.k8s.io/v1alpha1
+kind: FederatedTypeConfig
+metadata:
+  name: replicasets.apps
+spec:
+  target:
+    version: v1
+    kind: ReplicaSet
+  namespaced: true
+  comparisonField: Generation
+  propagationEnabled: true
+  template:
+    group: core.federation.k8s.io
+    version: v1alpha1
+    kind: FederatedReplicaSet
+  placement:
+    kind: FederatedReplicaSetPlacement
+  override:
+    kind: FederatedReplicaSetOverride
+  overridePath:
+    - spec
+    - replicas
+---
+apiVersion: core.federation.k8s.io/v1alpha1
+kind: FederatedTypeConfig
+metadata:
+  name: services
+spec:
+  target:
+    version: v1
+    kind: Service
+  namespaced: true
+  comparisonField: Generation
+  propagationEnabled: true
+  template:
+    group: core.federation.k8s.io
+    version: v1alpha1
+    kind: FederatedService
+  placement:
+    kind: FederatedServicePlacement
+---
+apiVersion: core.federation.k8s.io/v1alpha1
+kind: FederatedTypeConfig
+metadata:
+  name: jobs.batch
+spec:
+  target:
+    version: v1
+    kind: Job
+  namespaced: true
+  comparisonField: Generation
+  propagationEnabled: true
+  template:
+    group: core.federation.k8s.io
+    version: v1alpha1
+    kind: FederatedJob
+  placement:
+    kind: FederatedJobPlacement
+  override:
+    kind: FederatedJobOverride
+  overridePath:
+    - spec
+    - parallelism
+

--- a/hack/install-latest.yaml
+++ b/hack/install-latest.yaml
@@ -68,7 +68,7 @@ spec:
   names:
     kind: FederatedCluster
     plural: federatedclusters
-  scope: Cluster
+  scope: Namespaced
   subresources:
     status: {}
   validation:
@@ -1167,7 +1167,7 @@ spec:
         - --install-crds=false
         command:
         - /root/controller-manager
-        image: docker.io/maru/federation-v2:test
+        image: quay.io/kubernetes-multicluster/federation-v2:canary
         name: controller-manager
         resources:
           limits:

--- a/images/federation-v2/Dockerfile
+++ b/images/federation-v2/Dockerfile
@@ -13,9 +13,10 @@
 # limitations under the License.
 
 
-FROM ubuntu:14.04
+FROM ubuntu:latest
 RUN apt-get update
 RUN apt-get install -y ca-certificates
-ADD apiserver .
 ADD controller-manager .
+ENTRYPOINT ["./controller-manager"]
+CMD ["--install-crds=false"]
 

--- a/scripts/delete-federation.sh
+++ b/scripts/delete-federation.sh
@@ -51,7 +51,7 @@ if kubectl get federatedcluster &>/dev/null; then
   ${KCD} federatedcluster "${CONTEXT}"
 fi
 
-${KCD} -f hack/install.yaml
+${KCD} -f hack/install-latest.yaml
 ${KCD} -f vendor/k8s.io/cluster-registry/cluster-registry-crd.yaml
 
 # Remove public namespace

--- a/scripts/deploy-federation-latest.sh
+++ b/scripts/deploy-federation-latest.sh
@@ -20,4 +20,4 @@ set -o pipefail
 
 # Call the deploy script with the name of the latest image to use
 # committed install yaml and a prebuilt image.
-"$(dirname "${BASH_SOURCE}")"/deploy-federation.sh docker.io/maru/federation-v2:test
+"$(dirname "${BASH_SOURCE}")"/deploy-federation.sh quay.io/kubernetes-multicluster/federation-v2:canary

--- a/scripts/deploy-federation.sh
+++ b/scripts/deploy-federation.sh
@@ -52,7 +52,7 @@ PUBLIC_NS=kube-multicluster-public
 IMAGE_NAME="${1:-}"
 
 # TODO(marun) Replace with name of ci-built image
-LATEST_IMAGE_NAME=docker.io/maru/federation-v2:test
+LATEST_IMAGE_NAME=quay.io/kubernetes-multicluster/federation-v2:canary
 if [[ "${IMAGE_NAME}" == "$LATEST_IMAGE_NAME" ]]; then
   USE_LATEST=y
   INSTALL_YAML=hack/install-latest.yaml

--- a/scripts/imagebuild.sh
+++ b/scripts/imagebuild.sh
@@ -21,7 +21,6 @@ set -o pipefail
 base_dir="$(cd "$(dirname "$0")/.." ; pwd)"
 dockerfile_dir="${base_dir}/images/federation-v2"
 
-[ -f "$base_dir/bin/apiserver" ] || { echo "$base_dir/bin/apiserver not found" ; exit 1 ;}
 [ -f "$base_dir/bin/controller-manager" ] || { echo "$base_dir/bin/controller-manager not found" ; exit 1 ;}
 
 if [[ "${TRAVIS_BRANCH}" != "master" ]]; then
@@ -32,8 +31,7 @@ fi
 echo "Starting image build"
 export REGISTRY=quay.io/
 export REPO=kubernetes-multicluster
-echo "Copy apiserver"
-cp ${base_dir}/bin/apiserver ${dockerfile_dir}/apiserver
+
 
 echo "Copy controller manager"
 cp ${base_dir}/bin/controller-manager ${dockerfile_dir}/controller-manager
@@ -45,5 +43,4 @@ echo "Pushing images with default tags (git sha and 'canary')."
 docker build ${dockerfile_dir} -t ${REGISTRY}${REPO}/federation-v2:canary
 docker push ${REGISTRY}${REPO}/federation-v2:canary
 
-rm ${dockerfile_dir}/apiserver
 rm ${dockerfile_dir}/controller-manager


### PR DESCRIPTION
Depends on #136 

Allows a user to deploy federation with: `kubectl apply --validate=false -f hack/install-latest.yaml `
This sometimes fails when creating the federated types which is not ideal.

Included in this commit is alterations to deploy-federation.sh script to still allow a user to specify
an image that they want to build locally. This may not be necessary and could be removed.
