### PR TITLE
Avoid starting a namespace sync controller for namespaced federation

### DIFF
--- a/scripts/deploy-federation.sh
+++ b/scripts/deploy-federation.sh
@@ -144,10 +144,6 @@ kubectl apply --validate=false -f vendor/k8s.io/cluster-registry/cluster-registr
 
 # Enable available types
 for filename in ./config/federatedtypes/*.yaml; do
-  # The namespace controller is not required when the control plane is namespaced
-  if [[ "${NAMESPACED}" && "${filename}" == *namespace.yaml ]]; then
-    continue
-  fi
   kubectl -n "${NS}" apply -f "${filename}"
 done
 


### PR DESCRIPTION
@font (offline) and @gyliu513 (in a [comment](https://github.com/kubernetes-sigs/federation-v2/pull/283#discussion_r221222183)) both noticed that a sync controller was being launched for namespaces when the control plane was running namespaced.  This isn't desirable since a namespaced control plane shouldn't require permission to list namespaces.

Previously the only check against running a sync controller for namespaces was in the deployment script not applying the type config for namespaces if deploying a namespaced control plane.  Since helm deployment is now an option, it's necessary to move the check to code so it can be shared.