### PR TITLE
Use namespace sync controller in the dns tests

### DIFF
--- a/test/common/dns.go
+++ b/test/common/dns.go
@@ -26,6 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	pkgruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
+	kubeclientset "k8s.io/client-go/kubernetes"
 
 	dnsv1a1 "github.com/kubernetes-sigs/federation-v2/pkg/apis/multiclusterdns/v1alpha1"
 	"github.com/kubernetes-sigs/federation-v2/pkg/controller/util"
@@ -149,4 +150,24 @@ func equivalent(actual, desired pkgruntime.Object) bool {
 	statusActual := reflect.ValueOf(actual).Elem().FieldByName("Status").Interface()
 	statusDesired := reflect.ValueOf(desired).Elem().FieldByName("Status").Interface()
 	return reflect.DeepEqual(statusActual, statusDesired)
+}
+
+// WaitForNamespace waits for namespace to be created in a cluster.
+func WaitForNamespaceOrDie(tl TestLogger, client kubeclientset.Interface, clusterName, namespace string, interval, timeout time.Duration) {
+	err := wait.PollImmediate(interval, timeout, func() (exist bool, err error) {
+		_, err = client.CoreV1().Namespaces().Get(namespace, metav1.GetOptions{})
+		if errors.IsNotFound(err) {
+			return false, nil
+		}
+		if err != nil {
+			tl.Errorf("Error waiting for namespace %q to be created in cluster %q: %v",
+				namespace, clusterName, err)
+			return false, nil
+		}
+		return true, nil
+	})
+	if err != nil {
+		tl.Fatalf("Timed out waiting for namespace %q to exist in cluster %q: %v",
+			namespace, clusterName, err)
+	}
 }

--- a/test/common/typeconfig.go
+++ b/test/common/typeconfig.go
@@ -26,8 +26,40 @@ import (
 
 	"github.com/kubernetes-sigs/federation-v2/pkg/apis/core/typeconfig"
 	"github.com/kubernetes-sigs/federation-v2/pkg/apis/core/v1alpha1"
+	"github.com/kubernetes-sigs/federation-v2/pkg/controller/util"
 	"k8s.io/apimachinery/pkg/util/yaml"
 )
+
+var (
+	typeConfigs         []typeconfig.Interface
+	namespaceTypeConfig typeconfig.Interface
+)
+
+func TypeConfigsOrDie(tl TestLogger) []typeconfig.Interface {
+	if typeConfigs == nil {
+		var err error
+		typeConfigs, err = FederatedTypeConfigs()
+		if err != nil {
+			tl.Fatalf("Error loading type configs: %v", err)
+		}
+	}
+	return typeConfigs
+}
+
+func NamespaceTypeConfigOrDie(tl TestLogger) typeconfig.Interface {
+	if namespaceTypeConfig == nil {
+		for _, typeConfig := range TypeConfigsOrDie(tl) {
+			if typeConfig.GetTarget().Kind == util.NamespaceKind {
+				namespaceTypeConfig = typeConfig
+				break
+			}
+		}
+		if namespaceTypeConfig == nil {
+			tl.Fatalf("Unable to find namespace type config")
+		}
+	}
+	return namespaceTypeConfig
+}
 
 func FederatedTypeConfigs() ([]typeconfig.Interface, error) {
 	path := typeConfigPath()


### PR DESCRIPTION
Previously the dns tests created (and attempted to cleanup) the test namespace in member clusters.  This commit updates the tests to rely instead on the namespace sync controller to ensure resiliency.

This change was motivated by test failures noticed while working on #284.