### PR TITLE
Use `clusterNames` for federated serviceaccount placement.

### DIFF
--- a/example/sample1/federatedserviceaccount-placement.yaml
+++ b/example/sample1/federatedserviceaccount-placement.yaml
@@ -7,6 +7,6 @@ items:
     name: test-serviceaccount
     namespace: test-namespace
   spec:
-    clusternames:
+    clusterNames:
     - cluster1
     - cluster2


### PR DESCRIPTION
We have replaced `clusternames` to `clusterNames` for placement policy
in https://github.com/kubernetes-sigs/federation-v2/pull/260 , the
federated serviceaccount placement policy should also be updated.

Fixed https://github.com/kubernetes-sigs/federation-v2/issues/280

/cc @font @marun 