### PR TITLE
Makes Namespaces Conditional in Tests

### DIFF
--- a/test/common/testobjects.go
+++ b/test/common/testobjects.go
@@ -114,7 +114,9 @@ func GetPlacementTestObject(typeConfig typeconfig.Interface, namespace string, c
 		return nil, err
 	}
 	placementAPIResource := typeConfig.GetPlacement()
-	placement.SetNamespace(namespace)
+	if typeConfig.GetNamespaced() {
+		placement.SetNamespace(namespace)
+	}
 	placement.SetKind(placementAPIResource.Kind)
 	placement.SetAPIVersion(fmt.Sprintf("%s/%s", placementAPIResource.Group, placementAPIResource.Version))
 	err = util.SetClusterNames(placement, clusterNames)

--- a/test/common/testobjects.go
+++ b/test/common/testobjects.go
@@ -40,7 +40,9 @@ func NewTestObjects(typeConfig typeconfig.Interface, namespace string, clusterNa
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	template.SetNamespace(namespace)
+	if typeConfig.GetNamespaced() {
+		template.SetNamespace(namespace)
+	}
 	template.SetName("")
 	template.SetGenerateName("test-crud-")
 

--- a/test/common/testobjects.go
+++ b/test/common/testobjects.go
@@ -57,7 +57,9 @@ func NewTestObjects(typeConfig typeconfig.Interface, namespace string, clusterNa
 		if err != nil {
 			return nil, nil, nil, err
 		}
-		override.SetNamespace(namespace)
+		if typeConfig.GetNamespaced() {
+			override.SetNamespace(namespace)
+		}
 		overridesSlice, ok, err := unstructured.NestedSlice(override.Object, "spec", "overrides")
 		if err != nil {
 			return nil, nil, nil, fmt.Errorf("Error retrieving overrides for %q: %v", typeConfig.GetTemplate().Kind, err)


### PR DESCRIPTION
Sets a `namespace` in a template only if it exists in the type config. This is required for resources that are not ns-scoped.