### PR TITLE
Increase mem resources for fed controller, add federated service example, other misc. changes

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -313,7 +313,17 @@ kubebuilder create config \
 ```
 
 Once the installation YAML config `hack/install.yaml` is created, we need to
-delete the `type` field from the OpenAPI schema to avoid triggering validation
+update it to modify a few fields.
+
+First, increase the memory request and limit to avoid OOM issues by running the
+following commands:
+
+```bash
+sed -i 's/memory: 20Mi/memory: 64Mi/' hack/install.yaml
+sed -i 's/memory: 30Mi/memory: 128Mi/' hack/install.yaml
+```
+
+Then, delete the `type` field from the OpenAPI schema to avoid triggering validation
 errors in kubernetes version < 1.12 when a type specifies a subresource (e.g.
 status). The `type` field only triggers validation errors for resource types
 that define subresources, but it is simpler to fix for all types. See

--- a/docs/userguide.md
+++ b/docs/userguide.md
@@ -228,12 +228,24 @@ kubectl apply -R -f example/sample1
 Check the status of all the resources in each cluster by running:
 
 ```bash
-for r in configmaps secrets deploy; do
+for r in configmaps secrets service deploy; do
     for c in cluster1 cluster2; do
         echo; echo ------------ ${c} ------------; echo
         kubectl --context=${c} -n test-namespace get ${r}
         echo; echo
     done
+done
+```
+
+Now make sure `nginx` is running properly in each cluster:
+
+```bash
+for c in cluster1 cluster2; do
+    NODE_PORT=$(kubectl --context=${c} -n test-namespace get service \
+        test-service -o jsonpath='{.spec.ports[0].nodePort}')
+    echo; echo ------------ ${c} ------------; echo
+    curl $(echo -n $(minikube ip -p ${c})):${NODE_PORT}
+    echo; echo
 done
 ```
 
@@ -251,7 +263,7 @@ kubectl -n test-namespace edit federatednamespaceplacement test-namespace
 Then wait to verify all resources are removed from `cluster2`:
 
 ```bash
-for r in configmaps secrets deploy; do
+for r in configmaps secrets service deploy; do
     for c in cluster1 cluster2; do
         echo; echo ------------ ${c} ------------; echo
         kubectl --context=${c} -n test-namespace get ${r}
@@ -274,12 +286,24 @@ kubectl -n test-namespace edit federatednamespaceplacement test-namespace
 Then wait and verify all resources are added back to `cluster2`:
 
 ```bash
-for r in configmaps secrets deploy; do
+for r in configmaps secrets service deploy; do
     for c in cluster1 cluster2; do
         echo; echo ------------ ${c} ------------; echo
         kubectl --context=${c} -n test-namespace get ${r}
         echo; echo
     done
+done
+```
+
+Lastly, make sure `nginx` is running properly in each cluster:
+
+```bash
+for c in cluster1 cluster2; do
+    NODE_PORT=$(kubectl --context=${c} -n test-namespace get service \
+        test-service -o jsonpath='{.spec.ports[0].nodePort}')
+    echo; echo ------------ ${c} ------------; echo
+    curl $(echo -n $(minikube ip -p ${c})):${NODE_PORT}
+    echo; echo
 done
 ```
 

--- a/example/sample1/federateddeployment-template.yaml
+++ b/example/sample1/federateddeployment-template.yaml
@@ -10,16 +10,16 @@ items:
     template:
       metadata:
         labels:
-          foo: bar
+          app: nginx
       spec:
         replicas: 3
         selector:
           matchLabels:
-            foo: bar
+            app: nginx
         template:
           metadata:
             labels:
-              foo: bar
+              app: nginx
           spec:
             containers:
             - image: nginx

--- a/example/sample1/federatedservice-placement.yaml
+++ b/example/sample1/federatedservice-placement.yaml
@@ -1,0 +1,9 @@
+apiVersion: core.federation.k8s.io/v1alpha1
+kind: FederatedServicePlacement
+metadata:
+  name: test-service
+  namespace: test-namespace
+spec:
+  clusternames:
+  - cluster2
+  - cluster1

--- a/example/sample1/federatedservice-template.yaml
+++ b/example/sample1/federatedservice-template.yaml
@@ -1,0 +1,14 @@
+apiVersion: core.federation.k8s.io/v1alpha1
+kind: FederatedService
+metadata:
+  name: test-service
+  namespace: test-namespace
+spec:
+  template:
+    spec:
+      selector:
+        app: nginx
+      type: NodePort
+      ports:
+        - name: http
+          port: 80

--- a/hack/install-latest.yaml
+++ b/hack/install-latest.yaml
@@ -1152,10 +1152,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 30Mi
+            memory: 128Mi
           requests:
             cpu: 100m
-            memory: 20Mi
+            memory: 64Mi
       terminationGracePeriodSeconds: 10
   updateStrategy: {}
 status:

--- a/pkg/controller/federatedcluster/controller.go
+++ b/pkg/controller/federatedcluster/controller.go
@@ -218,9 +218,9 @@ func (cc *ClusterController) updateClusterStatus() error {
 		cc.clusterClusterStatusMap[cluster.Name] = *clusterStatusNew
 		cc.mu.Unlock()
 		cluster.Status = *clusterStatusNew
-		cluster, err := cc.fedClient.CoreV1alpha1().FederatedClusters(util.FederationSystemNamespace).UpdateStatus(&cluster)
+		_, err = cc.fedClient.CoreV1alpha1().FederatedClusters(util.FederationSystemNamespace).UpdateStatus(&cluster)
 		if err != nil {
-			glog.Warningf("Failed to update the status of cluster: %v ,error is : %v", cluster.Name, err)
+			glog.Warningf("Failed to update the status of cluster: %v, error is : %v", cluster.Name, err)
 			// Don't return err here, as we want to continue processing remaining clusters.
 			continue
 		}

--- a/scripts/deploy-federation.sh
+++ b/scripts/deploy-federation.sh
@@ -106,6 +106,10 @@ kubectl create clusterrolebinding federation-admin --clusterrole=cluster-admin -
 if [[ ! "${USE_LATEST}" ]]; then
   kubebuilder create config --controller-image "${IMAGE_NAME}" --name federation
 
+  # Increase memory request and limit to avoid OOM issues.
+  sed -i 's/memory: 20Mi/memory: 64Mi/' hack/install.yaml
+  sed -i 's/memory: 30Mi/memory: 128Mi/' hack/install.yaml
+
   # Delete the 'type' field from the openapi schema to avoid
   # triggering validation errors in kube < 1.12 when a type specifies
   # a subresource (e.g. status).  The 'type' field only triggers

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/kubernetes-sigs/federation-v2/test/e2e/framework"
+	_ "k8s.io/client-go/plugin/pkg/client/auth" // Load all client auth plugins for GCP, Azure, etc
 )
 
 func init() {

--- a/vendor/k8s.io/cluster-registry/cluster-registry-crd.yaml
+++ b/vendor/k8s.io/cluster-registry/cluster-registry-crd.yaml
@@ -83,7 +83,6 @@ spec:
                 type: object
               type: array
           type: object
-      type: object
   version: v1alpha1
 status:
   acceptedNames:


### PR DESCRIPTION
- Increase the memory request and limits for the federation-controller-manager.
- Add a federated service example config and update the userguide.
- Update Cluster Registry CRD for use in k8s 1.10. See https://github.com/kubernetes/kubernetes/issues/65293 for more details.
- Add client auth plugins for public cloud providers in order to run e2e tests.