### PR TITLE
Enable CI e2e job against single minikube cluster

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,17 @@ go:
 # Enable building in Travis using forked repos.
 go_import_path: github.com/kubernetes-sigs/federation-v2
 
+# Request latest Travis distro for systemd requirement.
+dist: xenial
 sudo: required
 
 services:
   - docker
+
+# Install dependencies for launching minikube cluster.
+before_install:
+  - sudo apt-get update
+  - sudo apt-get install -y socat ebtables
 
 # Install must be set to prevent default `go get` to run.
 # The dependencies have already been vendored by `dep` so

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ language: go
 go:
   - "1.10.1"
 
+# Enable building in Travis using forked repos.
+go_import_path: github.com/kubernetes-sigs/federation-v2
+
 sudo: required
 
 services:

--- a/scripts/deploy-federation.sh
+++ b/scripts/deploy-federation.sh
@@ -85,9 +85,10 @@ JOIN_CLUSTERS="${*}"
 
 # Use DOCKER_PUSH=false ./scripts/deploy-federation.sh <image> to skip docker
 # push on container image when not using latest image.
-DOCKER_PUSH=${DOCKER_PUSH:-docker push ${IMAGE_NAME}}
+DOCKER_PUSH=${DOCKER_PUSH:-true}
+DOCKER_PUSH_CMD="docker push ${IMAGE_NAME}"
 if [[ "${DOCKER_PUSH}" == false ]]; then
-    DOCKER_PUSH=
+    DOCKER_PUSH_CMD=
 fi
 
 if [[ ! "${USE_LATEST}" ]]; then
@@ -100,7 +101,7 @@ if [[ ! "${USE_LATEST}" ]]; then
     cp ${base_dir}/bin/controller-manager ${dockerfile_dir}/controller-manager
   fi
   docker build ${dockerfile_dir} -t "${IMAGE_NAME}"
-  ${DOCKER_PUSH}
+  ${DOCKER_PUSH_CMD}
   rm -f ${dockerfile_dir}/controller-manager
 fi
 

--- a/scripts/deploy-federation.sh
+++ b/scripts/deploy-federation.sh
@@ -83,6 +83,13 @@ fi
 shift
 JOIN_CLUSTERS="${*}"
 
+# Use DOCKER_PUSH=false ./scripts/deploy-federation.sh <image> to skip docker
+# push on container image when not using latest image.
+DOCKER_PUSH=${DOCKER_PUSH:-docker push ${IMAGE_NAME}}
+if [[ "${DOCKER_PUSH}" == false ]]; then
+    DOCKER_PUSH=
+fi
+
 if [[ ! "${USE_LATEST}" ]]; then
   base_dir="$(cd "$(dirname "$0")/.." ; pwd)"
   dockerfile_dir="${base_dir}/images/federation-v2"
@@ -93,7 +100,7 @@ if [[ ! "${USE_LATEST}" ]]; then
     cp ${base_dir}/bin/controller-manager ${dockerfile_dir}/controller-manager
   fi
   docker build ${dockerfile_dir} -t "${IMAGE_NAME}"
-  docker push "${IMAGE_NAME}"
+  ${DOCKER_PUSH}
   rm -f ${dockerfile_dir}/controller-manager
 fi
 

--- a/scripts/download-binaries.sh
+++ b/scripts/download-binaries.sh
@@ -35,10 +35,6 @@ logEnd() {
 }
 trap 'logEnd $?' EXIT
 
-# Use BASE_URL=https://my/binaries/url ./scripts/download-binaries to download
-# from a different bucket
-: "${BASE_URL:="https://storage.googleapis.com/k8s-c10s-test-binaries"}"
-
 echo "About to download some binaries. This might take a while..."
 
 root_dir="$(cd "$(dirname "$0")/.." ; pwd)"

