### PR TITLE
Add optional ObservedGeneration field to DNSEndpointStatus

### DIFF
--- a/pkg/apis/core/v1alpha1/zz_generated.kubebuilder.go
+++ b/pkg/apis/core/v1alpha1/zz_generated.kubebuilder.go
@@ -413,7 +413,6 @@ var (
 			Scope: "Namespaced",
 			Validation: &v1beta1.CustomResourceValidation{
 				OpenAPIV3Schema: &v1beta1.JSONSchemaProps{
-					Type: "object",
 					Properties: map[string]v1beta1.JSONSchemaProps{
 						"apiVersion": v1beta1.JSONSchemaProps{
 							Type: "string",
@@ -457,7 +456,6 @@ var (
 			Scope: "Namespaced",
 			Validation: &v1beta1.CustomResourceValidation{
 				OpenAPIV3Schema: &v1beta1.JSONSchemaProps{
-					Type: "object",
 					Properties: map[string]v1beta1.JSONSchemaProps{
 						"apiVersion": v1beta1.JSONSchemaProps{
 							Type: "string",
@@ -513,7 +511,6 @@ var (
 			Scope: "Namespaced",
 			Validation: &v1beta1.CustomResourceValidation{
 				OpenAPIV3Schema: &v1beta1.JSONSchemaProps{
-					Type: "object",
 					Properties: map[string]v1beta1.JSONSchemaProps{
 						"apiVersion": v1beta1.JSONSchemaProps{
 							Type: "string",
@@ -561,7 +558,6 @@ var (
 			Scope: "Namespaced",
 			Validation: &v1beta1.CustomResourceValidation{
 				OpenAPIV3Schema: &v1beta1.JSONSchemaProps{
-					Type: "object",
 					Properties: map[string]v1beta1.JSONSchemaProps{
 						"apiVersion": v1beta1.JSONSchemaProps{
 							Type: "string",
@@ -605,7 +601,6 @@ var (
 			Scope: "Namespaced",
 			Validation: &v1beta1.CustomResourceValidation{
 				OpenAPIV3Schema: &v1beta1.JSONSchemaProps{
-					Type: "object",
 					Properties: map[string]v1beta1.JSONSchemaProps{
 						"apiVersion": v1beta1.JSONSchemaProps{
 							Type: "string",
@@ -662,7 +657,6 @@ var (
 			Scope: "Namespaced",
 			Validation: &v1beta1.CustomResourceValidation{
 				OpenAPIV3Schema: &v1beta1.JSONSchemaProps{
-					Type: "object",
 					Properties: map[string]v1beta1.JSONSchemaProps{
 						"apiVersion": v1beta1.JSONSchemaProps{
 							Type: "string",
@@ -710,7 +704,6 @@ var (
 			Scope: "Namespaced",
 			Validation: &v1beta1.CustomResourceValidation{
 				OpenAPIV3Schema: &v1beta1.JSONSchemaProps{
-					Type: "object",
 					Properties: map[string]v1beta1.JSONSchemaProps{
 						"apiVersion": v1beta1.JSONSchemaProps{
 							Type: "string",
@@ -754,7 +747,6 @@ var (
 			Scope: "Namespaced",
 			Validation: &v1beta1.CustomResourceValidation{
 				OpenAPIV3Schema: &v1beta1.JSONSchemaProps{
-					Type: "object",
 					Properties: map[string]v1beta1.JSONSchemaProps{
 						"apiVersion": v1beta1.JSONSchemaProps{
 							Type: "string",
@@ -802,7 +794,6 @@ var (
 			Scope: "Namespaced",
 			Validation: &v1beta1.CustomResourceValidation{
 				OpenAPIV3Schema: &v1beta1.JSONSchemaProps{
-					Type: "object",
 					Properties: map[string]v1beta1.JSONSchemaProps{
 						"apiVersion": v1beta1.JSONSchemaProps{
 							Type: "string",
@@ -846,7 +837,6 @@ var (
 			Scope: "Namespaced",
 			Validation: &v1beta1.CustomResourceValidation{
 				OpenAPIV3Schema: &v1beta1.JSONSchemaProps{
-					Type: "object",
 					Properties: map[string]v1beta1.JSONSchemaProps{
 						"apiVersion": v1beta1.JSONSchemaProps{
 							Type: "string",
@@ -903,7 +893,6 @@ var (
 			Scope: "Namespaced",
 			Validation: &v1beta1.CustomResourceValidation{
 				OpenAPIV3Schema: &v1beta1.JSONSchemaProps{
-					Type: "object",
 					Properties: map[string]v1beta1.JSONSchemaProps{
 						"apiVersion": v1beta1.JSONSchemaProps{
 							Type: "string",
@@ -951,7 +940,6 @@ var (
 			Scope: "Namespaced",
 			Validation: &v1beta1.CustomResourceValidation{
 				OpenAPIV3Schema: &v1beta1.JSONSchemaProps{
-					Type: "object",
 					Properties: map[string]v1beta1.JSONSchemaProps{
 						"apiVersion": v1beta1.JSONSchemaProps{
 							Type: "string",
@@ -999,7 +987,6 @@ var (
 			Scope: "Namespaced",
 			Validation: &v1beta1.CustomResourceValidation{
 				OpenAPIV3Schema: &v1beta1.JSONSchemaProps{
-					Type: "object",
 					Properties: map[string]v1beta1.JSONSchemaProps{
 						"apiVersion": v1beta1.JSONSchemaProps{
 							Type: "string",
@@ -1043,7 +1030,6 @@ var (
 			Scope: "Namespaced",
 			Validation: &v1beta1.CustomResourceValidation{
 				OpenAPIV3Schema: &v1beta1.JSONSchemaProps{
-					Type: "object",
 					Properties: map[string]v1beta1.JSONSchemaProps{
 						"apiVersion": v1beta1.JSONSchemaProps{
 							Type: "string",
@@ -1100,7 +1086,6 @@ var (
 			Scope: "Namespaced",
 			Validation: &v1beta1.CustomResourceValidation{
 				OpenAPIV3Schema: &v1beta1.JSONSchemaProps{
-					Type: "object",
 					Properties: map[string]v1beta1.JSONSchemaProps{
 						"apiVersion": v1beta1.JSONSchemaProps{
 							Type: "string",
@@ -1148,7 +1133,6 @@ var (
 			Scope: "Namespaced",
 			Validation: &v1beta1.CustomResourceValidation{
 				OpenAPIV3Schema: &v1beta1.JSONSchemaProps{
-					Type: "object",
 					Properties: map[string]v1beta1.JSONSchemaProps{
 						"apiVersion": v1beta1.JSONSchemaProps{
 							Type: "string",
@@ -1192,7 +1176,6 @@ var (
 			Scope: "Namespaced",
 			Validation: &v1beta1.CustomResourceValidation{
 				OpenAPIV3Schema: &v1beta1.JSONSchemaProps{
-					Type: "object",
 					Properties: map[string]v1beta1.JSONSchemaProps{
 						"apiVersion": v1beta1.JSONSchemaProps{
 							Type: "string",
@@ -1248,7 +1231,6 @@ var (
 			Scope: "Namespaced",
 			Validation: &v1beta1.CustomResourceValidation{
 				OpenAPIV3Schema: &v1beta1.JSONSchemaProps{
-					Type: "object",
 					Properties: map[string]v1beta1.JSONSchemaProps{
 						"apiVersion": v1beta1.JSONSchemaProps{
 							Type: "string",
@@ -1296,7 +1278,6 @@ var (
 			Scope: "Namespaced",
 			Validation: &v1beta1.CustomResourceValidation{
 				OpenAPIV3Schema: &v1beta1.JSONSchemaProps{
-					Type: "object",
 					Properties: map[string]v1beta1.JSONSchemaProps{
 						"apiVersion": v1beta1.JSONSchemaProps{
 							Type: "string",
@@ -1340,7 +1321,6 @@ var (
 			Scope: "Namespaced",
 			Validation: &v1beta1.CustomResourceValidation{
 				OpenAPIV3Schema: &v1beta1.JSONSchemaProps{
-					Type: "object",
 					Properties: map[string]v1beta1.JSONSchemaProps{
 						"apiVersion": v1beta1.JSONSchemaProps{
 							Type: "string",
@@ -1384,7 +1364,6 @@ var (
 			Scope: "Namespaced",
 			Validation: &v1beta1.CustomResourceValidation{
 				OpenAPIV3Schema: &v1beta1.JSONSchemaProps{
-					Type: "object",
 					Properties: map[string]v1beta1.JSONSchemaProps{
 						"apiVersion": v1beta1.JSONSchemaProps{
 							Type: "string",
@@ -1432,7 +1411,6 @@ var (
 			Scope: "Namespaced",
 			Validation: &v1beta1.CustomResourceValidation{
 				OpenAPIV3Schema: &v1beta1.JSONSchemaProps{
-					Type: "object",
 					Properties: map[string]v1beta1.JSONSchemaProps{
 						"apiVersion": v1beta1.JSONSchemaProps{
 							Type: "string",
@@ -1480,7 +1458,6 @@ var (
 			Scope: "Namespaced",
 			Validation: &v1beta1.CustomResourceValidation{
 				OpenAPIV3Schema: &v1beta1.JSONSchemaProps{
-					Type: "object",
 					Properties: map[string]v1beta1.JSONSchemaProps{
 						"apiVersion": v1beta1.JSONSchemaProps{
 							Type: "string",

--- a/pkg/apis/multiclusterdns/v1alpha1/dnsendpoint_types.go
+++ b/pkg/apis/multiclusterdns/v1alpha1/dnsendpoint_types.go
@@ -41,6 +41,7 @@ type Endpoint struct {
 	// TTL for the record in seconds
 	RecordTTL TTL `json:"recordTTL,omitempty"`
 	// Labels stores labels defined for the Endpoint
+	// +optional
 	Labels Labels `json:"labels,omitempty"`
 }
 
@@ -51,14 +52,18 @@ type DNSEndpointSpec struct {
 
 // DNSEndpointStatus defines the observed state of DNSEndpoint
 type DNSEndpointStatus struct {
+	// ObservedGeneration is the generation as observed by the controller consuming the DNSEndpoint.
+	// +optional
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
-// DNSEndpoint
+// DNSEndpoint is the CRD wrapper for Endpoint
 // +k8s:openapi-gen=true
 // +kubebuilder:resource:path=dnsendpoints
+// +kubebuilder:subresource:status
 type DNSEndpoint struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/multiclusterdns/v1alpha1/zz_generated.kubebuilder.go
+++ b/pkg/apis/multiclusterdns/v1alpha1/zz_generated.kubebuilder.go
@@ -103,7 +103,6 @@ var (
 			Scope: "Namespaced",
 			Validation: &v1beta1.CustomResourceValidation{
 				OpenAPIV3Schema: &v1beta1.JSONSchemaProps{
-					Type: "object",
 					Properties: map[string]v1beta1.JSONSchemaProps{
 						"apiVersion": v1beta1.JSONSchemaProps{
 							Type: "string",
@@ -151,11 +150,19 @@ var (
 							},
 						},
 						"status": v1beta1.JSONSchemaProps{
-							Type:       "object",
-							Properties: map[string]v1beta1.JSONSchemaProps{},
+							Type: "object",
+							Properties: map[string]v1beta1.JSONSchemaProps{
+								"observedGeneration": v1beta1.JSONSchemaProps{
+									Type:   "integer",
+									Format: "int64",
+								},
+							},
 						},
 					},
 				},
+			},
+			Subresources: &v1beta1.CustomResourceSubresources{
+				Status: &v1beta1.CustomResourceSubresourceStatus{},
 			},
 		},
 	}

--- a/pkg/apis/scheduling/v1alpha1/zz_generated.kubebuilder.go
+++ b/pkg/apis/scheduling/v1alpha1/zz_generated.kubebuilder.go
@@ -83,7 +83,6 @@ var (
 			Scope: "Namespaced",
 			Validation: &v1beta1.CustomResourceValidation{
 				OpenAPIV3Schema: &v1beta1.JSONSchemaProps{
-					Type: "object",
 					Properties: map[string]v1beta1.JSONSchemaProps{
 						"apiVersion": v1beta1.JSONSchemaProps{
 							Type: "string",

--- a/pkg/client/clientset/versioned/clientset.go
+++ b/pkg/client/clientset/versioned/clientset.go
@@ -19,7 +19,6 @@ limitations under the License.
 package versioned
 
 import (
-	glog "github.com/golang/glog"
 	corev1alpha1 "github.com/kubernetes-sigs/federation-v2/pkg/client/clientset/versioned/typed/core/v1alpha1"
 	multiclusterdnsv1alpha1 "github.com/kubernetes-sigs/federation-v2/pkg/client/clientset/versioned/typed/multiclusterdns/v1alpha1"
 	schedulingv1alpha1 "github.com/kubernetes-sigs/federation-v2/pkg/client/clientset/versioned/typed/scheduling/v1alpha1"
@@ -114,7 +113,6 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 
 	cs.DiscoveryClient, err = discovery.NewDiscoveryClientForConfig(&configShallowCopy)
 	if err != nil {
-		glog.Errorf("failed to create the DiscoveryClient: %v", err)
 		return nil, err
 	}
 	return &cs, nil

--- a/pkg/client/clientset/versioned/fake/clientset_generated.go
+++ b/pkg/client/clientset/versioned/fake/clientset_generated.go
@@ -45,9 +45,10 @@ func NewSimpleClientset(objects ...runtime.Object) *Clientset {
 		}
 	}
 
-	fakePtr := testing.Fake{}
-	fakePtr.AddReactor("*", "*", testing.ObjectReaction(o))
-	fakePtr.AddWatchReactor("*", func(action testing.Action) (handled bool, ret watch.Interface, err error) {
+	cs := &Clientset{}
+	cs.discovery = &fakediscovery.FakeDiscovery{Fake: &cs.Fake}
+	cs.AddReactor("*", "*", testing.ObjectReaction(o))
+	cs.AddWatchReactor("*", func(action testing.Action) (handled bool, ret watch.Interface, err error) {
 		gvr := action.GetResource()
 		ns := action.GetNamespace()
 		watch, err := o.Watch(gvr, ns)
@@ -57,7 +58,7 @@ func NewSimpleClientset(objects ...runtime.Object) *Clientset {
 		return true, watch, nil
 	})
 
-	return &Clientset{fakePtr, &fakediscovery.FakeDiscovery{Fake: &fakePtr}}
+	return cs
 }
 
 // Clientset implements clientset.Interface. Meant to be embedded into a

--- a/pkg/client/clientset/versioned/typed/core/v1alpha1/fake/fake_federatedcluster.go
+++ b/pkg/client/clientset/versioned/typed/core/v1alpha1/fake/fake_federatedcluster.go
@@ -62,7 +62,7 @@ func (c *FakeFederatedClusters) List(opts v1.ListOptions) (result *v1alpha1.Fede
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1alpha1.FederatedClusterList{}
+	list := &v1alpha1.FederatedClusterList{ListMeta: obj.(*v1alpha1.FederatedClusterList).ListMeta}
 	for _, item := range obj.(*v1alpha1.FederatedClusterList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/pkg/client/clientset/versioned/typed/core/v1alpha1/fake/fake_federatedconfigmap.go
+++ b/pkg/client/clientset/versioned/typed/core/v1alpha1/fake/fake_federatedconfigmap.go
@@ -62,7 +62,7 @@ func (c *FakeFederatedConfigMaps) List(opts v1.ListOptions) (result *v1alpha1.Fe
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1alpha1.FederatedConfigMapList{}
+	list := &v1alpha1.FederatedConfigMapList{ListMeta: obj.(*v1alpha1.FederatedConfigMapList).ListMeta}
 	for _, item := range obj.(*v1alpha1.FederatedConfigMapList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/pkg/client/clientset/versioned/typed/core/v1alpha1/fake/fake_federatedconfigmapoverride.go
+++ b/pkg/client/clientset/versioned/typed/core/v1alpha1/fake/fake_federatedconfigmapoverride.go
@@ -62,7 +62,7 @@ func (c *FakeFederatedConfigMapOverrides) List(opts v1.ListOptions) (result *v1a
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1alpha1.FederatedConfigMapOverrideList{}
+	list := &v1alpha1.FederatedConfigMapOverrideList{ListMeta: obj.(*v1alpha1.FederatedConfigMapOverrideList).ListMeta}
 	for _, item := range obj.(*v1alpha1.FederatedConfigMapOverrideList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/pkg/client/clientset/versioned/typed/core/v1alpha1/fake/fake_federatedconfigmapplacement.go
+++ b/pkg/client/clientset/versioned/typed/core/v1alpha1/fake/fake_federatedconfigmapplacement.go
@@ -62,7 +62,7 @@ func (c *FakeFederatedConfigMapPlacements) List(opts v1.ListOptions) (result *v1
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1alpha1.FederatedConfigMapPlacementList{}
+	list := &v1alpha1.FederatedConfigMapPlacementList{ListMeta: obj.(*v1alpha1.FederatedConfigMapPlacementList).ListMeta}
 	for _, item := range obj.(*v1alpha1.FederatedConfigMapPlacementList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/pkg/client/clientset/versioned/typed/core/v1alpha1/fake/fake_federateddeployment.go
+++ b/pkg/client/clientset/versioned/typed/core/v1alpha1/fake/fake_federateddeployment.go
@@ -62,7 +62,7 @@ func (c *FakeFederatedDeployments) List(opts v1.ListOptions) (result *v1alpha1.F
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1alpha1.FederatedDeploymentList{}
+	list := &v1alpha1.FederatedDeploymentList{ListMeta: obj.(*v1alpha1.FederatedDeploymentList).ListMeta}
 	for _, item := range obj.(*v1alpha1.FederatedDeploymentList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/pkg/client/clientset/versioned/typed/core/v1alpha1/fake/fake_federateddeploymentoverride.go
+++ b/pkg/client/clientset/versioned/typed/core/v1alpha1/fake/fake_federateddeploymentoverride.go
@@ -62,7 +62,7 @@ func (c *FakeFederatedDeploymentOverrides) List(opts v1.ListOptions) (result *v1
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1alpha1.FederatedDeploymentOverrideList{}
+	list := &v1alpha1.FederatedDeploymentOverrideList{ListMeta: obj.(*v1alpha1.FederatedDeploymentOverrideList).ListMeta}
 	for _, item := range obj.(*v1alpha1.FederatedDeploymentOverrideList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/pkg/client/clientset/versioned/typed/core/v1alpha1/fake/fake_federateddeploymentplacement.go
+++ b/pkg/client/clientset/versioned/typed/core/v1alpha1/fake/fake_federateddeploymentplacement.go
@@ -62,7 +62,7 @@ func (c *FakeFederatedDeploymentPlacements) List(opts v1.ListOptions) (result *v
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1alpha1.FederatedDeploymentPlacementList{}
+	list := &v1alpha1.FederatedDeploymentPlacementList{ListMeta: obj.(*v1alpha1.FederatedDeploymentPlacementList).ListMeta}
 	for _, item := range obj.(*v1alpha1.FederatedDeploymentPlacementList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/pkg/client/clientset/versioned/typed/core/v1alpha1/fake/fake_federatedingress.go
+++ b/pkg/client/clientset/versioned/typed/core/v1alpha1/fake/fake_federatedingress.go
@@ -62,7 +62,7 @@ func (c *FakeFederatedIngresses) List(opts v1.ListOptions) (result *v1alpha1.Fed
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1alpha1.FederatedIngressList{}
+	list := &v1alpha1.FederatedIngressList{ListMeta: obj.(*v1alpha1.FederatedIngressList).ListMeta}
 	for _, item := range obj.(*v1alpha1.FederatedIngressList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/pkg/client/clientset/versioned/typed/core/v1alpha1/fake/fake_federatedingressplacement.go
+++ b/pkg/client/clientset/versioned/typed/core/v1alpha1/fake/fake_federatedingressplacement.go
@@ -62,7 +62,7 @@ func (c *FakeFederatedIngressPlacements) List(opts v1.ListOptions) (result *v1al
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1alpha1.FederatedIngressPlacementList{}
+	list := &v1alpha1.FederatedIngressPlacementList{ListMeta: obj.(*v1alpha1.FederatedIngressPlacementList).ListMeta}
 	for _, item := range obj.(*v1alpha1.FederatedIngressPlacementList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/pkg/client/clientset/versioned/typed/core/v1alpha1/fake/fake_federatedjob.go
+++ b/pkg/client/clientset/versioned/typed/core/v1alpha1/fake/fake_federatedjob.go
@@ -62,7 +62,7 @@ func (c *FakeFederatedJobs) List(opts v1.ListOptions) (result *v1alpha1.Federate
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1alpha1.FederatedJobList{}
+	list := &v1alpha1.FederatedJobList{ListMeta: obj.(*v1alpha1.FederatedJobList).ListMeta}
 	for _, item := range obj.(*v1alpha1.FederatedJobList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/pkg/client/clientset/versioned/typed/core/v1alpha1/fake/fake_federatedjoboverride.go
+++ b/pkg/client/clientset/versioned/typed/core/v1alpha1/fake/fake_federatedjoboverride.go
@@ -62,7 +62,7 @@ func (c *FakeFederatedJobOverrides) List(opts v1.ListOptions) (result *v1alpha1.
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1alpha1.FederatedJobOverrideList{}
+	list := &v1alpha1.FederatedJobOverrideList{ListMeta: obj.(*v1alpha1.FederatedJobOverrideList).ListMeta}
 	for _, item := range obj.(*v1alpha1.FederatedJobOverrideList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/pkg/client/clientset/versioned/typed/core/v1alpha1/fake/fake_federatedjobplacement.go
+++ b/pkg/client/clientset/versioned/typed/core/v1alpha1/fake/fake_federatedjobplacement.go
@@ -62,7 +62,7 @@ func (c *FakeFederatedJobPlacements) List(opts v1.ListOptions) (result *v1alpha1
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1alpha1.FederatedJobPlacementList{}
+	list := &v1alpha1.FederatedJobPlacementList{ListMeta: obj.(*v1alpha1.FederatedJobPlacementList).ListMeta}
 	for _, item := range obj.(*v1alpha1.FederatedJobPlacementList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/pkg/client/clientset/versioned/typed/core/v1alpha1/fake/fake_federatednamespaceplacement.go
+++ b/pkg/client/clientset/versioned/typed/core/v1alpha1/fake/fake_federatednamespaceplacement.go
@@ -62,7 +62,7 @@ func (c *FakeFederatedNamespacePlacements) List(opts v1.ListOptions) (result *v1
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1alpha1.FederatedNamespacePlacementList{}
+	list := &v1alpha1.FederatedNamespacePlacementList{ListMeta: obj.(*v1alpha1.FederatedNamespacePlacementList).ListMeta}
 	for _, item := range obj.(*v1alpha1.FederatedNamespacePlacementList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/pkg/client/clientset/versioned/typed/core/v1alpha1/fake/fake_federatedreplicaset.go
+++ b/pkg/client/clientset/versioned/typed/core/v1alpha1/fake/fake_federatedreplicaset.go
@@ -62,7 +62,7 @@ func (c *FakeFederatedReplicaSets) List(opts v1.ListOptions) (result *v1alpha1.F
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1alpha1.FederatedReplicaSetList{}
+	list := &v1alpha1.FederatedReplicaSetList{ListMeta: obj.(*v1alpha1.FederatedReplicaSetList).ListMeta}
 	for _, item := range obj.(*v1alpha1.FederatedReplicaSetList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/pkg/client/clientset/versioned/typed/core/v1alpha1/fake/fake_federatedreplicasetoverride.go
+++ b/pkg/client/clientset/versioned/typed/core/v1alpha1/fake/fake_federatedreplicasetoverride.go
@@ -62,7 +62,7 @@ func (c *FakeFederatedReplicaSetOverrides) List(opts v1.ListOptions) (result *v1
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1alpha1.FederatedReplicaSetOverrideList{}
+	list := &v1alpha1.FederatedReplicaSetOverrideList{ListMeta: obj.(*v1alpha1.FederatedReplicaSetOverrideList).ListMeta}
 	for _, item := range obj.(*v1alpha1.FederatedReplicaSetOverrideList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/pkg/client/clientset/versioned/typed/core/v1alpha1/fake/fake_federatedreplicasetplacement.go
+++ b/pkg/client/clientset/versioned/typed/core/v1alpha1/fake/fake_federatedreplicasetplacement.go
@@ -62,7 +62,7 @@ func (c *FakeFederatedReplicaSetPlacements) List(opts v1.ListOptions) (result *v
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1alpha1.FederatedReplicaSetPlacementList{}
+	list := &v1alpha1.FederatedReplicaSetPlacementList{ListMeta: obj.(*v1alpha1.FederatedReplicaSetPlacementList).ListMeta}
 	for _, item := range obj.(*v1alpha1.FederatedReplicaSetPlacementList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/pkg/client/clientset/versioned/typed/core/v1alpha1/fake/fake_federatedsecret.go
+++ b/pkg/client/clientset/versioned/typed/core/v1alpha1/fake/fake_federatedsecret.go
@@ -62,7 +62,7 @@ func (c *FakeFederatedSecrets) List(opts v1.ListOptions) (result *v1alpha1.Feder
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1alpha1.FederatedSecretList{}
+	list := &v1alpha1.FederatedSecretList{ListMeta: obj.(*v1alpha1.FederatedSecretList).ListMeta}
 	for _, item := range obj.(*v1alpha1.FederatedSecretList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/pkg/client/clientset/versioned/typed/core/v1alpha1/fake/fake_federatedsecretoverride.go
+++ b/pkg/client/clientset/versioned/typed/core/v1alpha1/fake/fake_federatedsecretoverride.go
@@ -62,7 +62,7 @@ func (c *FakeFederatedSecretOverrides) List(opts v1.ListOptions) (result *v1alph
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1alpha1.FederatedSecretOverrideList{}
+	list := &v1alpha1.FederatedSecretOverrideList{ListMeta: obj.(*v1alpha1.FederatedSecretOverrideList).ListMeta}
 	for _, item := range obj.(*v1alpha1.FederatedSecretOverrideList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/pkg/client/clientset/versioned/typed/core/v1alpha1/fake/fake_federatedsecretplacement.go
+++ b/pkg/client/clientset/versioned/typed/core/v1alpha1/fake/fake_federatedsecretplacement.go
@@ -62,7 +62,7 @@ func (c *FakeFederatedSecretPlacements) List(opts v1.ListOptions) (result *v1alp
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1alpha1.FederatedSecretPlacementList{}
+	list := &v1alpha1.FederatedSecretPlacementList{ListMeta: obj.(*v1alpha1.FederatedSecretPlacementList).ListMeta}
 	for _, item := range obj.(*v1alpha1.FederatedSecretPlacementList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/pkg/client/clientset/versioned/typed/core/v1alpha1/fake/fake_federatedservice.go
+++ b/pkg/client/clientset/versioned/typed/core/v1alpha1/fake/fake_federatedservice.go
@@ -62,7 +62,7 @@ func (c *FakeFederatedServices) List(opts v1.ListOptions) (result *v1alpha1.Fede
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1alpha1.FederatedServiceList{}
+	list := &v1alpha1.FederatedServiceList{ListMeta: obj.(*v1alpha1.FederatedServiceList).ListMeta}
 	for _, item := range obj.(*v1alpha1.FederatedServiceList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/pkg/client/clientset/versioned/typed/core/v1alpha1/fake/fake_federatedserviceaccount.go
+++ b/pkg/client/clientset/versioned/typed/core/v1alpha1/fake/fake_federatedserviceaccount.go
@@ -62,7 +62,7 @@ func (c *FakeFederatedServiceAccounts) List(opts v1.ListOptions) (result *v1alph
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1alpha1.FederatedServiceAccountList{}
+	list := &v1alpha1.FederatedServiceAccountList{ListMeta: obj.(*v1alpha1.FederatedServiceAccountList).ListMeta}
 	for _, item := range obj.(*v1alpha1.FederatedServiceAccountList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/pkg/client/clientset/versioned/typed/core/v1alpha1/fake/fake_federatedserviceaccountplacement.go
+++ b/pkg/client/clientset/versioned/typed/core/v1alpha1/fake/fake_federatedserviceaccountplacement.go
@@ -62,7 +62,7 @@ func (c *FakeFederatedServiceAccountPlacements) List(opts v1.ListOptions) (resul
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1alpha1.FederatedServiceAccountPlacementList{}
+	list := &v1alpha1.FederatedServiceAccountPlacementList{ListMeta: obj.(*v1alpha1.FederatedServiceAccountPlacementList).ListMeta}
 	for _, item := range obj.(*v1alpha1.FederatedServiceAccountPlacementList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/pkg/client/clientset/versioned/typed/core/v1alpha1/fake/fake_federatedserviceplacement.go
+++ b/pkg/client/clientset/versioned/typed/core/v1alpha1/fake/fake_federatedserviceplacement.go
@@ -62,7 +62,7 @@ func (c *FakeFederatedServicePlacements) List(opts v1.ListOptions) (result *v1al
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1alpha1.FederatedServicePlacementList{}
+	list := &v1alpha1.FederatedServicePlacementList{ListMeta: obj.(*v1alpha1.FederatedServicePlacementList).ListMeta}
 	for _, item := range obj.(*v1alpha1.FederatedServicePlacementList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/pkg/client/clientset/versioned/typed/core/v1alpha1/fake/fake_federatedtypeconfig.go
+++ b/pkg/client/clientset/versioned/typed/core/v1alpha1/fake/fake_federatedtypeconfig.go
@@ -62,7 +62,7 @@ func (c *FakeFederatedTypeConfigs) List(opts v1.ListOptions) (result *v1alpha1.F
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1alpha1.FederatedTypeConfigList{}
+	list := &v1alpha1.FederatedTypeConfigList{ListMeta: obj.(*v1alpha1.FederatedTypeConfigList).ListMeta}
 	for _, item := range obj.(*v1alpha1.FederatedTypeConfigList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/pkg/client/clientset/versioned/typed/core/v1alpha1/fake/fake_propagatedversion.go
+++ b/pkg/client/clientset/versioned/typed/core/v1alpha1/fake/fake_propagatedversion.go
@@ -62,7 +62,7 @@ func (c *FakePropagatedVersions) List(opts v1.ListOptions) (result *v1alpha1.Pro
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1alpha1.PropagatedVersionList{}
+	list := &v1alpha1.PropagatedVersionList{ListMeta: obj.(*v1alpha1.PropagatedVersionList).ListMeta}
 	for _, item := range obj.(*v1alpha1.PropagatedVersionList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/pkg/client/clientset/versioned/typed/multiclusterdns/v1alpha1/fake/fake_dnsendpoint.go
+++ b/pkg/client/clientset/versioned/typed/multiclusterdns/v1alpha1/fake/fake_dnsendpoint.go
@@ -62,7 +62,7 @@ func (c *FakeDNSEndpoints) List(opts v1.ListOptions) (result *v1alpha1.DNSEndpoi
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1alpha1.DNSEndpointList{}
+	list := &v1alpha1.DNSEndpointList{ListMeta: obj.(*v1alpha1.DNSEndpointList).ListMeta}
 	for _, item := range obj.(*v1alpha1.DNSEndpointList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/pkg/client/clientset/versioned/typed/multiclusterdns/v1alpha1/fake/fake_multiclusteringressdnsrecord.go
+++ b/pkg/client/clientset/versioned/typed/multiclusterdns/v1alpha1/fake/fake_multiclusteringressdnsrecord.go
@@ -62,7 +62,7 @@ func (c *FakeMultiClusterIngressDNSRecords) List(opts v1.ListOptions) (result *v
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1alpha1.MultiClusterIngressDNSRecordList{}
+	list := &v1alpha1.MultiClusterIngressDNSRecordList{ListMeta: obj.(*v1alpha1.MultiClusterIngressDNSRecordList).ListMeta}
 	for _, item := range obj.(*v1alpha1.MultiClusterIngressDNSRecordList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/pkg/client/clientset/versioned/typed/multiclusterdns/v1alpha1/fake/fake_multiclusterservicednsrecord.go
+++ b/pkg/client/clientset/versioned/typed/multiclusterdns/v1alpha1/fake/fake_multiclusterservicednsrecord.go
@@ -62,7 +62,7 @@ func (c *FakeMultiClusterServiceDNSRecords) List(opts v1.ListOptions) (result *v
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1alpha1.MultiClusterServiceDNSRecordList{}
+	list := &v1alpha1.MultiClusterServiceDNSRecordList{ListMeta: obj.(*v1alpha1.MultiClusterServiceDNSRecordList).ListMeta}
 	for _, item := range obj.(*v1alpha1.MultiClusterServiceDNSRecordList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/pkg/client/clientset/versioned/typed/scheduling/v1alpha1/fake/fake_replicaschedulingpreference.go
+++ b/pkg/client/clientset/versioned/typed/scheduling/v1alpha1/fake/fake_replicaschedulingpreference.go
@@ -62,7 +62,7 @@ func (c *FakeReplicaSchedulingPreferences) List(opts v1.ListOptions) (result *v1
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1alpha1.ReplicaSchedulingPreferenceList{}
+	list := &v1alpha1.ReplicaSchedulingPreferenceList{ListMeta: obj.(*v1alpha1.ReplicaSchedulingPreferenceList).ListMeta}
 	for _, item := range obj.(*v1alpha1.ReplicaSchedulingPreferenceList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/pkg/client/informers/externalversions/factory.go
+++ b/pkg/client/informers/externalversions/factory.go
@@ -34,12 +34,16 @@ import (
 	cache "k8s.io/client-go/tools/cache"
 )
 
+// SharedInformerOption defines the functional option type for SharedInformerFactory.
+type SharedInformerOption func(*sharedInformerFactory) *sharedInformerFactory
+
 type sharedInformerFactory struct {
 	client           versioned.Interface
 	namespace        string
 	tweakListOptions internalinterfaces.TweakListOptionsFunc
 	lock             sync.Mutex
 	defaultResync    time.Duration
+	customResync     map[reflect.Type]time.Duration
 
 	informers map[reflect.Type]cache.SharedIndexInformer
 	// startedInformers is used for tracking which informers have been started.
@@ -47,23 +51,62 @@ type sharedInformerFactory struct {
 	startedInformers map[reflect.Type]bool
 }
 
-// NewSharedInformerFactory constructs a new instance of sharedInformerFactory
+// WithCustomResyncConfig sets a custom resync period for the specified informer types.
+func WithCustomResyncConfig(resyncConfig map[v1.Object]time.Duration) SharedInformerOption {
+	return func(factory *sharedInformerFactory) *sharedInformerFactory {
+		for k, v := range resyncConfig {
+			factory.customResync[reflect.TypeOf(k)] = v
+		}
+		return factory
+	}
+}
+
+// WithTweakListOptions sets a custom filter on all listers of the configured SharedInformerFactory.
+func WithTweakListOptions(tweakListOptions internalinterfaces.TweakListOptionsFunc) SharedInformerOption {
+	return func(factory *sharedInformerFactory) *sharedInformerFactory {
+		factory.tweakListOptions = tweakListOptions
+		return factory
+	}
+}
+
+// WithNamespace limits the SharedInformerFactory to the specified namespace.
+func WithNamespace(namespace string) SharedInformerOption {
+	return func(factory *sharedInformerFactory) *sharedInformerFactory {
+		factory.namespace = namespace
+		return factory
+	}
+}
+
+// NewSharedInformerFactory constructs a new instance of sharedInformerFactory for all namespaces.
 func NewSharedInformerFactory(client versioned.Interface, defaultResync time.Duration) SharedInformerFactory {
-	return NewFilteredSharedInformerFactory(client, defaultResync, v1.NamespaceAll, nil)
+	return NewSharedInformerFactoryWithOptions(client, defaultResync)
 }
 
 // NewFilteredSharedInformerFactory constructs a new instance of sharedInformerFactory.
 // Listers obtained via this SharedInformerFactory will be subject to the same filters
 // as specified here.
+// Deprecated: Please use NewSharedInformerFactoryWithOptions instead
 func NewFilteredSharedInformerFactory(client versioned.Interface, defaultResync time.Duration, namespace string, tweakListOptions internalinterfaces.TweakListOptionsFunc) SharedInformerFactory {
-	return &sharedInformerFactory{
+	return NewSharedInformerFactoryWithOptions(client, defaultResync, WithNamespace(namespace), WithTweakListOptions(tweakListOptions))
+}
+
+// NewSharedInformerFactoryWithOptions constructs a new instance of a SharedInformerFactory with additional options.
+func NewSharedInformerFactoryWithOptions(client versioned.Interface, defaultResync time.Duration, options ...SharedInformerOption) SharedInformerFactory {
+	factory := &sharedInformerFactory{
 		client:           client,
-		namespace:        namespace,
-		tweakListOptions: tweakListOptions,
+		namespace:        v1.NamespaceAll,
 		defaultResync:    defaultResync,
 		informers:        make(map[reflect.Type]cache.SharedIndexInformer),
 		startedInformers: make(map[reflect.Type]bool),
+		customResync:     make(map[reflect.Type]time.Duration),
 	}
+
+	// Apply all options
+	for _, opt := range options {
+		factory = opt(factory)
+	}
+
+	return factory
 }
 
 // Start initializes all requested informers.
@@ -112,7 +155,13 @@ func (f *sharedInformerFactory) InformerFor(obj runtime.Object, newFunc internal
 	if exists {
 		return informer
 	}
-	informer = newFunc(f.client, f.defaultResync)
+
+	resyncPeriod, exists := f.customResync[informerType]
+	if !exists {
+		resyncPeriod = f.defaultResync
+	}
+
+	informer = newFunc(f.client, resyncPeriod)
 	f.informers[informerType] = informer
 
 	return informer


### PR DESCRIPTION
This is according to the discussion in https://github.com/kubernetes-incubator/external-dns/pull/657#discussion_r208657613

/cc @pmorie @font 