### PR TITLE
Update FederatedTypeConfig to be namespace-scoped

### DIFF
--- a/docs/userguide.md
+++ b/docs/userguide.md
@@ -166,7 +166,7 @@ supported types, run the following command:
 
 ```bash
 for f in ./config/federatedtypes/*.yaml; do
-    kubectl apply -f "${f}"
+    kubectl -n federation-system apply -f "${f}"
 done
 ```
 

--- a/hack/install-latest.yaml
+++ b/hack/install-latest.yaml
@@ -854,7 +854,7 @@ spec:
   names:
     kind: FederatedTypeConfig
     plural: federatedtypeconfigs
-  scope: Cluster
+  scope: Namespaced
   validation:
     openAPIV3Schema:
       properties:

--- a/pkg/apis/core/v1alpha1/federatedtypeconfig_types.go
+++ b/pkg/apis/core/v1alpha1/federatedtypeconfig_types.go
@@ -77,7 +77,6 @@ type FederatedTypeConfigStatus struct {
 
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +genclient:nonNamespaced
 
 // FederatedTypeConfig
 // +k8s:openapi-gen=true

--- a/pkg/apis/core/v1alpha1/federatedtypeconfig_types_test.go
+++ b/pkg/apis/core/v1alpha1/federatedtypeconfig_types_test.go
@@ -51,7 +51,7 @@ var _ = Describe("FederatedTypeConfig", func() {
 	Describe("when sending a storage request", func() {
 		Context("for a valid config", func() {
 			It("should provide CRUD access to the object", func() {
-				client = cs.CoreV1alpha1().FederatedTypeConfigs()
+				client = cs.CoreV1alpha1().FederatedTypeConfigs("foo")
 
 				By("returning success from the create request")
 				actual, err := client.Create(&instance)

--- a/pkg/apis/core/v1alpha1/zz_generated.kubebuilder.go
+++ b/pkg/apis/core/v1alpha1/zz_generated.kubebuilder.go
@@ -1365,7 +1365,7 @@ var (
 				Kind:   "FederatedTypeConfig",
 				Plural: "federatedtypeconfigs",
 			},
-			Scope: "Cluster",
+			Scope: "Namespaced",
 			Validation: &v1beta1.CustomResourceValidation{
 				OpenAPIV3Schema: &v1beta1.JSONSchemaProps{
 					Type: "object",

--- a/pkg/client/clientset/versioned/typed/core/v1alpha1/core_client.go
+++ b/pkg/client/clientset/versioned/typed/core/v1alpha1/core_client.go
@@ -141,8 +141,8 @@ func (c *CoreV1alpha1Client) FederatedServicePlacements(namespace string) Federa
 	return newFederatedServicePlacements(c, namespace)
 }
 
-func (c *CoreV1alpha1Client) FederatedTypeConfigs() FederatedTypeConfigInterface {
-	return newFederatedTypeConfigs(c)
+func (c *CoreV1alpha1Client) FederatedTypeConfigs(namespace string) FederatedTypeConfigInterface {
+	return newFederatedTypeConfigs(c, namespace)
 }
 
 func (c *CoreV1alpha1Client) PropagatedVersions(namespace string) PropagatedVersionInterface {

--- a/pkg/client/clientset/versioned/typed/core/v1alpha1/fake/fake_core_client.go
+++ b/pkg/client/clientset/versioned/typed/core/v1alpha1/fake/fake_core_client.go
@@ -112,8 +112,8 @@ func (c *FakeCoreV1alpha1) FederatedServicePlacements(namespace string) v1alpha1
 	return &FakeFederatedServicePlacements{c, namespace}
 }
 
-func (c *FakeCoreV1alpha1) FederatedTypeConfigs() v1alpha1.FederatedTypeConfigInterface {
-	return &FakeFederatedTypeConfigs{c}
+func (c *FakeCoreV1alpha1) FederatedTypeConfigs(namespace string) v1alpha1.FederatedTypeConfigInterface {
+	return &FakeFederatedTypeConfigs{c, namespace}
 }
 
 func (c *FakeCoreV1alpha1) PropagatedVersions(namespace string) v1alpha1.PropagatedVersionInterface {

--- a/pkg/client/clientset/versioned/typed/core/v1alpha1/fake/fake_federatedtypeconfig.go
+++ b/pkg/client/clientset/versioned/typed/core/v1alpha1/fake/fake_federatedtypeconfig.go
@@ -31,6 +31,7 @@ import (
 // FakeFederatedTypeConfigs implements FederatedTypeConfigInterface
 type FakeFederatedTypeConfigs struct {
 	Fake *FakeCoreV1alpha1
+	ns   string
 }
 
 var federatedtypeconfigsResource = schema.GroupVersionResource{Group: "core.federation.k8s.io", Version: "v1alpha1", Resource: "federatedtypeconfigs"}
@@ -40,7 +41,8 @@ var federatedtypeconfigsKind = schema.GroupVersionKind{Group: "core.federation.k
 // Get takes name of the federatedTypeConfig, and returns the corresponding federatedTypeConfig object, and an error if there is any.
 func (c *FakeFederatedTypeConfigs) Get(name string, options v1.GetOptions) (result *v1alpha1.FederatedTypeConfig, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewRootGetAction(federatedtypeconfigsResource, name), &v1alpha1.FederatedTypeConfig{})
+		Invokes(testing.NewGetAction(federatedtypeconfigsResource, c.ns, name), &v1alpha1.FederatedTypeConfig{})
+
 	if obj == nil {
 		return nil, err
 	}
@@ -50,7 +52,8 @@ func (c *FakeFederatedTypeConfigs) Get(name string, options v1.GetOptions) (resu
 // List takes label and field selectors, and returns the list of FederatedTypeConfigs that match those selectors.
 func (c *FakeFederatedTypeConfigs) List(opts v1.ListOptions) (result *v1alpha1.FederatedTypeConfigList, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewRootListAction(federatedtypeconfigsResource, federatedtypeconfigsKind, opts), &v1alpha1.FederatedTypeConfigList{})
+		Invokes(testing.NewListAction(federatedtypeconfigsResource, federatedtypeconfigsKind, c.ns, opts), &v1alpha1.FederatedTypeConfigList{})
+
 	if obj == nil {
 		return nil, err
 	}
@@ -71,13 +74,15 @@ func (c *FakeFederatedTypeConfigs) List(opts v1.ListOptions) (result *v1alpha1.F
 // Watch returns a watch.Interface that watches the requested federatedTypeConfigs.
 func (c *FakeFederatedTypeConfigs) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
-		InvokesWatch(testing.NewRootWatchAction(federatedtypeconfigsResource, opts))
+		InvokesWatch(testing.NewWatchAction(federatedtypeconfigsResource, c.ns, opts))
+
 }
 
 // Create takes the representation of a federatedTypeConfig and creates it.  Returns the server's representation of the federatedTypeConfig, and an error, if there is any.
 func (c *FakeFederatedTypeConfigs) Create(federatedTypeConfig *v1alpha1.FederatedTypeConfig) (result *v1alpha1.FederatedTypeConfig, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewRootCreateAction(federatedtypeconfigsResource, federatedTypeConfig), &v1alpha1.FederatedTypeConfig{})
+		Invokes(testing.NewCreateAction(federatedtypeconfigsResource, c.ns, federatedTypeConfig), &v1alpha1.FederatedTypeConfig{})
+
 	if obj == nil {
 		return nil, err
 	}
@@ -87,7 +92,8 @@ func (c *FakeFederatedTypeConfigs) Create(federatedTypeConfig *v1alpha1.Federate
 // Update takes the representation of a federatedTypeConfig and updates it. Returns the server's representation of the federatedTypeConfig, and an error, if there is any.
 func (c *FakeFederatedTypeConfigs) Update(federatedTypeConfig *v1alpha1.FederatedTypeConfig) (result *v1alpha1.FederatedTypeConfig, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewRootUpdateAction(federatedtypeconfigsResource, federatedTypeConfig), &v1alpha1.FederatedTypeConfig{})
+		Invokes(testing.NewUpdateAction(federatedtypeconfigsResource, c.ns, federatedTypeConfig), &v1alpha1.FederatedTypeConfig{})
+
 	if obj == nil {
 		return nil, err
 	}
@@ -98,7 +104,8 @@ func (c *FakeFederatedTypeConfigs) Update(federatedTypeConfig *v1alpha1.Federate
 // Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 func (c *FakeFederatedTypeConfigs) UpdateStatus(federatedTypeConfig *v1alpha1.FederatedTypeConfig) (*v1alpha1.FederatedTypeConfig, error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewRootUpdateSubresourceAction(federatedtypeconfigsResource, "status", federatedTypeConfig), &v1alpha1.FederatedTypeConfig{})
+		Invokes(testing.NewUpdateSubresourceAction(federatedtypeconfigsResource, "status", c.ns, federatedTypeConfig), &v1alpha1.FederatedTypeConfig{})
+
 	if obj == nil {
 		return nil, err
 	}
@@ -108,13 +115,14 @@ func (c *FakeFederatedTypeConfigs) UpdateStatus(federatedTypeConfig *v1alpha1.Fe
 // Delete takes name of the federatedTypeConfig and deletes it. Returns an error if one occurs.
 func (c *FakeFederatedTypeConfigs) Delete(name string, options *v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewRootDeleteAction(federatedtypeconfigsResource, name), &v1alpha1.FederatedTypeConfig{})
+		Invokes(testing.NewDeleteAction(federatedtypeconfigsResource, c.ns, name), &v1alpha1.FederatedTypeConfig{})
+
 	return err
 }
 
 // DeleteCollection deletes a collection of objects.
 func (c *FakeFederatedTypeConfigs) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewRootDeleteCollectionAction(federatedtypeconfigsResource, listOptions)
+	action := testing.NewDeleteCollectionAction(federatedtypeconfigsResource, c.ns, listOptions)
 
 	_, err := c.Fake.Invokes(action, &v1alpha1.FederatedTypeConfigList{})
 	return err
@@ -123,7 +131,8 @@ func (c *FakeFederatedTypeConfigs) DeleteCollection(options *v1.DeleteOptions, l
 // Patch applies the patch and returns the patched federatedTypeConfig.
 func (c *FakeFederatedTypeConfigs) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1alpha1.FederatedTypeConfig, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewRootPatchSubresourceAction(federatedtypeconfigsResource, name, data, subresources...), &v1alpha1.FederatedTypeConfig{})
+		Invokes(testing.NewPatchSubresourceAction(federatedtypeconfigsResource, c.ns, name, data, subresources...), &v1alpha1.FederatedTypeConfig{})
+
 	if obj == nil {
 		return nil, err
 	}

--- a/pkg/client/clientset/versioned/typed/core/v1alpha1/federatedtypeconfig.go
+++ b/pkg/client/clientset/versioned/typed/core/v1alpha1/federatedtypeconfig.go
@@ -30,7 +30,7 @@ import (
 // FederatedTypeConfigsGetter has a method to return a FederatedTypeConfigInterface.
 // A group's client should implement this interface.
 type FederatedTypeConfigsGetter interface {
-	FederatedTypeConfigs() FederatedTypeConfigInterface
+	FederatedTypeConfigs(namespace string) FederatedTypeConfigInterface
 }
 
 // FederatedTypeConfigInterface has methods to work with FederatedTypeConfig resources.
@@ -50,12 +50,14 @@ type FederatedTypeConfigInterface interface {
 // federatedTypeConfigs implements FederatedTypeConfigInterface
 type federatedTypeConfigs struct {
 	client rest.Interface
+	ns     string
 }
 
 // newFederatedTypeConfigs returns a FederatedTypeConfigs
-func newFederatedTypeConfigs(c *CoreV1alpha1Client) *federatedTypeConfigs {
+func newFederatedTypeConfigs(c *CoreV1alpha1Client, namespace string) *federatedTypeConfigs {
 	return &federatedTypeConfigs{
 		client: c.RESTClient(),
+		ns:     namespace,
 	}
 }
 
@@ -63,6 +65,7 @@ func newFederatedTypeConfigs(c *CoreV1alpha1Client) *federatedTypeConfigs {
 func (c *federatedTypeConfigs) Get(name string, options v1.GetOptions) (result *v1alpha1.FederatedTypeConfig, err error) {
 	result = &v1alpha1.FederatedTypeConfig{}
 	err = c.client.Get().
+		Namespace(c.ns).
 		Resource("federatedtypeconfigs").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -75,6 +78,7 @@ func (c *federatedTypeConfigs) Get(name string, options v1.GetOptions) (result *
 func (c *federatedTypeConfigs) List(opts v1.ListOptions) (result *v1alpha1.FederatedTypeConfigList, err error) {
 	result = &v1alpha1.FederatedTypeConfigList{}
 	err = c.client.Get().
+		Namespace(c.ns).
 		Resource("federatedtypeconfigs").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Do().
@@ -86,6 +90,7 @@ func (c *federatedTypeConfigs) List(opts v1.ListOptions) (result *v1alpha1.Feder
 func (c *federatedTypeConfigs) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	opts.Watch = true
 	return c.client.Get().
+		Namespace(c.ns).
 		Resource("federatedtypeconfigs").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Watch()
@@ -95,6 +100,7 @@ func (c *federatedTypeConfigs) Watch(opts v1.ListOptions) (watch.Interface, erro
 func (c *federatedTypeConfigs) Create(federatedTypeConfig *v1alpha1.FederatedTypeConfig) (result *v1alpha1.FederatedTypeConfig, err error) {
 	result = &v1alpha1.FederatedTypeConfig{}
 	err = c.client.Post().
+		Namespace(c.ns).
 		Resource("federatedtypeconfigs").
 		Body(federatedTypeConfig).
 		Do().
@@ -106,6 +112,7 @@ func (c *federatedTypeConfigs) Create(federatedTypeConfig *v1alpha1.FederatedTyp
 func (c *federatedTypeConfigs) Update(federatedTypeConfig *v1alpha1.FederatedTypeConfig) (result *v1alpha1.FederatedTypeConfig, err error) {
 	result = &v1alpha1.FederatedTypeConfig{}
 	err = c.client.Put().
+		Namespace(c.ns).
 		Resource("federatedtypeconfigs").
 		Name(federatedTypeConfig.Name).
 		Body(federatedTypeConfig).
@@ -120,6 +127,7 @@ func (c *federatedTypeConfigs) Update(federatedTypeConfig *v1alpha1.FederatedTyp
 func (c *federatedTypeConfigs) UpdateStatus(federatedTypeConfig *v1alpha1.FederatedTypeConfig) (result *v1alpha1.FederatedTypeConfig, err error) {
 	result = &v1alpha1.FederatedTypeConfig{}
 	err = c.client.Put().
+		Namespace(c.ns).
 		Resource("federatedtypeconfigs").
 		Name(federatedTypeConfig.Name).
 		SubResource("status").
@@ -132,6 +140,7 @@ func (c *federatedTypeConfigs) UpdateStatus(federatedTypeConfig *v1alpha1.Federa
 // Delete takes name of the federatedTypeConfig and deletes it. Returns an error if one occurs.
 func (c *federatedTypeConfigs) Delete(name string, options *v1.DeleteOptions) error {
 	return c.client.Delete().
+		Namespace(c.ns).
 		Resource("federatedtypeconfigs").
 		Name(name).
 		Body(options).
@@ -142,6 +151,7 @@ func (c *federatedTypeConfigs) Delete(name string, options *v1.DeleteOptions) er
 // DeleteCollection deletes a collection of objects.
 func (c *federatedTypeConfigs) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
 	return c.client.Delete().
+		Namespace(c.ns).
 		Resource("federatedtypeconfigs").
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Body(options).
@@ -153,6 +163,7 @@ func (c *federatedTypeConfigs) DeleteCollection(options *v1.DeleteOptions, listO
 func (c *federatedTypeConfigs) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1alpha1.FederatedTypeConfig, err error) {
 	result = &v1alpha1.FederatedTypeConfig{}
 	err = c.client.Patch(pt).
+		Namespace(c.ns).
 		Resource("federatedtypeconfigs").
 		SubResource(subresources...).
 		Name(name).

--- a/pkg/client/informers/externalversions/core/v1alpha1/federatedtypeconfig.go
+++ b/pkg/client/informers/externalversions/core/v1alpha1/federatedtypeconfig.go
@@ -41,32 +41,33 @@ type FederatedTypeConfigInformer interface {
 type federatedTypeConfigInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
 	tweakListOptions internalinterfaces.TweakListOptionsFunc
+	namespace        string
 }
 
 // NewFederatedTypeConfigInformer constructs a new informer for FederatedTypeConfig type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewFederatedTypeConfigInformer(client versioned.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
-	return NewFilteredFederatedTypeConfigInformer(client, resyncPeriod, indexers, nil)
+func NewFederatedTypeConfigInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return NewFilteredFederatedTypeConfigInformer(client, namespace, resyncPeriod, indexers, nil)
 }
 
 // NewFilteredFederatedTypeConfigInformer constructs a new informer for FederatedTypeConfig type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewFilteredFederatedTypeConfigInformer(client versioned.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
+func NewFilteredFederatedTypeConfigInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
 	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.CoreV1alpha1().FederatedTypeConfigs().List(options)
+				return client.CoreV1alpha1().FederatedTypeConfigs(namespace).List(options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.CoreV1alpha1().FederatedTypeConfigs().Watch(options)
+				return client.CoreV1alpha1().FederatedTypeConfigs(namespace).Watch(options)
 			},
 		},
 		&core_v1alpha1.FederatedTypeConfig{},
@@ -76,7 +77,7 @@ func NewFilteredFederatedTypeConfigInformer(client versioned.Interface, resyncPe
 }
 
 func (f *federatedTypeConfigInformer) defaultInformer(client versioned.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredFederatedTypeConfigInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	return NewFilteredFederatedTypeConfigInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
 }
 
 func (f *federatedTypeConfigInformer) Informer() cache.SharedIndexInformer {

--- a/pkg/client/informers/externalversions/core/v1alpha1/interface.go
+++ b/pkg/client/informers/externalversions/core/v1alpha1/interface.go
@@ -190,7 +190,7 @@ func (v *version) FederatedServicePlacements() FederatedServicePlacementInformer
 
 // FederatedTypeConfigs returns a FederatedTypeConfigInformer.
 func (v *version) FederatedTypeConfigs() FederatedTypeConfigInformer {
-	return &federatedTypeConfigInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
+	return &federatedTypeConfigInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
 }
 
 // PropagatedVersions returns a PropagatedVersionInformer.

--- a/pkg/client/listers/core/v1alpha1/expansion_generated.go
+++ b/pkg/client/listers/core/v1alpha1/expansion_generated.go
@@ -186,6 +186,10 @@ type FederatedServicePlacementNamespaceListerExpansion interface{}
 // FederatedTypeConfigLister.
 type FederatedTypeConfigListerExpansion interface{}
 
+// FederatedTypeConfigNamespaceListerExpansion allows custom methods to be added to
+// FederatedTypeConfigNamespaceLister.
+type FederatedTypeConfigNamespaceListerExpansion interface{}
+
 // PropagatedVersionListerExpansion allows custom methods to be added to
 // PropagatedVersionLister.
 type PropagatedVersionListerExpansion interface{}

--- a/pkg/client/listers/core/v1alpha1/federatedtypeconfig.go
+++ b/pkg/client/listers/core/v1alpha1/federatedtypeconfig.go
@@ -29,8 +29,8 @@ import (
 type FederatedTypeConfigLister interface {
 	// List lists all FederatedTypeConfigs in the indexer.
 	List(selector labels.Selector) (ret []*v1alpha1.FederatedTypeConfig, err error)
-	// Get retrieves the FederatedTypeConfig from the index for a given name.
-	Get(name string) (*v1alpha1.FederatedTypeConfig, error)
+	// FederatedTypeConfigs returns an object that can list and get FederatedTypeConfigs.
+	FederatedTypeConfigs(namespace string) FederatedTypeConfigNamespaceLister
 	FederatedTypeConfigListerExpansion
 }
 
@@ -52,9 +52,38 @@ func (s *federatedTypeConfigLister) List(selector labels.Selector) (ret []*v1alp
 	return ret, err
 }
 
-// Get retrieves the FederatedTypeConfig from the index for a given name.
-func (s *federatedTypeConfigLister) Get(name string) (*v1alpha1.FederatedTypeConfig, error) {
-	obj, exists, err := s.indexer.GetByKey(name)
+// FederatedTypeConfigs returns an object that can list and get FederatedTypeConfigs.
+func (s *federatedTypeConfigLister) FederatedTypeConfigs(namespace string) FederatedTypeConfigNamespaceLister {
+	return federatedTypeConfigNamespaceLister{indexer: s.indexer, namespace: namespace}
+}
+
+// FederatedTypeConfigNamespaceLister helps list and get FederatedTypeConfigs.
+type FederatedTypeConfigNamespaceLister interface {
+	// List lists all FederatedTypeConfigs in the indexer for a given namespace.
+	List(selector labels.Selector) (ret []*v1alpha1.FederatedTypeConfig, err error)
+	// Get retrieves the FederatedTypeConfig from the indexer for a given namespace and name.
+	Get(name string) (*v1alpha1.FederatedTypeConfig, error)
+	FederatedTypeConfigNamespaceListerExpansion
+}
+
+// federatedTypeConfigNamespaceLister implements the FederatedTypeConfigNamespaceLister
+// interface.
+type federatedTypeConfigNamespaceLister struct {
+	indexer   cache.Indexer
+	namespace string
+}
+
+// List lists all FederatedTypeConfigs in the indexer for a given namespace.
+func (s federatedTypeConfigNamespaceLister) List(selector labels.Selector) (ret []*v1alpha1.FederatedTypeConfig, err error) {
+	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
+		ret = append(ret, m.(*v1alpha1.FederatedTypeConfig))
+	})
+	return ret, err
+}
+
+// Get retrieves the FederatedTypeConfig from the indexer for a given namespace and name.
+func (s federatedTypeConfigNamespaceLister) Get(name string) (*v1alpha1.FederatedTypeConfig, error) {
+	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/federatedtypeconfig/controller.go
+++ b/pkg/controller/federatedtypeconfig/controller.go
@@ -25,6 +25,7 @@ import (
 	"github.com/kubernetes-sigs/kubebuilder/pkg/controller/types"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/rest"
@@ -83,7 +84,12 @@ func ProvideController(arguments args.InjectArgs, fedNamespace string, stopChan 
 		InformerRegistry: arguments.ControllerManager,
 	}
 
-	if err := gc.Watch(&corev1a1.FederatedTypeConfig{}); err != nil {
+	// Watch only the federation namespace.
+	//
+	// TODO(marun) Avoid requiring cluster read permission on
+	// FederatedTypeConfig by using a namespace-scoped informer
+	// instead of the manager-supplied SharedInformer.
+	if err := gc.Watch(&corev1a1.FederatedTypeConfig{}, &NamespacePredicate{fedNamespace}); err != nil {
 		return gc, err
 	}
 	return gc, nil
@@ -92,7 +98,7 @@ func ProvideController(arguments args.InjectArgs, fedNamespace string, stopChan 
 func (c *FederatedTypeConfigController) Reconcile(k types.ReconcileKey) error {
 	log.Printf("Running reconcile FederatedTypeConfig for %s\n", k.Name)
 
-	typeConfig, err := c.lister.Get(k.Name)
+	typeConfig, err := c.lister.FederatedTypeConfigs(k.Namespace).Get(k.Name)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			runtime.HandleError(fmt.Errorf("federatedtypeconfig '%s' in work queue no longer exists", k))
@@ -185,7 +191,7 @@ func (c *FederatedTypeConfigController) ensureFinalizer(tc *corev1a1.FederatedTy
 	}
 	finalizers.Insert(finalizer)
 	accessor.SetFinalizers(finalizers.List())
-	_, err = c.client.FederatedTypeConfigs().Update(tc)
+	_, err = c.client.FederatedTypeConfigs(tc.Namespace).Update(tc)
 	return err
 }
 
@@ -200,6 +206,32 @@ func (c *FederatedTypeConfigController) removeFinalizer(tc *corev1a1.FederatedTy
 	}
 	finalizers.Delete(finalizer)
 	accessor.SetFinalizers(finalizers.List())
-	_, err = c.client.FederatedTypeConfigs().Update(tc)
+	_, err = c.client.FederatedTypeConfigs(tc.Namespace).Update(tc)
 	return err
+}
+
+// Predicate to restrict event handling to a single namespace.
+type NamespacePredicate struct {
+	namespace string
+}
+
+func (np *NamespacePredicate) HandleUpdate(old, new interface{}) bool {
+	return np.objInNamespace(old)
+}
+
+func (np *NamespacePredicate) HandleDelete(obj interface{}) bool {
+	return np.objInNamespace(obj)
+}
+
+func (np *NamespacePredicate) HandleCreate(obj interface{}) bool {
+	return np.objInNamespace(obj)
+}
+
+func (np *NamespacePredicate) objInNamespace(obj interface{}) bool {
+	metaObj, ok := obj.(metav1.Object)
+	if !ok {
+		log.Printf("Cannot handle %T because obj is not an Object: %v\n", obj, obj)
+		return false
+	}
+	return metaObj.GetNamespace() == np.namespace
 }

--- a/scripts/deploy-federation.sh
+++ b/scripts/deploy-federation.sh
@@ -139,7 +139,7 @@ kubectl apply --validate=false -f vendor/k8s.io/cluster-registry/cluster-registr
 
 # Enable available types
 for filename in ./config/federatedtypes/*.yaml; do
-  kubectl apply -f "${filename}"
+  kubectl -n "${NS}" apply -f "${filename}"
 done
 
 # Join the host cluster

--- a/test/common/crudtester.go
+++ b/test/common/crudtester.go
@@ -57,6 +57,7 @@ type FederatedTypeCrudTester struct {
 }
 
 type TestCluster struct {
+	Config    *rest.Config
 	Client    util.ResourceClient
 	IsPrimary bool
 }

--- a/test/e2e/framework/unmanaged.go
+++ b/test/e2e/framework/unmanaged.go
@@ -195,6 +195,7 @@ func (f *UnmanagedFramework) ClusterDynamicClients(apiResource *metav1.APIResour
 		// Check if this cluster is the same name as the host cluster name to
 		// make it the primary cluster.
 		testClusters[clusterName] = common.TestCluster{
+			config,
 			client,
 			(clusterName == hostClusterName),
 		}

--- a/test/integration/framework/federation.go
+++ b/test/integration/framework/federation.go
@@ -242,6 +242,7 @@ func (f *FederationFixture) ClusterDynamicClients(tl common.TestLogger, apiResou
 			tl.Fatalf("Error creating a resource client in cluster %q for kind %q: %v", name, apiResource.Kind, err)
 		}
 		clientMap[name] = common.TestCluster{
+			config,
 			client,
 			cluster.IsPrimary,
 		}


### PR DESCRIPTION
This is the next step in allowing the fedv2 control plane to run in an arbitrary namespace (#197).  As part of this PR I updated the CRD e2e test to support targeting multiple clusters to ensure this change can be tested against the default managed fixture which uses 2 clusters.