--- a/scripts/download-e2e-binaries.sh
+++ b/scripts/download-e2e-binaries.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+
+# Copyright 2018 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script automates the download of e2e binaries used in testing of
+# federation.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# Use DEBUG=1 ./scripts/download-e2e-binaries.sh to get debug output
+curl_args="-Ls"
+[[ -z "${DEBUG:-""}" ]] || {
+  set -x
+  curl_args="-L"
+}
+
+logEnd() {
+  local msg='done.'
+  [ "$1" -eq 0 ] || msg='Error downloading assets'
+  echo "$msg"
+}
+trap 'logEnd $?' EXIT
+
+echo "About to download some binaries. This might take a while..."
+
+root_dir="$(cd "$(dirname "$0")/.." ; pwd)"
+dest_dir="${root_dir}/bin"
+mkdir -p "${dest_dir}"
+
+# Minikube
+mk_version="0.28.1"
+mk_bin="minikube-linux-amd64"
+mk_url="https://github.com/kubernetes/minikube/releases/download/v${mk_version}/${mk_bin}"
+mk_dest="${dest_dir}/minikube"
+curl "${curl_args}" "${mk_url}" --output "${mk_dest}"
+chmod 755 "${mk_dest}"
+
+# crictl
+crictl_version="1.11.1"
+crictl_tgz="crictl-v1.11.1-linux-amd64.tar.gz"
+crictl_url="https://github.com/kubernetes-incubator/cri-tools/releases/download/v${crictl_version}/${crictl_tgz}"
+curl "${curl_args}O" "${crictl_url}" \
+  && tar xzfP "${crictl_tgz}" -C "${dest_dir}" \
+  && rm "${crictl_tgz}"
+
+echo    "# destination:"
+echo    "#   ${dest_dir}"
+echo    "# versions:"
+echo -n "#   minikube:           "; ${dest_dir}/minikube version | awk '{print $3}'
+echo -n "#     crictl:           "; ${dest_dir}/crictl --version | awk '{print $3}'

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -20,31 +20,83 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+source "$(dirname "${BASH_SOURCE}")/util.sh"
+
+function build-binaries() {
+  go build -o bin/controller-manager ./cmd/controller-manager
+  go build -o bin/kubefed2 ./cmd/kubefed2
+}
+
+function run-integration-tests() {
+  # Ensure the test binaries are in the path.
+  export TEST_ASSET_PATH="${base_dir}/bin"
+  export TEST_ASSET_ETCD="${TEST_ASSET_PATH}/etcd"
+  export TEST_ASSET_KUBE_APISERVER="${TEST_ASSET_PATH}/kube-apiserver"
+  go test -v ./test/integration
+  rc=$((rc || $?))
+  return ${rc}
+}
+
+function launch-minikube-cluster() {
+  # Move crictl to system path as expected by kubeadm.
+  sudo mv ${TEST_ASSET_PATH}/crictl /usr/bin/
+  sudo bash -c "export PATH=${PATH}; minikube start -p cluster1 --kubernetes-version v1.11.0 --vm-driver=none --v=4"
+
+  # Change ownership of .kube and .minikube config to use without sudo.
+  sudo chown -R $USER $HOME/.kube
+  sudo chgrp -R $USER $HOME/.kube
+
+  sudo chown -R $USER $HOME/.minikube
+  sudo chgrp -R $USER $HOME/.minikube
+}
+
+# Wait for the kubernetes API server to be ready.
+function kube-apiserver-ready() {
+  local result="$(kubectl -n kube-system get pod kube-apiserver-minikube -o jsonpath='{.status.conditions[?(@.type == "Ready")].status}' 2> /dev/null)"
+  [[ "${result}" = "True" ]]
+}
+
+function run-e2e-tests() {
+  go test -v ./test/e2e -args -kubeconfig=${HOME}/.kube/config -ginkgo.v
+  rc=$((rc || $?))
+  return ${rc}
+}
+
+
 # Make sure, we run in the root of the repo and
 # therefore run the tests on all packages
 base_dir="$( cd "$(dirname "$0")/.." && pwd )"
 cd "$base_dir" || {
   echo "Cannot cd to '$base_dir'. Aborting." >&2
   exit 1
-
 }
 
 rc=0
 
 echo "Building federation binaries"
-go build -o bin/controller-manager ./cmd/controller-manager
-go build -o bin/kubefed2 ./cmd/kubefed2
+build-binaries
 
 echo "Downloading test dependencies"
 ./scripts/download-binaries.sh
-rc=$((rc || $?))
 
-echo "Running go test"
-# Ensure the test binaries are in the path
-export TEST_ASSET_PATH="${base_dir}/bin"
-export TEST_ASSET_ETCD="${TEST_ASSET_PATH}/etcd"
-export TEST_ASSET_KUBE_APISERVER="${TEST_ASSET_PATH}/kube-apiserver"
-go test -v ./test/integration ./test/e2e
-rc=$((rc || $?))
+echo "Running go integration tests"
+run-integration-tests
+
+echo "Downloading e2e test dependencies"
+./scripts/download-e2e-binaries.sh
+
+export PATH=${TEST_ASSET_PATH}:${PATH}
+
+echo "Launching minikube cluster"
+launch-minikube-cluster
+
+echo "Waiting for minikube cluster to be ready"
+util::wait-for-condition "kube-apiserver readiness" 'kube-apiserver-ready' 180
+
+echo "Deploying federation-v2"
+DOCKER_PUSH=false ./scripts/deploy-federation.sh quay.io/kubernetes-multicluster/federation-v2:e2e
+
+echo "Running go e2e tests"
+run-e2e-tests
 
 exit $rc


### PR DESCRIPTION
This updates the pre-commit CI job. It continues to run integration tests but now runs [unmanaged](https://github.com/kubernetes-sigs/federation-v2/blob/master/docs/development.md#unmanaged-and-hybrid-cluster-setup) instead of [managed](https://github.com/kubernetes-sigs/federation-v2/blob/master/docs/development.md#managed) e2e tests i.e. a single minikube k8s cluster.

This works because we are requesting an Ubuntu 16.04 distro (Xenial) from Travis in order to use systemd. This distro is not actually documented in Travis, but appears to be available as an experimental feature.