### PR TITLE
Improve e2e reliability

### DIFF
--- a/pkg/controller/util/placement.go
+++ b/pkg/controller/util/placement.go
@@ -20,11 +20,13 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
+const clusterNamesField = "clusterNames"
+
 func GetClusterNames(placement *unstructured.Unstructured) ([]string, error) {
-	clusterNames, _, err := unstructured.NestedStringSlice(placement.Object, "spec", "clusternames")
+	clusterNames, _, err := unstructured.NestedStringSlice(placement.Object, "spec", clusterNamesField)
 	return clusterNames, err
 }
 
 func SetClusterNames(placement *unstructured.Unstructured, clusterNames []string) error {
-	return unstructured.SetNestedStringSlice(placement.Object, clusterNames, "spec", "clusternames")
+	return unstructured.SetNestedStringSlice(placement.Object, clusterNames, "spec", clusterNamesField)
 }

--- a/scripts/download-e2e-binaries.sh
+++ b/scripts/download-e2e-binaries.sh
@@ -57,6 +57,9 @@ curl "${curl_args}O" "${crictl_url}" \
   && tar xzfP "${crictl_tgz}" -C "${dest_dir}" \
   && rm "${crictl_tgz}"
 
+# Pull the busybox image (used in tests of workload types)
+docker pull busybox
+
 echo    "# destination:"
 echo    "#   ${dest_dir}"
 echo    "# versions:"

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -51,7 +51,7 @@ function launch-minikube-cluster() {
 }
 
 function run-e2e-tests() {
-  go test -v ./test/e2e -args -kubeconfig=${HOME}/.kube/config -ginkgo.v -single-call-timeout=5m
+  go test -v ./test/e2e -args -kubeconfig=${HOME}/.kube/config -ginkgo.v -single-call-timeout=1m
   rc=$((rc || $?))
   return ${rc}
 }

--- a/test/common/fixtures/deployment-override.yaml
+++ b/test/common/fixtures/deployment-override.yaml
@@ -6,4 +6,4 @@ metadata:
 spec:
   overrides:
     - clusterName: placeholder
-      replicas: 5
+      replicas: 2

--- a/test/common/fixtures/deployment-template.yaml
+++ b/test/common/fixtures/deployment-template.yaml
@@ -17,5 +17,6 @@ spec:
         spec:
           terminationGracePeriodSeconds: 0
           containers:
-            - name: nginx
-              image: nginx
+            - name: busybox
+              image: busybox
+              command: ["/bin/sh", "-c", "trap : TERM INT; (while true; do sleep 1000; done) & wait"]

--- a/test/common/fixtures/deployment-template.yaml
+++ b/test/common/fixtures/deployment-template.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   template:
     spec:
-      replicas: 3
+      replicas: 1
       selector:
         matchLabels:
           foo: bar

--- a/test/common/fixtures/job-template.yaml
+++ b/test/common/fixtures/job-template.yaml
@@ -19,5 +19,6 @@ spec:
           terminationGracePeriodSeconds: 0
           restartPolicy: Never
           containers:
-            - name: nginx
-              image: nginx
+            - name: busybox
+              image: busybox
+              command: ["/bin/sh", "-c", "trap : TERM INT; (while true; do sleep 1000; done) & wait"]

--- a/test/common/fixtures/replicaset-override.yaml
+++ b/test/common/fixtures/replicaset-override.yaml
@@ -6,4 +6,4 @@ metadata:
 spec:
   overrides:
     - clusterName: placeholder
-      replicas: 5
+      replicas: 2

--- a/test/common/fixtures/replicaset-template.yaml
+++ b/test/common/fixtures/replicaset-template.yaml
@@ -17,5 +17,6 @@ spec:
         spec:
           terminationGracePeriodSeconds: 0
           containers:
-            - name: nginx
-              image: nginx
+            - name: busybox
+              image: busybox
+              command: ["/bin/sh", "-c", "trap : TERM INT; (while true; do sleep 1000; done) & wait"]

--- a/test/common/fixtures/replicaset-template.yaml
+++ b/test/common/fixtures/replicaset-template.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   template:
     spec:
-      replicas: 3
+      replicas: 1
       selector:
         matchLabels:
           foo: bar

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -28,9 +28,11 @@ import (
 )
 
 const (
+	// Using the same interval as integration should be fine given the
+	// minimal load that the apiserver is likely to be under.
+	PollInterval = 50 * time.Millisecond
 	// How long to try single API calls (like 'get' or 'list'). Used to prevent
 	// transient failures from failing tests.
-	PollInterval             = 2 * time.Second
 	DefaultSingleCallTimeout = 30 * time.Second
 )
 


### PR DESCRIPTION
2 commits target #214

- Fix crudtester check of placement change when the host cluster is joined to itself.
- Fix case of placement field `clusterNames`

The remaining commits speed up test execution:

- Change replicaset and deployment e2e fixture to use replicas=1 with an override of replicas=2 (previously was 3 and override of 5).
- Change replicaset, deployment and job e2e fixture to use <2mb `busybox` image (previously was 100mb `nginx` image).
- Reduce poll and wait intervals