### PR TITLE
Rename --cluster-namespace to --registry-namespace

### DIFF
--- a/pkg/kubefed2/join.go
+++ b/pkg/kubefed2/join.go
@@ -128,7 +128,7 @@ func (j *joinFederation) Complete(args []string) error {
 		j.clusterContext = j.ClusterName
 	}
 
-	glog.V(2).Infof("Args and flags: name %s, host: %s, host-system-namespace: %s, cluster-namespace: %s, kubeconfig: %s, cluster-context: %s, secret-name: %s, limited-scope: %s, dry-run: %v",
+	glog.V(2).Infof("Args and flags: name %s, host: %s, host-system-namespace: %s, registry-namespace: %s, kubeconfig: %s, cluster-context: %s, secret-name: %s, limited-scope: %s, dry-run: %v",
 		j.ClusterName, j.HostClusterContext, j.FederationNamespace, j.ClusterNamespace, j.Kubeconfig, j.clusterContext,
 		j.secretName, j.limitedScope, j.DryRun)
 

--- a/pkg/kubefed2/options/options.go
+++ b/pkg/kubefed2/options/options.go
@@ -40,7 +40,7 @@ func (o *SubcommandOptions) CommonBind(flags *pflag.FlagSet) {
 	flags.StringVar(&o.HostClusterContext, "host-cluster-context", "", "Host cluster context")
 	flags.StringVar(&o.FederationNamespace, "federation-namespace", util.DefaultFederationSystemNamespace,
 		"Namespace in the host cluster where the federation system components are installed.  This namespace will also be the target of propagation if the controller manager is configured with --limited-scope and clusters are joined with --limited-scope.")
-	flags.StringVar(&o.ClusterNamespace, "cluster-namespace", util.MulticlusterPublicNamespace,
+	flags.StringVar(&o.ClusterNamespace, "registry-namespace", util.MulticlusterPublicNamespace,
 		"Namespace in the host cluster where clusters are registered")
 	flags.BoolVar(&o.DryRun, "dry-run", false,
 		"Run the command in dry-run mode, without making any server requests.")

--- a/test/e2e/framework/test_context.go
+++ b/test/e2e/framework/test_context.go
@@ -53,7 +53,7 @@ func registerFlags(t *TestContextType) {
 		"kubeconfig context to use/override. If unset, will use value from 'current-context'.")
 	flag.StringVar(&t.FederationSystemNamespace, "fed-namespace", util.DefaultFederationSystemNamespace,
 		fmt.Sprintf("The namespace the federation control plane is deployed in.  If unset, will default to %q.", util.DefaultFederationSystemNamespace))
-	flag.StringVar(&t.ClusterNamespace, "cluster-namespace", util.MulticlusterPublicNamespace,
+	flag.StringVar(&t.ClusterNamespace, "registry-namespace", util.MulticlusterPublicNamespace,
 		fmt.Sprintf("The cluster registry namespace.  If unset, will default to %q.", util.MulticlusterPublicNamespace))
 	flag.StringVar(&t.TargetNamespace, "target-namespace", metav1.NamespaceAll,
 		"The namespace to target for federation.  If unset, will default to all namespaces")


### PR DESCRIPTION
This is for consistency with --add-to-registry as per a request by @font: https://github.com/kubernetes-sigs/federation-v2/pull/213#discussion_r211833990