### PR TITLE
Target in-memory controllers in e2e at the test namespace

### DIFF
--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -68,9 +68,8 @@ type FederationFramework interface {
 // The workaround is using a wrapper that performs late-binding on the
 // framework flavor.
 type frameworkWrapper struct {
-	impl              FederationFramework
-	baseName          string
-	testNamespaceName string
+	impl     FederationFramework
+	baseName string
 }
 
 func NewFederationFramework(baseName string) FederationFramework {
@@ -142,10 +141,7 @@ func (f *frameworkWrapper) SetUpControllerFixture(typeConfig typeconfig.Interfac
 }
 
 func (f *frameworkWrapper) TestNamespaceName() string {
-	if f.testNamespaceName == "" {
-		f.testNamespaceName = f.framework().TestNamespaceName()
-	}
-	return f.testNamespaceName
+	return f.framework().TestNamespaceName()
 }
 
 func createTestNamespace(client kubeclientset.Interface, baseName string) string {

--- a/test/e2e/framework/managed.go
+++ b/test/e2e/framework/managed.go
@@ -59,6 +59,8 @@ type ManagedFramework struct {
 	fixtures []framework.TestFixture
 
 	baseName string
+
+	testNamespaceName string
 }
 
 func NewManagedFramework(baseName string) FederationFramework {
@@ -122,8 +124,11 @@ func (f *ManagedFramework) FederationSystemNamespace() string {
 }
 
 func (f *ManagedFramework) TestNamespaceName() string {
-	client := f.KubeClient(fmt.Sprintf("%s-create-namespace", f.baseName))
-	return createTestNamespace(client, f.baseName)
+	if f.testNamespaceName == "" {
+		client := f.KubeClient(fmt.Sprintf("%s-create-namespace", f.baseName))
+		f.testNamespaceName = createTestNamespace(client, f.baseName)
+	}
+	return f.testNamespaceName
 }
 
 func (f *ManagedFramework) SetUpControllerFixture(typeConfig typeconfig.Interface) {

--- a/test/e2e/framework/test_context.go
+++ b/test/e2e/framework/test_context.go
@@ -24,27 +24,19 @@ import (
 
 	"github.com/golang/glog"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"github.com/kubernetes-sigs/federation-v2/pkg/controller/util"
 )
 
 type TestContextType struct {
-	TestManagedFederation     bool
-	InMemoryControllers       bool
-	KubeConfig                string
-	KubeContext               string
-	FederationSystemNamespace string
-	ClusterNamespace          string
-	SingleCallTimeout         time.Duration
-	LimitedScope              bool
-}
-
-func (tc *TestContextType) TargetNamespace() string {
-	if tc.LimitedScope {
-		return tc.FederationSystemNamespace
-	}
-	return metav1.NamespaceAll
+	TestManagedFederation           bool
+	InMemoryControllers             bool
+	KubeConfig                      string
+	KubeContext                     string
+	FederationSystemNamespace       string
+	ClusterNamespace                string
+	SingleCallTimeout               time.Duration
+	LimitedScope                    bool
+	LimitedScopeInMemoryControllers bool
 }
 
 var TestContext TestContextType
@@ -65,6 +57,8 @@ func registerFlags(t *TestContextType) {
 	flag.DurationVar(&t.SingleCallTimeout, "single-call-timeout", DefaultSingleCallTimeout,
 		fmt.Sprintf("The maximum duration of a single call.  If unset, will default to %v", DefaultSingleCallTimeout))
 	flag.BoolVar(&t.LimitedScope, "limited-scope", false, "Whether the federation namespace (configurable via --federation-namespace) will be the only target for federation.")
+	flag.BoolVar(&t.LimitedScopeInMemoryControllers, "limited-scope-in-memory-controllers", true,
+		"Whether federation controllers started in memory should target only the test namespace.  If debugging cluster-scoped federation outside of a test namespace, this should be set to false.")
 }
 
 func validateFlags(t *TestContextType) {


### PR DESCRIPTION
Otherwise any failed test runs that leave federation primitives in a persistent test cluster may impact future test runs when running with in-memory controllers.

It is still possible to debug in-memory controllers that target the entire cluster by passing `-limited-scope-in-memory-controllers=false` to test invocation.