### PR TITLE
Randomize order of test execution in ci

### DIFF
--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -23,7 +23,7 @@ set -o pipefail
 source "$(dirname "${BASH_SOURCE}")/util.sh"
 ROOT_DIR="$(cd "$(dirname "$0")/.." ; pwd)"
 MAKE_CMD="make -C ${ROOT_DIR}"
-E2E_TEST_CMD="go test -v ./test/e2e -args -kubeconfig=${HOME}/.kube/config -ginkgo.v -single-call-timeout=1m -ginkgo.trace"
+E2E_TEST_CMD="go test -v ./test/e2e -args -kubeconfig=${HOME}/.kube/config -ginkgo.v -single-call-timeout=1m -ginkgo.trace -ginkgo.randomizeAllSpecs"
 
 function build-binaries() {
   ${MAKE_CMD} controller


### PR DESCRIPTION
This should flush out unexpected test dependencies.

Reference: https://onsi.github.io/ginkgo/#the-spec-runner