### PR TITLE
Upgrade Kubebuilder to v1.0.3.

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -315,7 +315,7 @@ kubebuilder create config \
 Once the installation YAML config `hack/install.yaml` is created, we need to
 update it to modify a few fields.
 
-First, increase the memory request and limit to avoid OOM issues by running the
+Increase the memory request and limit to avoid OOM issues by running the
 following commands:
 
 ```bash
@@ -323,19 +323,7 @@ sed -i 's/memory: 20Mi/memory: 64Mi/' hack/install.yaml
 sed -i 's/memory: 30Mi/memory: 128Mi/' hack/install.yaml
 ```
 
-Then, delete the `type` field from the OpenAPI schema to avoid triggering validation
-errors in kubernetes version < 1.12 when a type specifies a subresource (e.g.
-status). The `type` field only triggers validation errors for resource types
-that define subresources, but it is simpler to fix for all types. See
-https://github.com/kubernetes/kubernetes/issues/65293 for more details.
-
-Run the following command to fix the config:
-
-```bash
-sed -i -e '/^      type: object$/d' hack/install.yaml
-```
-
-Once the installation YAML config `hack/install.yaml` is fixed, you are able
+Once the installation YAML config `hack/install.yaml` is updated, you are able
 to apply this configuration by following the [manual deployment steps in the
 user guide](userguide.md#manual-deployment). Be sure to use this newly
 generated configuration instead of `hack/install-latest.yaml`.

--- a/docs/userguide.md
+++ b/docs/userguide.md
@@ -12,10 +12,8 @@ is a detailed list of binaries required.
 
 The federation deployment depends on `kubebuilder`, `etcd`, `kubectl`, and
 `kube-apiserver` >= v1.11 being installed in the path. The `kubebuilder`
-release packages all of these dependencies together, but the latest version of
-`kubebuilder` (v1.0.0 as of this writing) only includes binaries for
-kubernetes 1.10. Once `kubebuilder` bundles binaries >= 1.11, it will
-only require downloading the `kubebuilder` release.
+([v1.0.3](https://github.com/kubernetes-sigs/kubebuilder/releases/tag/v1.0.3)
+as of this writing) release packages all of these dependencies together.
 
 These binaries can be installed via the `download-binaries.sh` script, which
 downloads them to `./bin`:
@@ -31,25 +29,9 @@ Or you can install them manually yourself using the guidelines provided below.
 
 This repo depends on
 [kubebuilder](https://github.com/kubernetes-sigs/kubebuilder)
-to generate code and build binaries. Download the [v1.0.0
-release](https://github.com/kubernetes-sigs/kubebuilder/releases/tag/v1.0.0)
+to generate code and build binaries. Download the [v1.0.3
+release](https://github.com/kubernetes-sigs/kubebuilder/releases/tag/v1.0.3)
 and install it in your `PATH`.
-
-#### kubectl
-
-Download a version of
-[`kubectl`](https://kubernetes.io/docs/tasks/tools/install-kubectl/) >= v1.11 and
-install it in your `PATH`. To download version 1.11:
-  - https://storage.googleapis.com/kubernetes-release/release/v1.11.0/bin/linux/amd64/kubectl
-
-#### kube-apiserver
-
-Download a version of
-[`kube-apiserver`](https://github.com/kubernetes/kubernetes/releases) >= 1.11
-and install it in your `PATH`. Make sure the path to this binary comes before
-the path to the `kubebuilder` installation, otherwise you will use the
-`kube-apiserver` from `kubebuilder` instead. To download version 1.11:
-  - https://storage.googleapis.com/kubernetes-release/release/v1.11.0/bin/linux/amd64/kube-apiserver
 
 ### Create Clusters
 

--- a/scripts/download-binaries.sh
+++ b/scripts/download-binaries.sh
@@ -41,24 +41,17 @@ root_dir="$(cd "$(dirname "$0")/.." ; pwd)"
 dest_dir="${root_dir}/bin"
 mkdir -p "${dest_dir}"
 
-kb_version="1.0.0"
+kb_version="1.0.3"
 kb_tgz="kubebuilder_${kb_version}_linux_amd64.tar.gz"
 kb_url="https://github.com/kubernetes-sigs/kubebuilder/releases/download/v${kb_version}/${kb_tgz}"
 curl "${curl_args}O" "${kb_url}" \
   && tar xzfP "${kb_tgz}" -C "${dest_dir}" --strip-components=2 \
   && rm "${kb_tgz}"
 
-# Use a stable version of kube-apiserver to ensure a version >= 1.11.
-# TODO(marun) Remove when kubebuilder includes released 1.11 binaries
-stable_version="$(curl "${curl_args}" https://storage.googleapis.com/kubernetes-release/release/stable.txt)"
-ks_url="https://storage.googleapis.com/kubernetes-release/release/${stable_version}/bin/linux/amd64/kube-apiserver"
-ks_dest="${dest_dir}/kube-apiserver"
-curl "${curl_args}" "${ks_url}" --output "${ks_dest}"
-
 echo    "# destination:"
 echo    "#   ${dest_dir}"
 echo    "# versions:"
 echo -n "#   etcd:           "; "${dest_dir}/etcd" --version | head -n 1
-echo -n "#   kube-apiserver: "; "${ks_dest}" --version
+echo -n "#   kube-apiserver: "; "${dest_dir}/kube-apiserver" --version
 echo -n "#   kubectl:        "; "${dest_dir}/kubectl" version --client --short
 echo -n "#   kubebuilder:    "; "${dest_dir}/kubebuilder" version

--- a/scripts/generate-install-yaml.sh
+++ b/scripts/generate-install-yaml.sh
@@ -27,12 +27,3 @@ kubebuilder create config --controller-image "${IMAGE_NAME}" \
 # Increase memory request and limit to avoid OOM issues.
 sed -i 's/memory: 20Mi/memory: 64Mi/' "${INSTALL_YAML}"
 sed -i 's/memory: 30Mi/memory: 128Mi/' "${INSTALL_YAML}"
-
-# Delete the 'type' field from the openapi schema to avoid
-# triggering validation errors in kube < 1.12 when a type specifies
-# a subresource (e.g. status).  The 'type' field only triggers
-# validation errors for resource types that define subresources, but
-# it is simpler to fix for all types.
-#
-# Reference: https://github.com/kubernetes/kubernetes/issues/65293
-sed -i -e '/^      type: object$/d' "${INSTALL_YAML}"


### PR DESCRIPTION
Kubebuider v1.0.3 is shipping with Kubernetes 1.11, there is no need
to download the v1.11 kube-apiserver in test script, and also no need
to update `hack/install.yaml`, as the issue https://github.com/kubernetes/kubernetes/issues/65293
was already fixed in kubernetes v1.11.

/cc @marun @pmorie 