### PR TITLE
Update install-latest.yaml to work with latest image

### DIFF
--- a/hack/install-latest.yaml
+++ b/hack/install-latest.yaml
@@ -930,7 +930,7 @@ spec:
   names:
     kind: FederatedTypeConfig
     plural: federatedtypeconfigs
-  scope: Namespaced
+  scope: Cluster
   validation:
     openAPIV3Schema:
       properties:


### PR DESCRIPTION
Reverted the update that made `FederatedTypeConfig` namespace scoped in order to continue working with the latest stable released version of fedv2 (v0.0.1). This allows the userguide to continue working as expected.

Fixes #232.

/cc @pmorie 