### PR TITLE
Cleanup e2e readiness

### DIFF
--- a/pkg/controller/util/federated_informer.go
+++ b/pkg/controller/util/federated_informer.go
@@ -206,7 +206,7 @@ func NewFederatedInformer(
 				curCluster, ok := cur.(*fedv1a1.FederatedCluster)
 				if !ok {
 					glog.Errorf("Cluster %v/%v not added; incorrect type", curCluster.Namespace, curCluster.Name)
-				} else if isClusterReady(curCluster) {
+				} else if IsClusterReady(curCluster) {
 					federatedInformer.addCluster(curCluster)
 					glog.Infof("Cluster %v/%v is ready", curCluster.Namespace, curCluster.Name)
 					if clusterLifecycle.ClusterAvailable != nil {
@@ -227,7 +227,7 @@ func NewFederatedInformer(
 					glog.Errorf("Internal error: Cluster %v not updated.  New cluster not of correct type.", cur)
 					return
 				}
-				if isClusterReady(oldCluster) != isClusterReady(curCluster) || !reflect.DeepEqual(oldCluster.Spec, curCluster.Spec) || !reflect.DeepEqual(oldCluster.ObjectMeta.Annotations, curCluster.ObjectMeta.Annotations) {
+				if IsClusterReady(oldCluster) != IsClusterReady(curCluster) || !reflect.DeepEqual(oldCluster.Spec, curCluster.Spec) || !reflect.DeepEqual(oldCluster.ObjectMeta.Annotations, curCluster.ObjectMeta.Annotations) {
 					var data []interface{}
 					if clusterLifecycle.ClusterUnavailable != nil {
 						data = getClusterData(oldCluster.Name)
@@ -237,7 +237,7 @@ func NewFederatedInformer(
 						clusterLifecycle.ClusterUnavailable(oldCluster, data)
 					}
 
-					if isClusterReady(curCluster) {
+					if IsClusterReady(curCluster) {
 						federatedInformer.addCluster(curCluster)
 						if clusterLifecycle.ClusterAvailable != nil {
 							clusterLifecycle.ClusterAvailable(curCluster)
@@ -252,7 +252,7 @@ func NewFederatedInformer(
 	return federatedInformer
 }
 
-func isClusterReady(cluster *fedv1a1.FederatedCluster) bool {
+func IsClusterReady(cluster *fedv1a1.FederatedCluster) bool {
 	for _, condition := range cluster.Status.Conditions {
 		if condition.Type == fedcommon.ClusterReady {
 			if condition.Status == apiv1.ConditionTrue {
@@ -356,7 +356,7 @@ func (f *federatedInformerImpl) GetUnreadyClusters() ([]*fedv1a1.FederatedCluste
 	result := make([]*fedv1a1.FederatedCluster, 0, len(items))
 	for _, item := range items {
 		if cluster, ok := item.(*fedv1a1.FederatedCluster); ok {
-			if !isClusterReady(cluster) {
+			if !IsClusterReady(cluster) {
 				result = append(result, cluster)
 			}
 		} else {
@@ -375,7 +375,7 @@ func (f *federatedInformerImpl) GetReadyClusters() ([]*fedv1a1.FederatedCluster,
 	result := make([]*fedv1a1.FederatedCluster, 0, len(items))
 	for _, item := range items {
 		if cluster, ok := item.(*fedv1a1.FederatedCluster); ok {
-			if isClusterReady(cluster) {
+			if IsClusterReady(cluster) {
 				result = append(result, cluster)
 			}
 		} else {
@@ -396,7 +396,7 @@ func (f *federatedInformerImpl) getReadyClusterUnlocked(name string) (*fedv1a1.F
 	key := fmt.Sprintf("%s/%s", f.fedNamespace, name)
 	if obj, exist, err := f.clusterInformer.store.GetByKey(key); exist && err == nil {
 		if cluster, ok := obj.(*fedv1a1.FederatedCluster); ok {
-			if isClusterReady(cluster) {
+			if IsClusterReady(cluster) {
 				return cluster, true, nil
 			}
 			return nil, false, nil

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -52,13 +52,18 @@ var _ = ginkgo.SynchronizedBeforeSuite(func() []byte {
 		framework.SetUpManagedFederation()
 		// TODO(marun) support parallel execution by sending
 		// configuration for test-managed federation to other nodes
-	} else if framework.TestContext.InMemoryControllers {
-		// This supports a hybrid setup where the user asks for an unmanaged
-		// federation with in memory controllers. This means the k8s clusters
-		// are already running along with the federation and cluster registry
-		// API servers. This will then join the clusters and launch the
-		// required federation controllers e.g. cluster and sync controllers.
-		framework.SetUpUnmanagedFederation()
+	} else {
+		if framework.TestContext.InMemoryControllers {
+			// This supports a hybrid setup where the user asks for an unmanaged
+			// federation with in memory controllers. This means the k8s clusters
+			// are already running along with the federation and cluster registry
+			// API servers. This will then join the clusters and launch the
+			// required federation controllers e.g. cluster and sync controllers.
+			framework.SetUpUnmanagedFederation()
+		}
+		// Wait for readiness of registered clusters to ensure tests
+		// run against a healthy federation.
+		framework.WaitForUnmanagedClusterReadiness()
 	}
 
 	return nil

--- a/test/integration/framework/cluster.go
+++ b/test/integration/framework/cluster.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework
+
+import (
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	fedv1a1 "github.com/kubernetes-sigs/federation-v2/pkg/apis/core/v1alpha1"
+	fedclientset "github.com/kubernetes-sigs/federation-v2/pkg/client/clientset/versioned"
+	"github.com/kubernetes-sigs/federation-v2/pkg/controller/util"
+	"github.com/kubernetes-sigs/federation-v2/test/common"
+)
+
+func WaitForClusterReadiness(tl common.TestLogger, client fedclientset.Interface,
+	namespace string, interval, timeout time.Duration) {
+	clusterList := ListFederatedClusters(tl, client, namespace)
+	for _, cluster := range clusterList.Items {
+		clusterIsReadyOrFail(tl, client, namespace, interval, timeout, &cluster)
+	}
+	tl.Logf("All federated clusters are ready")
+}
+
+func ListFederatedClusters(tl common.TestLogger, client fedclientset.Interface, namespace string) *fedv1a1.FederatedClusterList {
+	clusterList, err := client.CoreV1alpha1().FederatedClusters(namespace).List(metav1.ListOptions{})
+	if err != nil {
+		tl.Fatalf("Error retrieving list of federated clusters: %+v", err)
+	}
+	if len(clusterList.Items) == 0 {
+		tl.Fatal("No federated clusters found")
+	}
+	return clusterList
+}
+
+func clusterIsReadyOrFail(tl common.TestLogger, client fedclientset.Interface,
+	namespace string, interval, timeout time.Duration, cluster *fedv1a1.FederatedCluster) {
+	clusterName := cluster.Name
+	tl.Logf("Checking readiness for federated cluster %q", clusterName)
+	if util.IsClusterReady(cluster) {
+		return
+	}
+	err := wait.Poll(interval, timeout, func() (bool, error) {
+		cluster, err := client.CoreV1alpha1().FederatedClusters(namespace).Get(clusterName, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		return util.IsClusterReady(cluster), nil
+	})
+	if err != nil {
+		tl.Fatalf("Error determining readiness for cluster %q: %+v", clusterName, err)
+	}
+}

--- a/test/integration/framework/federation.go
+++ b/test/integration/framework/federation.go
@@ -91,6 +91,9 @@ func (f *FederationFixture) setUp(tl common.TestLogger, clusterCount int) {
 	tl.Logf("Starting cluster controller")
 	f.ClusterController = NewClusterControllerFixture(config, f.SystemNamespace, f.SystemNamespace)
 	tl.Log("Federation started.")
+
+	client := fedclientset.NewForConfigOrDie(config)
+	WaitForClusterReadiness(tl, client, f.SystemNamespace, DefaultWaitInterval, wait.ForeverTestTimeout)
 }
 
 func (f *FederationFixture) TearDown(tl common.TestLogger) {


### PR DESCRIPTION
Previously cluster readiness checks were performed only for unmanaged e2e fixture and were performed on every request for clients from the fixture.  This PR ensures that readiness checks are performed once on fixture setup and for both managed and unmanaged fixture.