### PR TITLE
Ensure control plane can run with only authz for the federation namespace

### DIFF
--- a/pkg/controller/sync/controller.go
+++ b/pkg/controller/sync/controller.go
@@ -127,7 +127,7 @@ func StartFederationSyncController(typeConfig typeconfig.Interface, kubeConfig *
 	if minimizeLatency {
 		controller.minimizeLatency()
 	}
-	glog.Infof(fmt.Sprintf("Starting sync controller for %s resources", typeConfig.GetTemplate().Kind))
+	glog.Infof(fmt.Sprintf("Starting sync controller for %q", typeConfig.GetTemplate().Kind))
 	controller.Run(stopChan)
 	return nil
 }

--- a/scripts/delete-federation.sh
+++ b/scripts/delete-federation.sh
@@ -62,7 +62,11 @@ else
 fi
 
 # Remove permissive rolebinding that allows federation controllers to run.
-${KCD} clusterrolebinding federation-admin
+if [[ "${NAMESPACED}" ]]; then
+  ${KCD} -n "${NS}" rolebinding federation-admin
+else
+  ${KCD} clusterrolebinding federation-admin
+fi
 
 # Wait for the namespaces to be removed
 function ns-deleted() {

--- a/scripts/deploy-federation.sh
+++ b/scripts/deploy-federation.sh
@@ -117,11 +117,13 @@ else
 fi
 
 # Create a permissive clusterrolebinding to allow federation controllers to run.
-# TODO(marun) Make this more restrictive.
-# TODO(marun) Use a rolebinding when namespaced once the
-# federaatedtypeconfig controller can limit informer scope to the
-# namespace.
-kubectl create clusterrolebinding federation-admin --clusterrole=cluster-admin --serviceaccount="${NS}:default"
+if [[ "${NAMESPACED}" ]]; then
+  # TODO(marun) Investigate why cluster-admin is required to view cluster registry clusters in a namespace
+  kubectl -n "${NS}" create rolebinding federation-admin --clusterrole=cluster-admin --serviceaccount="${NS}:default"
+else
+  # TODO(marun) Make this more restrictive.
+  kubectl create clusterrolebinding federation-admin --clusterrole=cluster-admin --serviceaccount="${NS}:default"
+fi
 
 if [[ ! "${USE_LATEST}" ]]; then
   if [[ "${NAMESPACED}" ]]; then


### PR DESCRIPTION
This PR limits the permissions of the federation service account to a role binding when run in namespaced mode.  For some reason the `cluster-admin` roles is required - `admin` or `edit` do not grant sufficient access.

Supporting limited authz required rewriting the controller for `FederatedTypeConfig`.  The `kubebuilder` controller framework didn't appear to have any provision for limiting informer scope, so this PR rewrites the controller to be consistent with all the other federation controllers.

Targets #197 