### PR TITLE
Support defaulting to namespace placement for namespace-scoped federation

### DIFF
--- a/pkg/controller/sync/controller.go
+++ b/pkg/controller/sync/controller.go
@@ -333,7 +333,7 @@ func (s *FederationSyncController) reconcile(qualifiedName util.QualifiedName) u
 
 	templateKind := s.typeConfig.GetTemplate().Kind
 	key := qualifiedName.String()
-	placementKey := key
+	placementName := util.QualifiedName{Namespace: qualifiedName.Namespace, Name: qualifiedName.Name}
 	namespace := qualifiedName.Namespace
 
 	targetKind := s.typeConfig.GetTarget().Kind
@@ -356,13 +356,13 @@ func (s *FederationSyncController) reconcile(qualifiedName util.QualifiedName) u
 		// template or placement objects from the cache by using the proper
 		// cluster-scoped or namespace-scoped key.
 		if qualifiedName.Namespace == "" {
-			qualifiedName.Namespace = qualifiedName.Name
-			placementKey = qualifiedName.String()
-			glog.V(4).Infof("Received Namespace update for %v. Using placement key %v", key, placementKey)
+			qualifiedName.Namespace = namespace
+			placementName.Namespace = namespace
+			glog.V(4).Infof("Received Namespace update for %v. Using placement key %v", key, placementName)
 		} else if qualifiedName.Namespace != "" {
 			qualifiedName.Namespace = ""
 			key = qualifiedName.String()
-			glog.V(4).Infof("Received FederatedNamespacePlacement update for %v. Using template key %v", placementKey, key)
+			glog.V(4).Infof("Received FederatedNamespacePlacement update for %v. Using template key %v", placementName, key)
 		}
 	}
 
@@ -405,9 +405,9 @@ func (s *FederationSyncController) reconcile(qualifiedName util.QualifiedName) u
 		return util.StatusNotSynced
 	}
 
-	selectedClusters, unselectedClusters, err := s.placementPlugin.ComputePlacement(placementKey, clusterNames)
+	selectedClusters, unselectedClusters, err := s.placementPlugin.ComputePlacement(placementName, clusterNames)
 	if err != nil {
-		runtime.HandleError(fmt.Errorf("Failed to compute placement for %s %q: %v", templateKind, placementKey, err))
+		runtime.HandleError(fmt.Errorf("Failed to compute placement for %s %q: %v", templateKind, placementName, err))
 		return util.StatusError
 	}
 

--- a/pkg/controller/sync/placement/namespace.go
+++ b/pkg/controller/sync/placement/namespace.go
@@ -47,7 +47,8 @@ func (p *NamespacePlacementPlugin) HasSynced() bool {
 	return p.controller.HasSynced()
 }
 
