### PR TITLE
Enabled delete federation can delete hack/install.yaml

### DIFF
--- a/docs/userguide.md
+++ b/docs/userguide.md
@@ -325,14 +325,12 @@ Run the following command to perform a cleanup of the cluster registry and
 federation deployments:
 
 ```bash
-./scripts/delete-federation.sh cluster2
+./scripts/delete-federation.sh
 ```
 
-The above script unjoins the host cluster from the federation control plane it deploys, by default.
-The argument(s) used is/are the list of context names of the additional clusters that needs to be
-unjoined from this federation control plane. Clarifying, say the `host-cluster-context` used is
-`cluster1`, then on successful completion of the script used in example, both `cluster1` and `cluster2`
-will be unjoined from the deployed federation control plane.
+The above script unjoins the all of the clusters from the federation control plane it deploys,
+by default. On successful completion of the script used in example, both `cluster1` and
+`cluster2` will be unjoined from the deployed federation control plane.
 
 ## Namespaced Federation
 


### PR DESCRIPTION
There are now three types for install federation:
- install-latest.yaml
- install.yaml
- install-namespace.yaml

We need to make sure the delete script can handle all of the cases.

/cc @marun @font 

This is a follow up for PR https://github.com/kubernetes-sigs/federation-v2/pull/290#pullrequestreview-159342381