### PR TITLE
Improve godoc for MultiClusterServiceDNSRecord and DNSEndpoint

### DIFF
--- a/pkg/apis/multiclusterdns/v1alpha1/dnsendpoint_types.go
+++ b/pkg/apis/multiclusterdns/v1alpha1/dnsendpoint_types.go
@@ -30,17 +30,17 @@ type TTL int64
 // it is then stored in a persistent storage via serialization
 type Labels map[string]string
 
-// Endpoint is a high-level way of a connection between a service and an IP
+// Endpoint is a high-level association between a service and an IP.
 type Endpoint struct {
-	// The hostname of the DNS record
+	// The FQDN of the DNS record.
 	DNSName string `json:"dnsName,omitempty"`
-	// The targets the DNS record points to
+	// The targets that the DNS record points to.
 	Targets Targets `json:"targets,omitempty"`
-	// RecordType type of record, e.g. CNAME, A, SRV, TXT etc
+	// RecordType type of record, e.g. CNAME, A, SRV, TXT etc.
 	RecordType string `json:"recordType,omitempty"`
-	// TTL for the record in seconds
+	// TTL for the record in seconds.
 	RecordTTL TTL `json:"recordTTL,omitempty"`
-	// Labels stores labels defined for the Endpoint
+	// Labels stores labels defined for the Endpoint.
 	// +optional
 	Labels Labels `json:"labels,omitempty"`
 }
@@ -60,7 +60,9 @@ type DNSEndpointStatus struct {
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
-// DNSEndpoint is the CRD wrapper for Endpoint
+// DNSEndpoint is the CRD wrapper for Endpoint which is designed to act as a
+// source of truth for external-dns.
+//
 // +k8s:openapi-gen=true
 // +kubebuilder:resource:path=dnsendpoints
 // +kubebuilder:subresource:status

--- a/pkg/apis/multiclusterdns/v1alpha1/servicednsrecord_types.go
+++ b/pkg/apis/multiclusterdns/v1alpha1/servicednsrecord_types.go
@@ -21,7 +21,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// ServiceDNSRecordSpec defines the desired state of ServiceDNSRecord
+// ServiceDNSRecordSpec defines the desired state of ServiceDNSRecord.
 type ServiceDNSRecordSpec struct {
 	// FederationName is the name of the federation to which the corresponding federated service belongs
 	FederationName string `json:"federationName,omitempty"`
@@ -51,7 +51,27 @@ type ClusterDNS struct {
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
-// ServiceDNSRecord
+// ServiceDNSRecord defines a scheme of DNS name and subdomains that
+// should be programmed with endpoint information about a Service deployed in
+// multiple Kubernetes clusters. ServiceDNSRecord is name-associated
+// with the Services it programs endpoint information for, meaning that a
+// ServiceDNSRecord expresses the intent to program DNS with
+// information about endpoints for the Kubernetes Service resources with the
+// same name and namespace in different clusters.
+//
+// For the example, given the following values:
+//
+// metadata.name: test-service
+// metadata.namespace: test-namespace
+// spec.federationName: test-federation
+// spec.dnsSuffix: example.com
+//
+// the following set of DNS names will be programmed:
+//
+// Global Level: test-service.test-namespace.test-federation.svc.example.com
+// Region Level: test-service.test-namespace.test-federation.svc.(status.DNS[*].region).example.com
+// Zone Level  : test-service.test-namespace.test-federation.svc.(status.DNS[*].zone).(status.DNS[*].region).example.com
+//
 // +k8s:openapi-gen=true
 // +kubebuilder:resource:path=servicednsrecords
 // +kubebuilder:subresource:status


### PR DESCRIPTION
Adds basic information about service DNS to the API godoc. Since ingress is very similar, I'll make this for DNS only for now, get the verbiage correct in this PR, and then do a follow-up PR to add godoc for ingress as well.