### PR TITLE
Fixes Delete Bug in Delete Script

### DIFF
--- a/scripts/delete-federation.sh
+++ b/scripts/delete-federation.sh
@@ -42,7 +42,7 @@ ${KCD} namespace ${PUBLIC_NS}
 
 # Disable available types
 for filename in ./config/federatedtypes/*.yaml; do
-  ${KCD} -f "${filename}"
+  ${KCD} -f "${filename}" -n ${NS}
 done
 
 # Remove federation CRDs, namespace, RBAC and deployment resources.


### PR DESCRIPTION
Previously, federated config types were not being deleted by
`delete-federation.sh`. This is because a namespace was not
being provided in the `kubectl` delete command. This commit
adds the ns to the kubectl command to properly delete the
federated config type resources.

Fixes Issue: #227