### PR TITLE
kubefed: clean up role and binding creation

### DIFF
--- a/pkg/kubefed2/util/util.go
+++ b/pkg/kubefed2/util/util.go
@@ -119,3 +119,10 @@ func ClusterServiceAccountName(joiningClusterName, hostClusterName string) strin
 func RoleName(serviceAccountName string) string {
 	return fmt.Sprintf("federation-controller-manager:%s", serviceAccountName)
 }
+
+// HealthzRoleName returns the name of a ClusterRole and its
+// associated ClusterRoleBinding that is used to allow the service
+// account to check the health of the cluster.
+func HealthzRoleName(serviceAccountName string) string {
+	return fmt.Sprintf("federation-controller-manager:healthz-%s", serviceAccountName)
+}


### PR DESCRIPTION
This PR cleans up role and binding creation by separating out the common healthz rule into a new role.  The existing methods are cleaned up for consistency.

This is in response to a comment from @irfanurrehman: https://github.com/kubernetes-sigs/federation-v2/pull/215#discussion_r211552117