### PR TITLE
Fixes for namespace-scoped federatednamespaceplacement

### DIFF
--- a/docs/userguide.md
+++ b/docs/userguide.md
@@ -321,8 +321,8 @@ successfully verified a working federation-v2 deployment.
 To cleanup the example simply delete the namespace and its placement:
 
 ```bash
+kubectl -n test-namespace delete federatednamespaceplacement test-namespace
 kubectl delete ns test-namespace
-kubectl delete federatednamespaceplacement test-namespace
 ```
 
 ## Cleanup

--- a/example/sample1/federatednamespace-placement.yaml
+++ b/example/sample1/federatednamespace-placement.yaml
@@ -5,6 +5,7 @@ items:
   kind: FederatedNamespacePlacement
   metadata:
     name: test-namespace
+    namespace: test-namespace
   spec:
     clusternames:
     - cluster1

--- a/pkg/controller/sync/controller.go
+++ b/pkg/controller/sync/controller.go
@@ -430,6 +430,7 @@ func (s *FederationSyncController) reconcile(qualifiedName util.QualifiedName) u
 		// to not propagate beyond just the default system namespaces e.g.
 		// clusterregistry.
 		if isSystemNamespace(s.fedNamespace, namespace) {
+			glog.V(4).Infof("Ignoring system namespace %v", namespace)
 			return util.StatusAllOK
 		}
 
@@ -461,6 +462,7 @@ func (s *FederationSyncController) reconcile(qualifiedName util.QualifiedName) u
 		return util.StatusError
 	}
 	if template == nil {
+		glog.V(4).Infof("No template for %v %v found", templateKind, key)
 		return util.StatusAllOK
 	}
 


### PR DESCRIPTION
`FederatedNamespacePlacement` becoming namespace-scoped has resulted in the user guide example not working. Specifically, the resources all get created successfully, but when you try to remove `cluster2` from the `FederatedNamespacePlacement` object, the resources in the `test-namespace` are not removed because the `test-namespace` is never removed.

This was caused by mismatching keys to retrieve `Namespace` and `FederatedNamespacePlacement` objects from the cache. This is a temporary fix as `Namespaces` are the only resources we currently support whose template is cluster-scoped while the placement is namespace-scoped. A proper long-term solution should be investigated, especially when we begin to support more cluster-scoped resources.