### PR TITLE
Added one-liner note for a command to project its importance

### DIFF
--- a/docs/userguide.md
+++ b/docs/userguide.md
@@ -60,7 +60,10 @@ Once you have minikube installed run:
 ```bash
 minikube start -p cluster1 --kubernetes-version v1.11.0
 minikube start -p cluster2 --kubernetes-version v1.11.0
-kubectl config use-context cluster1
+```
+**NOTE:** Please make sure to set the correct context using the command below as this guide depends on it.
+```bash
+kubectl config use-context cluster1   
 ```
 
 Even though the `minikube` cluster has been started, you'll want to verify all


### PR DESCRIPTION
I've faced some issues while deploying the federation v2 control plane when I missed the following command  "kubectl config use-context cluster1" and I ended up installing everything in cluster2 which is of no use.