### PR TITLE
Bump e2e timeout to avoid deployment e2e timeout

### DIFF
--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -31,7 +31,7 @@ const (
 	// How long to try single API calls (like 'get' or 'list'). Used to prevent
 	// transient failures from failing tests.
 	PollInterval      = 2 * time.Second
-	SingleCallTimeout = 60 * time.Second
+	SingleCallTimeout = 90 * time.Second
 )
 
 // unique identifier of the e2e run


### PR DESCRIPTION
Deployments have the most complex workflow of the existing kubernetes types, and the interaction of the deployment controller with the sync controller is likely to case the deployment crud test to take longer than for other types.  Since the deployment crud test has been regularly flaking, the previous timeout was likely not long enough.

Targets #214 