-func (p *NamespacePlacementPlugin) ComputePlacement(key string, clusterNames []string) (selectedClusters, unselectedClusters []string, err error) {
+func (p *NamespacePlacementPlugin) ComputePlacement(qualifiedName util.QualifiedName, clusterNames []string) (selectedClusters, unselectedClusters []string, err error) {
+	key := qualifiedName.String()
 	cachedObj, _, err := p.store.GetByKey(key)
 	if err != nil {
 		return nil, nil, err

--- a/pkg/controller/sync/placement/namespaced.go
+++ b/pkg/controller/sync/placement/namespaced.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package placement
+
+import (
+	"github.com/kubernetes-sigs/federation-v2/pkg/controller/util"
+	pkgruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+type namespacedPlacementPlugin struct {
+	resourcePlugin  PlacementPlugin
+	namespacePlugin *ResourcePlacementPlugin
+}
+
+func NewNamespacedPlacementPlugin(resourceClient, namespaceClient util.ResourceClient, targetNamespace string, triggerFunc func(pkgruntime.Object)) PlacementPlugin {
+	return &namespacedPlacementPlugin{
+		resourcePlugin:  NewResourcePlacementPlugin(resourceClient, targetNamespace, triggerFunc),
+		namespacePlugin: newResourcePlacementPluginWithOk(namespaceClient, targetNamespace, triggerFunc),
+	}
+}
+
+func (p *namespacedPlacementPlugin) Run(stopCh <-chan struct{}) {
+	go p.resourcePlugin.Run(stopCh)
+	go p.namespacePlugin.Run(stopCh)
+}
+
+func (p *namespacedPlacementPlugin) HasSynced() bool {
+	return p.resourcePlugin.HasSynced() && p.namespacePlugin.HasSynced()
+}
+
+func (p *namespacedPlacementPlugin) ComputePlacement(qualifiedName util.QualifiedName, clusterNames []string) (selectedClusters, unselectedClusters []string, err error) {
+	selectedClusters, unselectedClusters, err = p.resourcePlugin.ComputePlacement(qualifiedName, clusterNames)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	placementName := util.QualifiedName{Namespace: qualifiedName.Namespace, Name: qualifiedName.Namespace}
+	namespaceSelectedClusters, _, ok, err := p.namespacePlugin.computePlacementWithOk(placementName, clusterNames)
+	if err != nil {
+		return nil, nil, err
+	}
+	if !ok {
+		// Use the resource placement if no namespace placement is
+		// available.
+		return selectedClusters, unselectedClusters, nil
+	}
+
+	resourceClusterSet := sets.NewString(selectedClusters...)
+	namespaceClusterSet := sets.NewString(namespaceSelectedClusters...)
+	clusterSet := sets.NewString(clusterNames...)
+
+	// If both namespace and resource placement exist, the desired
+	// list of clusters should be their intersection.
+	selectedSet := resourceClusterSet.Intersection(namespaceClusterSet)
+
+	return selectedSet.List(), clusterSet.Difference(selectedSet).List(), nil
+}

--- a/pkg/controller/sync/placement/plugin.go
+++ b/pkg/controller/sync/placement/plugin.go
@@ -16,8 +16,12 @@ limitations under the License.
 
 package placement
 
+import (
+	"github.com/kubernetes-sigs/federation-v2/pkg/controller/util"
+)
+
 type PlacementPlugin interface {
 	Run(stopCh <-chan struct{})
 	HasSynced() bool
-	ComputePlacement(key string, clusterNames []string) (selectedClusters, unselectedClusters []string, err error)
+	ComputePlacement(qualifiedName util.QualifiedName, clusterNames []string) (selectedClusters, unselectedClusters []string, err error)
 }

--- a/pkg/controller/sync/placement/resource.go
+++ b/pkg/controller/sync/placement/resource.go
@@ -47,7 +47,8 @@ func (p *ResourcePlacementPlugin) HasSynced() bool {
 	return p.controller.HasSynced()
 }
 
-func (p *ResourcePlacementPlugin) ComputePlacement(key string, clusterNames []string) (selectedClusters, unselectedClusters []string, err error) {
+func (p *ResourcePlacementPlugin) ComputePlacement(qualifiedName util.QualifiedName, clusterNames []string) (selectedClusters, unselectedClusters []string, err error) {
+	key := qualifiedName.String()
 	cachedObj, _, err := p.store.GetByKey(key)
 	if err != nil {
 		return nil, nil, err

--- a/test/common/crudtester.go
+++ b/test/common/crudtester.go
@@ -428,6 +428,10 @@ func (c *FederatedTypeCrudTester) waitForResource(client util.ResourceClient, qu
 	return err
 }
 
+func (c *FederatedTypeCrudTester) TestClusters() map[string]TestCluster {
+	return c.testClusters
+}
+
 func (c *FederatedTypeCrudTester) waitForResourceDeletion(client util.ResourceClient, qualifiedName util.QualifiedName, versionRemoved func() bool) error {
 	err := wait.PollImmediate(c.waitInterval, c.clusterWaitTimeout, func() (bool, error) {
 		_, err := client.Resources(qualifiedName.Namespace).Get(qualifiedName.Name, metav1.GetOptions{})

--- a/test/e2e/crud.go
+++ b/test/e2e/crud.go
@@ -241,7 +241,11 @@ func waitForCrd(pool dynamic.ClientPool, tl common.TestLogger, apiResource metav
 	}
 }
 
-func validateCrud(f framework.FederationFramework, tl common.TestLogger, typeConfig typeconfig.Interface, testObjectFunc testObjectAccessor) {
+func initCrudTest(f framework.FederationFramework, tl common.TestLogger,
+	typeConfig typeconfig.Interface, testObjectFunc testObjectAccessor) (
+	crudTester *common.FederatedTypeCrudTester, template, placement,
+	override *unstructured.Unstructured) {
+
 	// Initialize in-memory controllers if configuration requires
 	f.SetUpControllerFixture(typeConfig)
 
@@ -261,11 +265,18 @@ func validateCrud(f framework.FederationFramework, tl common.TestLogger, typeCon
 	for name, _ := range testClusters {
 		clusterNames = append(clusterNames, name)
 	}
-	template, placement, override, err := testObjectFunc(f.TestNamespaceName(), clusterNames)
+	template, placement, override, err = testObjectFunc(f.TestNamespaceName(), clusterNames)
 	if err != nil {
 		tl.Fatalf("Error creating test objects: %v", err)
 	}
 
+	return crudTester, template, placement, override
+}
+
+func validateCrud(f framework.FederationFramework, tl common.TestLogger,
+	typeConfig typeconfig.Interface, testObjectFunc testObjectAccessor) {
+
+	crudTester, template, placement, override := initCrudTest(f, tl, typeConfig, testObjectFunc)
 	crudTester.CheckLifecycle(template, placement, override)
 }
 

--- a/test/e2e/placement.go
+++ b/test/e2e/placement.go
@@ -1,0 +1,131 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	"github.com/kubernetes-sigs/federation-v2/pkg/apis/core/typeconfig"
+	fedv1a1 "github.com/kubernetes-sigs/federation-v2/pkg/apis/core/v1alpha1"
+	"github.com/kubernetes-sigs/federation-v2/pkg/controller/util"
+	"github.com/kubernetes-sigs/federation-v2/test/common"
+	"github.com/kubernetes-sigs/federation-v2/test/e2e/framework"
+
+	. "github.com/onsi/ginkgo"
+)
+
+var _ = Describe("Placement", func() {
+	f := framework.NewFederationFramework("placement")
+
+	tl := framework.NewE2ELogger()
+
+	typeConfigs := common.TypeConfigsOrDie(tl)
+
+	// TODO(marun) Since this test only targets namespaced federation,
+	// concurrent test isolation against unmanaged fixture is
+	// effectively impossible.  The namespace placement would be
+	// picked up by other controllers targeting the federation
+	// namespace.
+	It("should be computed from namespace and resource placement for namespaced federation", func() {
+		if !framework.TestContext.LimitedScope {
+			framework.Skipf("Considering namespace placement when determining resource placement is not supported for cluster-scoped federation.")
+		}
+
+		// Select the first non-namespace type config
+		var selectedTypeConfig typeconfig.Interface
+		for _, typeConfig := range typeConfigs {
+			if typeConfig.GetTemplate().Kind != util.NamespaceKind {
+				selectedTypeConfig = typeConfig
+				break
+			}
+		}
+		if selectedTypeConfig == nil {
+			tl.Fatal("Unable to find non-namespace type config")
+		}
+
+		// Propagate a resource to member clusters
+		testObjectFunc := func(namespace string, clusterNames []string) (template, placement, override *unstructured.Unstructured, err error) {
+			return common.NewTestObjects(selectedTypeConfig, namespace, clusterNames)
+		}
+		crudTester, desiredTemplate, desiredPlacement, desiredOverride := initCrudTest(f, tl, selectedTypeConfig, testObjectFunc)
+		template, _, _ := crudTester.CheckCreate(desiredTemplate, desiredPlacement, desiredOverride)
+		defer func() {
+			orphanDependents := false
+			crudTester.CheckDelete(template, &orphanDependents)
+		}()
+
+		namespace := f.TestNamespaceName()
+
+		// Create namespace placement with no clusters.
+		client := f.FedClient("placement")
+		placementKey := fmt.Sprintf("%s/%s", namespace, namespace)
+		_, err := client.CoreV1alpha1().FederatedNamespacePlacements(namespace).Create(&fedv1a1.FederatedNamespacePlacement{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: namespace,
+				Name:      namespace,
+			},
+		})
+		if err != nil {
+			tl.Fatalf("Error creating FederatedNamespacePlacement %s/%s: %v", placementKey, err)
+		}
+		tl.Logf("Created new FederatedNamespacePlacement %q", placementKey)
+		// Ensure the removal of the namespace placement to avoid affecting other tests.
+		defer func() {
+			err := client.CoreV1alpha1().FederatedNamespacePlacements(namespace).Delete(namespace, nil)
+			if err != nil && !errors.IsNotFound(err) {
+				tl.Fatalf("Error deleting FederatedNamespacePlacement %s/%s: %v", namespace, namespace, err)
+			}
+			tl.Logf("Deleted FederatedNamespacePlacement %q", placementKey)
+		}()
+
+		// Check for removal of the propagated resource from all clusters
+		targetAPIResource := selectedTypeConfig.GetTarget()
+		targetKind := targetAPIResource.Kind
+		qualifiedName := util.NewQualifiedName(template)
+		for clusterName, testCluster := range crudTester.TestClusters() {
+			client, err := util.NewResourceClientFromConfig(testCluster.Config, &targetAPIResource)
+			if err != nil {
+				tl.Fatalf("Error creating resource client for %q: %v", targetKind, err)
+			}
+			err = wait.PollImmediate(framework.PollInterval, framework.TestContext.SingleCallTimeout, func() (bool, error) {
+				_, err := client.Resources(namespace).Get(qualifiedName.Name, metav1.GetOptions{})
+				if errors.IsNotFound(err) {
+					return true, nil
+				}
+				if err != nil {
+					tl.Errorf("Failed to check for existence of %s %q in cluster %q: %v",
+						targetKind, qualifiedName, clusterName, err,
+					)
+				}
+				return false, nil
+			})
+			if err != nil {
+				tl.Fatalf("Failed to confirm removal of %s %q in cluster %q within %v",
+					targetKind, qualifiedName, clusterName, framework.TestContext.SingleCallTimeout,
+				)
+			}
+			tl.Logf("Confirmed removal of %s %q in cluster %q",
+				targetKind, qualifiedName, clusterName,
+			)
+		}
+	})
+})


### PR DESCRIPTION
In cluster-scoped federation, the namespace sync controller uses namespace placement to determine whether a namespace should appear in member clusters. If a namespace does not appear in member clusters, any resources it contains are also prevented from appearing.

Since namespace-scoped federation does not run the namespace sync controller, namespace placement would have no effect.  This PR changes that by ensuring that, for namespaced federation, placement for a given resource is the determined from the resource and namespace placement.

Fixes #298