### PR TITLE
Extends Pluralization Support

### DIFF
--- a/pkg/apis/core/v1alpha1/federatedtypeconfig_types.go
+++ b/pkg/apis/core/v1alpha1/federatedtypeconfig_types.go
@@ -99,12 +99,12 @@ func SetFederatedTypeConfigDefaults(obj *FederatedTypeConfig) {
 		group := nameParts[1]
 		setStringDefault(&obj.Spec.Target.Group, group)
 	}
-	setStringDefault(&obj.Spec.Template.PluralName, pluralName(obj.Spec.Template.Kind))
-	setStringDefault(&obj.Spec.Placement.PluralName, pluralName(obj.Spec.Placement.Kind))
+	setStringDefault(&obj.Spec.Template.PluralName, PluralName(obj.Spec.Template.Kind))
+	setStringDefault(&obj.Spec.Placement.PluralName, PluralName(obj.Spec.Placement.Kind))
 	setStringDefault(&obj.Spec.Placement.Group, obj.Spec.Template.Group)
 	setStringDefault(&obj.Spec.Placement.Version, obj.Spec.Template.Version)
 	if obj.Spec.Override != nil {
-		setStringDefault(&obj.Spec.Override.PluralName, pluralName(obj.Spec.Override.Kind))
+		setStringDefault(&obj.Spec.Override.PluralName, PluralName(obj.Spec.Override.Kind))
 		setStringDefault(&obj.Spec.Override.Group, obj.Spec.Template.Group)
 		setStringDefault(&obj.Spec.Override.Version, obj.Spec.Template.Version)
 	}
@@ -119,11 +119,13 @@ func setStringDefault(value *string, defaultValue string) {
 	*value = defaultValue
 }
 
-// PluralNameForKind naively computes the plural name from the kind by
-// lowercasing and suffixing with 's'.
-func pluralName(kind string) string {
+// PluralName computes the plural name from the kind by
+// lowercasing and suffixing with 's' or `es`.
+func PluralName(kind string) string {
 	lowerKind := strings.ToLower(kind)
-	if strings.HasSuffix(lowerKind, "s") {
+	if strings.HasSuffix(lowerKind, "s") || strings.HasSuffix(lowerKind, "x") ||
+		strings.HasSuffix(lowerKind, "ch") || strings.HasSuffix(lowerKind, "sh") ||
+		strings.HasSuffix(lowerKind, "z") || strings.HasSuffix(lowerKind, "o") {
 		return fmt.Sprintf("%ses", lowerKind)
 	}
 	return fmt.Sprintf("%ss", lowerKind)

--- a/pkg/apis/core/v1alpha1/federatedtypeconfig_types_test.go
+++ b/pkg/apis/core/v1alpha1/federatedtypeconfig_types_test.go
@@ -24,6 +24,7 @@ import (
 
 	. "github.com/kubernetes-sigs/federation-v2/pkg/apis/core/v1alpha1"
 	. "github.com/kubernetes-sigs/federation-v2/pkg/client/clientset/versioned/typed/core/v1alpha1"
+	"testing"
 )
 
 // EDIT THIS FILE!
@@ -81,3 +82,100 @@ var _ = Describe("FederatedTypeConfig", func() {
 		})
 	})
 })
+
+func TestPluralName(t *testing.T) {
+	var tests = []struct {
+		name   string
+		plural string
+		expect bool
+	}{
+		{
+			name:   "ingress",
+			plural: "ingresses",
+			expect: true,
+		},
+		{
+			name:   "ingress",
+			plural: "ingresss",
+			expect: false,
+		},
+		{
+			name:   "match",
+			plural: "matches",
+			expect: true,
+		},
+		{
+			name:   "match",
+			plural: "matchs",
+			expect: false,
+		},
+		{
+			name:   "mesh",
+			plural: "meshes",
+			expect: true,
+		},
+		{
+			name:   "mesh",
+			plural: "meshs",
+			expect: false,
+		},
+		{
+			name:   "box",
+			plural: "boxes",
+			expect: true,
+		},
+		{
+			name:   "box",
+			plural: "boxs",
+			expect: false,
+		},
+		{
+			name:   "match",
+			plural: "matches",
+			expect: true,
+		},
+		{
+			name:   "match",
+			plural: "matchs",
+			expect: false,
+		},
+		{
+			name:   "go",
+			plural: "goes",
+			expect: true,
+		},
+		{
+			name:   "go",
+			plural: "gos",
+			expect: false,
+		},
+		{
+			name:   "waltz",
+			plural: "waltzes",
+			expect: true,
+		},
+		{
+			name:   "waltz",
+			plural: "waltzs",
+			expect: false,
+		},
+	}
+
+	for _, rt := range tests {
+		actual := PluralName(rt.name)
+		if rt.expect && actual != rt.plural {
+			t.Errorf(
+				"failed pluralizing:\n\texpected: %v\n\t  actual: %v",
+				rt.name,
+				actual,
+			)
+		}
+		if !rt.expect && actual == rt.plural {
+			t.Errorf(
+				"pluralizing should have failed:\n\texpected: %v\n\t  actual: %v",
+				rt.name,
+				actual,
+			)
+		}
+	}
+}


### PR DESCRIPTION
Previously, the pluralName function would only add 'es' to
strings with an 's' suffix. Adding 'es' should be used for
additional suffixes. This will prevent improper pluralization
of future supported types. See:

https://howtospell.co.uk/adding-es-plural-rule

Fixes Issue: #219