### PR TITLE
Enable -ginkgo.trace for ci testing

### DIFF
--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -21,7 +21,7 @@ set -o nounset
 set -o pipefail
 
 source "$(dirname "${BASH_SOURCE}")/util.sh"
-E2E_TEST_CMD="go test -v ./test/e2e -args -kubeconfig=${HOME}/.kube/config -ginkgo.v -single-call-timeout=1m"
+E2E_TEST_CMD="go test -v ./test/e2e -args -kubeconfig=${HOME}/.kube/config -ginkgo.v -single-call-timeout=1m -ginkgo.trace"
 
 function build-binaries() {
   go build -o bin/controller-manager ./cmd/controller-manager


### PR DESCRIPTION
Works around #204.