### PR TITLE
Enable e2e test timeout to be configured

### DIFF
--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -51,7 +51,7 @@ function launch-minikube-cluster() {
 }
 
 function run-e2e-tests() {
-  go test -v ./test/e2e -args -kubeconfig=${HOME}/.kube/config -ginkgo.v
+  go test -v ./test/e2e -args -kubeconfig=${HOME}/.kube/config -ginkgo.v -single-call-timeout=5m
   rc=$((rc || $?))
   return ${rc}
 }

--- a/test/e2e/crud.go
+++ b/test/e2e/crud.go
@@ -235,7 +235,7 @@ func waitForCrd(pool dynamic.ClientPool, tl common.TestLogger, apiResource metav
 	if err != nil {
 		tl.Fatalf("Error creating client for crd %q: %v", apiResource.Kind, err)
 	}
-	err = wait.PollImmediate(framework.PollInterval, framework.SingleCallTimeout, func() (bool, error) {
+	err = wait.PollImmediate(framework.PollInterval, framework.TestContext.SingleCallTimeout, func() (bool, error) {
 		_, err := client.Resources("invalid").Get("invalid", metav1.GetOptions{})
 		if errors.IsNotFound(err) {
 			return true, nil
@@ -264,7 +264,7 @@ func validateCrud(f framework.FederationFramework, tl common.TestLogger, typeCon
 	kubeConfig := f.KubeConfig()
 	targetAPIResource := typeConfig.GetTarget()
 	testClusters := f.ClusterDynamicClients(&targetAPIResource, userAgent)
-	crudTester, err := common.NewFederatedTypeCrudTester(tl, typeConfig, kubeConfig, testClusters, framework.PollInterval, framework.SingleCallTimeout)
+	crudTester, err := common.NewFederatedTypeCrudTester(tl, typeConfig, kubeConfig, testClusters, framework.PollInterval, framework.TestContext.SingleCallTimeout)
 	if err != nil {
 		tl.Fatalf("Error creating crudtester for %q: %v", templateKind, err)
 	}

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -151,7 +151,7 @@ func createNamespace(client kubeclientset.Interface, baseName string) (string, e
 	// Be robust about making the namespace creation call.
 	// TODO(marun) should all api calls be made 'robustly'?
 	var namespaceName string
-	if err := wait.PollImmediate(PollInterval, SingleCallTimeout, func() (bool, error) {
+	if err := wait.PollImmediate(PollInterval, TestContext.SingleCallTimeout, func() (bool, error) {
 		namespace, err := client.Core().Namespaces().Create(namespaceObj)
 		if err != nil {
 			Logf("Unexpected error while creating namespace: %v", err)

--- a/test/e2e/framework/test_context.go
+++ b/test/e2e/framework/test_context.go
@@ -20,6 +20,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/golang/glog"
 
@@ -36,6 +37,7 @@ type TestContextType struct {
 	FederationSystemNamespace string
 	ClusterNamespace          string
 	TargetNamespace           string
+	SingleCallTimeout         time.Duration
 }
 
 var TestContext TestContextType
@@ -55,6 +57,8 @@ func registerFlags(t *TestContextType) {
 		fmt.Sprintf("The cluster registry namespace.  If unset, will default to %q.", util.MulticlusterPublicNamespace))
 	flag.StringVar(&t.TargetNamespace, "target-namespace", metav1.NamespaceAll,
 		"The namespace to target for federation.  If unset, will default to all namespaces")
+	flag.DurationVar(&t.SingleCallTimeout, "single-call-timeout", DefaultSingleCallTimeout,
+		fmt.Sprintf("The maximum duration of a single call.  If unset, will default to %v", DefaultSingleCallTimeout))
 }
 
 func validateFlags(t *TestContextType) {

--- a/test/e2e/framework/unmanaged.go
+++ b/test/e2e/framework/unmanaged.go
@@ -287,7 +287,7 @@ func deleteNamespace(client kubeclientset.Interface, namespaceName string) {
 	// nested clusters having been removed.  It will be necessary to
 	// identify that a given namespace is in the hosting cluster and
 	// therefore does not have to be deleted before finalizer removal.
-	err := wait.PollImmediate(PollInterval, SingleCallTimeout, func() (bool, error) {
+	err := wait.PollImmediate(PollInterval, TestContext.SingleCallTimeout, func() (bool, error) {
 		if _, err := client.Core().Namespaces().Get(namespaceName, metav1.GetOptions{}); err != nil {
 			if apierrors.IsNotFound(err) {
 				return true, nil
@@ -377,7 +377,7 @@ func DumpEventsInNamespace(eventsLister EventsLister, namespace string) {
 func ClusterIsReadyOrFail(client fedclientset.Interface, cluster *fedv1a1.FederatedCluster) {
 	clusterName := cluster.Name
 	By(fmt.Sprintf("Checking readiness of cluster %q", clusterName))
-	err := wait.PollImmediate(PollInterval, SingleCallTimeout, func() (bool, error) {
+	err := wait.PollImmediate(PollInterval, TestContext.SingleCallTimeout, func() (bool, error) {
 		for _, condition := range cluster.Status.Conditions {
 			if condition.Type == fedcommon.ClusterReady && condition.Status == corev1.ConditionTrue {
 				return true, nil

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -30,8 +30,8 @@ import (
 const (
 	// How long to try single API calls (like 'get' or 'list'). Used to prevent
 	// transient failures from failing tests.
-	PollInterval      = 2 * time.Second
-	SingleCallTimeout = 90 * time.Second
+	PollInterval             = 2 * time.Second
+	DefaultSingleCallTimeout = 30 * time.Second
 )
 
 // unique identifier of the e2e run


### PR DESCRIPTION
This will allow a short default timeout for developers and CI can set a long timeout to avoid timeout flakes.