### PR TITLE
s/clustername/clusterName/ everywhere

### DIFF
--- a/docs/userguide.md
+++ b/docs/userguide.md
@@ -243,7 +243,7 @@ Remove `cluster2` via a patch command or manually:
 
 ```bash
 kubectl -n test-namespace patch federatednamespaceplacement test-namespace \
-    --type=merge -p '{"spec":{"clusternames": ["cluster1"]}}'
+    --type=merge -p '{"spec":{"clusterNames": ["cluster1"]}}'
 
 kubectl -n test-namespace edit federatednamespaceplacement test-namespace
 ```
@@ -266,7 +266,7 @@ manually:
 
 ```bash
 kubectl -n test-namespace patch federatednamespaceplacement test-namespace \
-    --type=merge -p '{"spec":{"clusternames": ["cluster1", "cluster2"]}}'
+    --type=merge -p '{"spec":{"clusterNames": ["cluster1", "cluster2"]}}'
 
 kubectl -n test-namespace edit federatednamespaceplacement test-namespace
 ```

--- a/example/sample1/federatedconfigmap-override.yaml
+++ b/example/sample1/federatedconfigmap-override.yaml
@@ -8,6 +8,6 @@ items:
     namespace: test-namespace
   spec:
     overrides:
-    - clustername: cluster2
+    - clusterName: cluster2
       data:
         foo: bar

--- a/example/sample1/federatedconfigmap-placement.yaml
+++ b/example/sample1/federatedconfigmap-placement.yaml
@@ -7,6 +7,6 @@ items:
     name: test-configmap
     namespace: test-namespace
   spec:
-    clusternames:
+    clusterNames:
     - cluster2
     - cluster1

--- a/example/sample1/federateddeployment-override.yaml
+++ b/example/sample1/federateddeployment-override.yaml
@@ -8,5 +8,5 @@ items:
     namespace: test-namespace
   spec:
     overrides:
-    - clustername: cluster2
+    - clusterName: cluster2
       replicas: 5

--- a/example/sample1/federateddeployment-placement.yaml
+++ b/example/sample1/federateddeployment-placement.yaml
@@ -7,6 +7,6 @@ items:
     name: test-deployment
     namespace: test-namespace
   spec:
-    clusternames:
+    clusterNames:
     - cluster2
     - cluster1

--- a/example/sample1/federatednamespace-placement.yaml
+++ b/example/sample1/federatednamespace-placement.yaml
@@ -6,6 +6,6 @@ items:
   metadata:
     name: test-namespace
   spec:
-    clusternames:
+    clusterNames:
     - cluster1
     - cluster2

--- a/example/sample1/federatedsecret-override.yaml
+++ b/example/sample1/federatedsecret-override.yaml
@@ -8,6 +8,6 @@ items:
     namespace: test-namespace
   spec:
     overrides:
-    - clustername: cluster2
+    - clusterName: cluster2
       data:
         A: null

--- a/example/sample1/federatedsecret-placement.yaml
+++ b/example/sample1/federatedsecret-placement.yaml
@@ -7,6 +7,6 @@ items:
     name: test-secret
     namespace: test-namespace
   spec:
-    clusternames:
+    clusterNames:
     - cluster2
     - cluster1

--- a/example/sample1/federatedservice-placement.yaml
+++ b/example/sample1/federatedservice-placement.yaml
@@ -4,6 +4,6 @@ metadata:
   name: test-service
   namespace: test-namespace
 spec:
-  clusternames:
+  clusterNames:
   - cluster2
   - cluster1

--- a/pkg/controller/sync/controller.go
+++ b/pkg/controller/sync/controller.go
@@ -957,7 +957,7 @@ func (s *FederationSyncController) objectForCluster(template, override *unstruct
 	overrideField := overridePath[len(overridePath)-1]
 	for _, overrideInterface := range overrides {
 		clusterOverride := overrideInterface.(map[string]interface{})
-		if clusterOverride["clustername"] != clusterName {
+		if clusterOverride[util.ClusterNameField] != clusterName {
 			continue
 		}
 		data, ok := clusterOverride[overrideField]

--- a/pkg/controller/util/constants.go
+++ b/pkg/controller/util/constants.go
@@ -24,8 +24,9 @@ import (
 const (
 	NoResyncPeriod time.Duration = 0 * time.Second
 
-	NamespaceKind = "Namespace"
-	ServiceKind   = "Service"
+	NamespaceKind     = "Namespace"
+	ServiceKind       = "Service"
+	ClusterNamesField = "clusterNames"
 )
 
 type ReconciliationStatus int

--- a/pkg/controller/util/constants.go
+++ b/pkg/controller/util/constants.go
@@ -26,6 +26,7 @@ const (
 
 	NamespaceKind     = "Namespace"
 	ServiceKind       = "Service"
+	ClusterNameField  = "clusterName"
 	ClusterNamesField = "clusterNames"
 )
 

--- a/pkg/controller/util/placement.go
+++ b/pkg/controller/util/placement.go
@@ -20,13 +20,11 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
-const clusterNamesField = "clusterNames"
-
 func GetClusterNames(placement *unstructured.Unstructured) ([]string, error) {
-	clusterNames, _, err := unstructured.NestedStringSlice(placement.Object, "spec", clusterNamesField)
+	clusterNames, _, err := unstructured.NestedStringSlice(placement.Object, "spec", ClusterNamesField)
 	return clusterNames, err
 }
 
 func SetClusterNames(placement *unstructured.Unstructured, clusterNames []string) error {
-	return unstructured.SetNestedStringSlice(placement.Object, clusterNames, "spec", clusterNamesField)
+	return unstructured.SetNestedStringSlice(placement.Object, clusterNames, "spec", ClusterNamesField)
 }

--- a/test/common/testobjects.go
+++ b/test/common/testobjects.go
@@ -66,7 +66,7 @@ func NewTestObjects(typeConfig typeconfig.Interface, namespace string, clusterNa
 		} else {
 			targetOverrides = map[string]interface{}{}
 		}
-		targetOverrides["clusterName"] = clusterNames[0]
+		targetOverrides[util.ClusterNameField] = clusterNames[0]
 		overridesSlice[0] = targetOverrides
 		err = unstructured.SetNestedSlice(override.Object, overridesSlice, "spec", "overrides")
 		if err != nil {


### PR DESCRIPTION
#253 only partially fixed a renaming of `clusternames` to `clusterNames` (the actual json field name), and this caused #255.  This PR fixes the remaining references to fix the breakage that resulted from the partial rename.  As part of #255, a follow-on PR will add testing to prevent this from recurring.

