### PR TITLE
Bump e2e poll timeout to account for unmanaged fixture on travis

### DIFF
--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -31,7 +31,7 @@ const (
 	// How long to try single API calls (like 'get' or 'list'). Used to prevent
 	// transient failures from failing tests.
 	PollInterval      = 2 * time.Second
-	SingleCallTimeout = 30 * time.Second
+	SingleCallTimeout = 60 * time.Second
 )
 
 // unique identifier of the e2e run


### PR DESCRIPTION
The previous `SingleCallTimeout` value of `30s` appears to be too low, as evidenced by the increasing incidence of CI jobs failing with timeout failures since e2e tests have started executing against unmanaged fixture.