### PR TITLE
Remove /config from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,5 @@
 /bin
 /default.etcd
 /kubeconfig
-/config
 /hack/install.yaml
 /images/federation-v2/controller-manager


### PR DESCRIPTION
/config is a an artifact from the previous use of `apiserver-builder` and should be removed.

/cc @font 