### PR TITLE
Fix controller manager to only accept args from command line

### DIFF
--- a/cmd/controller-manager/main.go
+++ b/cmd/controller-manager/main.go
@@ -94,19 +94,7 @@ func main() {
 		}
 	}
 
-	// Allow federation and cluster namespaces to be overridden by
-	// environment variables to allow the namespaces to be set to the
-	// pod namespace via the downward api.
-	fedNamespaceFromEnv := os.Getenv("FEDERATION_NAMESPACE")
-	if len(fedNamespaceFromEnv) > 0 {
-		fedNamespace = fedNamespaceFromEnv
-	}
 	glog.Infof("Federation namespace: %s", fedNamespace)
-
-	clusterNamespaceFromEnv := os.Getenv("CLUSTER_REGISTRY_NAMESPACE")
-	if len(clusterNamespaceFromEnv) > 0 {
-		clusterNamespace = clusterNamespaceFromEnv
-	}
 	glog.Infof("Cluster registry namespace: %s", clusterNamespace)
 
 	targetNamespace := metav1.NamespaceAll

--- a/scripts/generate-namespaced-install-yaml.sh
+++ b/scripts/generate-namespaced-install-yaml.sh
@@ -32,8 +32,11 @@ sed -i -e '/^  namespace: federation-system$/d' "${INSTALL_YAML}"
 # Convert rbac from cluster- to namespace-scoped
 sed -i -e 's/ClusterRole/Role/' "${INSTALL_YAML}"
 
-# Add --limited-scope arg to container
-sed -i -e 's/\(\s*- \)\(--install-crds=false\)/\1\2\n\1--limited-scope=true/' "${INSTALL_YAML}"
+# Add args to container
+sed -i -e '/--install-crds=false/a\
+        - --limited-scope=true\
+        - --federation-namespace=$(FEDERATION_NAMESPACE)\
+        - --registry-namespace=$(CLUSTER_REGISTRY_NAMESPACE)' "${INSTALL_YAML}"
 
 # Add namespace env args to container
  sed -i -e '/terminationGracePeriodSeconds/i\

--- a/scripts/generate-namespaced-install-yaml.sh
+++ b/scripts/generate-namespaced-install-yaml.sh
@@ -36,7 +36,8 @@ sed -i -e 's/ClusterRole/Role/' "${INSTALL_YAML}"
 sed -i -e 's/\(\s*- \)\(--install-crds=false\)/\1\2\n\1--limited-scope=true/' "${INSTALL_YAML}"
 
 # Add namespace env args to container
- sed -i -e '/terminationGracePeriodSeconds/i\        env:\
+ sed -i -e '/terminationGracePeriodSeconds/i\
+        env:\
         - name: FEDERATION_NAMESPACE\
           valueFrom:\
             fieldRef:\


### PR DESCRIPTION
As per a [PR comment](https://github.com/kubernetes-sigs/federation-v2/pull/216#discussion_r212668792) from @pmorie, the controller manager should accept arguments set via the downward api from the command line rather than as environment variables.