### PR TITLE
Refactor all controllers to use the same async worker code

### DIFF
--- a/pkg/controller/federatedtypeconfig/controller.go
+++ b/pkg/controller/federatedtypeconfig/controller.go
@@ -19,7 +19,6 @@ package federatedtypeconfig
 import (
 	"fmt"
 	"sync"
-	"time"
 
 	"github.com/golang/glog"
 
@@ -28,13 +27,10 @@ import (
 	pkgruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/rest"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/util/flowcontrol"
-	"k8s.io/client-go/util/workqueue"
 
 	corev1a1 "github.com/kubernetes-sigs/federation-v2/pkg/apis/core/v1alpha1"
 	fedclientset "github.com/kubernetes-sigs/federation-v2/pkg/client/clientset/versioned"
@@ -65,21 +61,12 @@ type Controller struct {
 	stopChannels map[string]chan struct{}
 	lock         sync.RWMutex
 
-	// For triggering reconciliation of a single resource. This is
-	// used when there is an add/update/delete operation on a resource
-	// in federated API server.
-	deliverer *util.DelayingDeliverer
-
 	// Store for the FederatedTypeConfig objects
 	store cache.Store
 	// Informer for the FederatedTypeConfig objects
 	controller cache.Controller
 
-	// Work queue allowing parallel processing of resources
-	workQueue workqueue.Interface
-
-	// Backoff manager
-	backoff *flowcontrol.Backoff
+	worker util.ReconcileWorker
 }
 
 // StartController starts the Controller for managing FederatedTypeConfig objects.
@@ -106,11 +93,9 @@ func newController(client corev1alpha1client.CoreV1alpha1Interface, config *rest
 		clusterNamespace: clusterNamespace,
 		targetNamespace:  targetNamespace,
 		stopChannels:     make(map[string]chan struct{}),
-		workQueue:        workqueue.New(),
-		backoff:          flowcontrol.NewBackOff(5*time.Second, time.Minute),
 	}
 
-	c.deliverer = util.NewDelayingDeliverer()
+	c.worker = util.NewReconcileWorker(c.reconcile, util.WorkerTiming{})
 
 	c.store, c.controller = cache.NewInformer(
 		&cache.ListWatch{
@@ -126,9 +111,7 @@ func newController(client corev1alpha1client.CoreV1alpha1Interface, config *rest
 		},
 		&corev1a1.FederatedTypeConfig{},
 		util.NoResyncPeriod,
-		util.NewTriggerOnAllChanges(func(obj pkgruntime.Object) {
-			c.deliverObj(obj, 0, false)
-		}),
+		util.NewTriggerOnAllChanges(c.worker.EnqueueObject),
 	)
 
 	return c, nil
@@ -137,9 +120,6 @@ func newController(client corev1alpha1client.CoreV1alpha1Interface, config *rest
 // Run runs the Controller.
 func (c *Controller) Run(stopChan <-chan struct{}) {
 	go c.controller.Run(stopChan)
-	c.deliverer.StartWithHandler(func(item *util.DelayingDelivererItem) {
-		c.workQueue.Add(item)
-	})
 
 	// wait for the caches to synchronize before starting the worker
 	if !cache.WaitForCacheSync(stopChan, c.controller.HasSynced) {
@@ -147,66 +127,16 @@ func (c *Controller) Run(stopChan <-chan struct{}) {
 		return
 	}
 
-	// TODO: Allow multiple workers.
-	go wait.Until(c.worker, time.Second, stopChan)
-
-	util.StartBackoffGC(c.backoff, stopChan)
+	c.worker.Run(stopChan)
 
 	// Ensure all goroutines are cleaned up when the stop channel closes
 	go func() {
 		<-stopChan
-		c.workQueue.ShutDown()
-		c.deliverer.Stop()
 		c.shutDown()
 	}()
 }
 
-type reconciliationStatus int
-
-const (
-	statusAllOK reconciliationStatus = iota
-	statusError
-)
-
-func (c *Controller) worker() {
-	for {
-		obj, quit := c.workQueue.Get()
-		if quit {
-			return
-		}
-
-		item := obj.(*util.DelayingDelivererItem)
-		qualifiedName := item.Value.(*util.QualifiedName)
-		status := c.reconcile(*qualifiedName)
-		c.workQueue.Done(item)
-
-		switch status {
-		case statusAllOK:
-			break
-		case statusError:
-			c.deliver(*qualifiedName, 0, true)
-		}
-	}
-}
-
-func (c *Controller) deliverObj(obj pkgruntime.Object, delay time.Duration, failed bool) {
-	qualifiedName := util.NewQualifiedName(obj)
-	c.deliver(qualifiedName, delay, failed)
-}
-
-// Adds backoff to delay if this delivery is related to some failure. Resets backoff if there was no failure.
-func (c *Controller) deliver(qualifiedName util.QualifiedName, delay time.Duration, failed bool) {
-	key := qualifiedName.String()
-	if failed {
-		c.backoff.Next(key, time.Now())
-		delay = delay + c.backoff.Get(key)
-	} else {
-		c.backoff.Reset(key)
-	}
-	c.deliverer.DeliverAfter(key, &qualifiedName, delay)
-}
-
-func (c *Controller) reconcile(qualifiedName util.QualifiedName) reconciliationStatus {
+func (c *Controller) reconcile(qualifiedName util.QualifiedName) util.ReconciliationStatus {
 	key := qualifiedName.String()
 
 	glog.Infof("Running reconcile FederatedTypeConfig for %q", key)
@@ -214,10 +144,10 @@ func (c *Controller) reconcile(qualifiedName util.QualifiedName) reconciliationS
 	cachedObj, exist, err := c.store.GetByKey(key)
 	if err != nil {
 		runtime.HandleError(fmt.Errorf("Failed to query FederatedTypeConfig store for %q: %v", key, err))
-		return statusError
+		return util.StatusError
 	}
 	if !exist {
-		return statusAllOK
+		return util.StatusAllOK
 	}
 	typeConfig := cachedObj.(*corev1a1.FederatedTypeConfig)
 
@@ -231,15 +161,15 @@ func (c *Controller) reconcile(qualifiedName util.QualifiedName) reconciliationS
 		err := c.removeFinalizer(typeConfig)
 		if err != nil {
 			runtime.HandleError(fmt.Errorf("Failed to remove finalizer from FederatedTypeConfig %q: %v", key, err))
-			return statusError
+			return util.StatusError
 		}
-		return statusAllOK
+		return util.StatusAllOK
 	}
 
 	err = c.ensureFinalizer(typeConfig)
 	if err != nil {
 		runtime.HandleError(fmt.Errorf("Failed to ensure finalizer for FederatedTypeConfig %q: %v", key, err))
-		return statusError
+		return util.StatusError
 	}
 
 	enabled := typeConfig.Spec.PropagationEnabled
@@ -248,13 +178,13 @@ func (c *Controller) reconcile(qualifiedName util.QualifiedName) reconciliationS
 	if startNewController {
 		if err := c.startController(typeConfig); err != nil {
 			runtime.HandleError(err)
-			return statusError
+			return util.StatusError
 		}
 	} else if stopController {
 		c.stopController(typeConfig.Name, stopChan)
 	}
 
-	return statusAllOK
+	return util.StatusAllOK
 }
 
 func (c *Controller) shutDown() {

--- a/pkg/controller/ingressdns/controller.go
+++ b/pkg/controller/ingressdns/controller.go
@@ -31,13 +31,10 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	pkgruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
 	kubeclientset "k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/util/flowcontrol"
-	"k8s.io/client-go/util/workqueue"
 	crclientset "k8s.io/cluster-registry/pkg/client/clientset/versioned"
 
 	fedv1a1 "github.com/kubernetes-sigs/federation-v2/pkg/apis/core/v1alpha1"
@@ -54,11 +51,6 @@ const (
 type Controller struct {
 	fedClient fedclientset.Interface
 
-	// For triggering reconciliation of a single resource. This is
-	// used when there is an add/update/delete operation on a resource
-	// in federated API server.
-	deliverer *util.DelayingDeliverer
-
 	// For triggering reconciliation of all target resources. This is
 	// used when a new cluster becomes available.
 	clusterDeliverer *util.DelayingDeliverer
@@ -71,13 +63,8 @@ type Controller struct {
 	// Informer for the MultiClusterIngressDNSRecord objects
 	ingressDNSController cache.Controller
 
-	// Work queue allowing parallel processing of resources
-	workQueue workqueue.Interface
+	worker util.ReconcileWorker
 
-	// Backoff manager
-	backoff *flowcontrol.Backoff
-
-	reviewDelay             time.Duration
 	clusterAvailableDelay   time.Duration
 	clusterUnavailableDelay time.Duration
 	smallDelay              time.Duration
@@ -107,16 +94,16 @@ func StartController(config *restclient.Config, fedNamespace, clusterNamespace, 
 func newController(fedClient fedclientset.Interface, kubeClient kubeclientset.Interface, crClient crclientset.Interface, fedNamespace, clusterNamespace, targetNamespace string) (*Controller, error) {
 	s := &Controller{
 		fedClient:               fedClient,
-		reviewDelay:             time.Second * 10,
 		clusterAvailableDelay:   time.Second * 20,
 		clusterUnavailableDelay: time.Second * 60,
 		smallDelay:              time.Second * 3,
-		workQueue:               workqueue.New(),
-		backoff:                 flowcontrol.NewBackOff(5*time.Second, time.Minute),
 	}
 
-	// Build deliverers for triggering reconciliations.
-	s.deliverer = util.NewDelayingDeliverer()
+	s.worker = util.NewReconcileWorker(s.reconcile, util.WorkerTiming{
+		ClusterSyncDelay: s.clusterAvailableDelay,
+	})
+
+	// Build deliverer for triggering cluster reconciliations.
 	s.clusterDeliverer = util.NewDelayingDeliverer()
 
 	// Informer for the MultiClusterIngressDNSRecord resource in federation.
@@ -132,7 +119,7 @@ func newController(fedClient fedclientset.Interface, kubeClient kubeclientset.In
 		&dnsv1a1.MultiClusterIngressDNSRecord{},
 		util.NoResyncPeriod,
 		util.NewTriggerOnAllChanges(func(obj pkgruntime.Object) {
-			s.deliverObj(obj, 0, false)
+			s.worker.EnqueueObject(obj)
 		}),
 	)
 
@@ -152,7 +139,7 @@ func newController(fedClient fedclientset.Interface, kubeClient kubeclientset.In
 			SingularName: "ingress",
 			Namespaced:   true},
 		func(obj pkgruntime.Object) {
-			s.deliverObj(obj, 0, false)
+			s.worker.EnqueueObject(obj)
 		},
 
 		&util.ClusterLifecycleHandlerFuncs{
@@ -174,85 +161,26 @@ func newController(fedClient fedclientset.Interface, kubeClient kubeclientset.In
 func (c *Controller) minimizeLatency() {
 	c.clusterAvailableDelay = time.Second
 	c.clusterUnavailableDelay = time.Second
-	c.reviewDelay = 50 * time.Millisecond
 	c.smallDelay = 20 * time.Millisecond
+	c.worker.SetDelay(50*time.Millisecond, c.clusterAvailableDelay)
 }
 
 // Run runs the Controller.
 func (c *Controller) Run(stopChan <-chan struct{}) {
 	go c.ingressDNSController.Run(stopChan)
 	c.ingressFederatedInformer.Start()
-	c.deliverer.StartWithHandler(func(item *util.DelayingDelivererItem) {
-		c.workQueue.Add(item)
-	})
 	c.clusterDeliverer.StartWithHandler(func(_ *util.DelayingDelivererItem) {
 		c.reconcileOnClusterChange()
 	})
 
-	// TODO: Allow multiple workers.
-	go wait.Until(c.worker, time.Second, stopChan)
-
-	util.StartBackoffGC(c.backoff, stopChan)
+	c.worker.Run(stopChan)
 
 	// Ensure all goroutines are cleaned up when the stop channel closes
 	go func() {
 		<-stopChan
 		c.ingressFederatedInformer.Stop()
-		c.workQueue.ShutDown()
-		c.deliverer.Stop()
 		c.clusterDeliverer.Stop()
 	}()
-}
-
-type reconciliationStatus int
-
-const (
-	statusAllOK reconciliationStatus = iota
-	statusNeedsRecheck
-	statusError
-	statusNotSynced
-)
-
-func (c *Controller) worker() {
-	for {
-		obj, quit := c.workQueue.Get()
-		if quit {
-			return
-		}
-
-		item := obj.(*util.DelayingDelivererItem)
-		qualifiedName := item.Value.(*util.QualifiedName)
-		status := c.reconcile(*qualifiedName)
-		c.workQueue.Done(item)
-
-		switch status {
-		case statusAllOK:
-			break
-		case statusError:
-			c.deliver(*qualifiedName, 0, true)
-		case statusNeedsRecheck:
-			c.deliver(*qualifiedName, c.reviewDelay, false)
-		case statusNotSynced:
-			c.deliver(*qualifiedName, c.clusterAvailableDelay, false)
-		}
-	}
-}
-
-func (c *Controller) deliverObj(obj pkgruntime.Object, delay time.Duration, failed bool) {
-	qualifiedName := util.NewQualifiedName(obj)
-	c.deliver(qualifiedName, delay, failed)
-}
-
-// Adds backoff to delay if this delivery is related to some failure. Resets backoff if there was no failure.
-func (c *Controller) deliver(qualifiedName util.QualifiedName, delay time.Duration, failed bool) {
-	key := qualifiedName.String()
-	if failed {
-		c.backoff.Next(key, time.Now())
-		delay = delay + c.backoff.Get(key)
-	} else {
-		c.backoff.Reset(key)
-	}
-	c.deliverer.DeliverAfter(key, &qualifiedName, delay)
 }
 
 // Check whether all data stores are in sync. False is returned if any of the ingressFederatedInformer/stores is not yet
@@ -281,13 +209,13 @@ func (c *Controller) reconcileOnClusterChange() {
 	}
 	for _, obj := range c.ingressDNSStore.List() {
 		qualifiedName := util.NewQualifiedName(obj.(pkgruntime.Object))
-		c.deliver(qualifiedName, c.smallDelay, false)
+		c.worker.EnqueueWithDelay(qualifiedName, c.smallDelay)
 	}
 }
 
-func (c *Controller) reconcile(qualifiedName util.QualifiedName) reconciliationStatus {
+func (c *Controller) reconcile(qualifiedName util.QualifiedName) util.ReconciliationStatus {
 	if !c.isSynced() {
-		return statusNotSynced
+		return util.StatusNotSynced
 	}
 
 	key := qualifiedName.String()
@@ -299,10 +227,10 @@ func (c *Controller) reconcile(qualifiedName util.QualifiedName) reconciliationS
 	cachedIngressDNSObj, exist, err := c.ingressDNSStore.GetByKey(key)
 	if err != nil {
 		runtime.HandleError(fmt.Errorf("Failed to query MultiClusterIngressDNS store for %q: %v", key, err))
-		return statusError
+		return util.StatusError
 	}
 	if !exist {
-		return statusAllOK
+		return util.StatusAllOK
 	}
 	cachedIngressDNS := cachedIngressDNSObj.(*dnsv1a1.MultiClusterIngressDNSRecord)
 
@@ -315,7 +243,7 @@ func (c *Controller) reconcile(qualifiedName util.QualifiedName) reconciliationS
 	clusters, err := c.ingressFederatedInformer.GetReadyClusters()
 	if err != nil {
 		runtime.HandleError(fmt.Errorf("Failed to get ready cluster list: %v", err))
-		return statusError
+		return util.StatusError
 	}
 
 	// Iterate through all ready clusters and aggregate the ingress status for the key
@@ -326,7 +254,7 @@ func (c *Controller) reconcile(qualifiedName util.QualifiedName) reconciliationS
 
 		lbStatus, err := c.getIngressStatusInCluster(cluster.Name, key)
 		if err != nil {
-			return statusError
+			return util.StatusError
 		}
 		clusterDNS.LoadBalancer = *lbStatus
 		newIngressDNS.Status.DNS = append(newIngressDNS.Status.DNS, clusterDNS)
@@ -340,11 +268,11 @@ func (c *Controller) reconcile(qualifiedName util.QualifiedName) reconciliationS
 		_, err = c.fedClient.MulticlusterdnsV1alpha1().MultiClusterIngressDNSRecords(newIngressDNS.Namespace).UpdateStatus(newIngressDNS)
 		if err != nil {
 			runtime.HandleError(fmt.Errorf("Error updating the MultiClusterIngressDNS object %s: %v", key, err))
-			return statusError
+			return util.StatusError
 		}
 	}
 
-	return statusAllOK
+	return util.StatusAllOK
 }
 
 // getIngressStatusInCluster returns ingress status in federated cluster

--- a/pkg/controller/util/worker.go
+++ b/pkg/controller/util/worker.go
@@ -1,0 +1,171 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"time"
+
+	pkgruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/flowcontrol"
+	"k8s.io/client-go/util/workqueue"
+)
+
+type ReconcileFunc func(qualifiedName QualifiedName) ReconciliationStatus
+
+type ReconcileWorker interface {
+	Enqueue(qualifiedName QualifiedName)
+	EnqueueForClusterSync(qualifiedName QualifiedName)
+	EnqueueForError(qualifiedName QualifiedName)
+	EnqueueForRetry(qualifiedName QualifiedName)
+	EnqueueObject(obj pkgruntime.Object)
+	EnqueueWithDelay(qualifiedName QualifiedName, delay time.Duration)
+	Run(stopChan <-chan struct{})
+	SetDelay(retryDelay, clusterSyncDelay time.Duration)
+}
+
+type WorkerTiming struct {
+	Interval         time.Duration
+	RetryDelay       time.Duration
+	ClusterSyncDelay time.Duration
+	InitialBackoff   time.Duration
+	MaxBackoff       time.Duration
+}
+
+type asyncWorker struct {
+	reconcile ReconcileFunc
+
+	timing WorkerTiming
+
+	// For triggering reconciliation of a single resource. This is
+	// used when there is an add/update/delete operation on a resource
+	// in either federated API server or in some member of the
+	// federation.
+	deliverer *DelayingDeliverer
+
+	// Work queue allowing parallel processing of resources
+	queue workqueue.Interface
+
+	// Backoff manager
+	backoff *flowcontrol.Backoff
+}
+
+func NewReconcileWorker(reconcile ReconcileFunc, timing WorkerTiming) ReconcileWorker {
+	if timing.Interval == 0 {
+		timing.Interval = time.Second * 1
+	}
+	if timing.RetryDelay == 0 {
+		timing.RetryDelay = time.Second * 10
+	}
+	if timing.InitialBackoff == 0 {
+		timing.InitialBackoff = time.Second * 5
+	}
+	if timing.MaxBackoff == 0 {
+		timing.MaxBackoff = time.Minute
+	}
+	return &asyncWorker{
+		reconcile: reconcile,
+		timing:    timing,
+		deliverer: NewDelayingDeliverer(),
+		queue:     workqueue.New(),
+		backoff:   flowcontrol.NewBackOff(timing.InitialBackoff, timing.MaxBackoff),
+	}
+}
+
+func (w *asyncWorker) Enqueue(qualifiedName QualifiedName) {
+	w.deliver(qualifiedName, 0, false)
+}
+
+func (w *asyncWorker) EnqueueForError(qualifiedName QualifiedName) {
+	w.deliver(qualifiedName, 0, true)
+}
+
+func (w *asyncWorker) EnqueueForRetry(qualifiedName QualifiedName) {
+	w.deliver(qualifiedName, w.timing.RetryDelay, false)
+}
+
+func (w *asyncWorker) EnqueueForClusterSync(qualifiedName QualifiedName) {
+	w.deliver(qualifiedName, w.timing.ClusterSyncDelay, false)
+}
+
+func (w *asyncWorker) EnqueueObject(obj pkgruntime.Object) {
+	qualifiedName := NewQualifiedName(obj)
+	w.Enqueue(qualifiedName)
+}
+
+func (w *asyncWorker) EnqueueWithDelay(qualifiedName QualifiedName, delay time.Duration) {
+	w.deliver(qualifiedName, delay, false)
+}
+
+func (w *asyncWorker) Run(stopChan <-chan struct{}) {
+	StartBackoffGC(w.backoff, stopChan)
+	w.deliverer.StartWithHandler(func(item *DelayingDelivererItem) {
+		w.queue.Add(item)
+	})
+	go wait.Until(w.worker, w.timing.Interval, stopChan)
+
+	// Ensure all goroutines are cleaned up when the stop channel closes
+	go func() {
+		<-stopChan
+		w.queue.ShutDown()
+		w.deliverer.Stop()
+	}()
+}
+
+func (w *asyncWorker) SetDelay(retryDelay, clusterSyncDelay time.Duration) {
+	w.timing.RetryDelay = retryDelay
+	w.timing.ClusterSyncDelay = clusterSyncDelay
+}
+
+// deliver adds backoff to delay if this delivery is related to some
+// failure. Resets backoff if there was no failure.
+func (w *asyncWorker) deliver(qualifiedName QualifiedName, delay time.Duration, failed bool) {
+
+	key := qualifiedName.String()
+	if failed {
+		w.backoff.Next(key, time.Now())
+		delay = delay + w.backoff.Get(key)
+	} else {
+		w.backoff.Reset(key)
+	}
+	w.deliverer.DeliverAfter(key, &qualifiedName, delay)
+}
+
+func (w *asyncWorker) worker() {
+	for {
+		obj, quit := w.queue.Get()
+		if quit {
+			return
+		}
+
+		item := obj.(*DelayingDelivererItem)
+		qualifiedName := item.Value.(*QualifiedName)
+		status := w.reconcile(*qualifiedName)
+		w.queue.Done(item)
+
+		switch status {
+		case StatusAllOK:
+			break
+		case StatusError:
+			w.EnqueueForError(*qualifiedName)
+		case StatusNeedsRecheck:
+			w.EnqueueForRetry(*qualifiedName)
+		case StatusNotSynced:
+			w.EnqueueForClusterSync(*qualifiedName)
+		}
+	}
+}


### PR DESCRIPTION
This was motivated by needing the same code for #276.  Likely there will be further convergence in the future if not a switch to kubebuilder-based controllers if we can work with them to get the features we need.