### PR TITLE
Use ownerReference to ensure PropagatedVersion removal 

### DIFF
--- a/pkg/controller/sync/controller.go
+++ b/pkg/controller/sync/controller.go
@@ -489,10 +489,7 @@ func (s *FederationSyncController) delete(template pkgruntime.Object,
 		return nil
 	}
 
-	err = s.versionManager.Delete(qualifiedName)
-	if err != nil {
-		return err
-	}
+	s.versionManager.Delete(qualifiedName)
 
 	err = s.templateClient.Resources(qualifiedName.Namespace).Delete(qualifiedName.Name, nil)
 	if err != nil {

--- a/pkg/controller/sync/version/adapter.go
+++ b/pkg/controller/sync/version/adapter.go
@@ -17,6 +17,7 @@ limitations under the License.
 package version
 
 import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	pkgruntime "k8s.io/apimachinery/pkg/runtime"
 
 	fedv1a1 "github.com/kubernetes-sigs/federation-v2/pkg/apis/core/v1alpha1"
@@ -27,7 +28,7 @@ type VersionAdapter interface {
 	TypeName() string
 
 	// Create a new instance of the version type
-	NewVersion(qualifiedName util.QualifiedName, status *fedv1a1.PropagatedVersionStatus) pkgruntime.Object
+	NewVersion(qualifiedName util.QualifiedName, ownerReference metav1.OwnerReference, status *fedv1a1.PropagatedVersionStatus) pkgruntime.Object
 
 	// Type-agnostic access / mutation of the Status field of a version resource
 	GetStatus(obj pkgruntime.Object) *fedv1a1.PropagatedVersionStatus
@@ -35,7 +36,6 @@ type VersionAdapter interface {
 
 	// Methods that interact with the API
 	Create(obj pkgruntime.Object) (pkgruntime.Object, error)
-	Delete(qualifiedName util.QualifiedName) error
 	Get(qualifiedName util.QualifiedName) (pkgruntime.Object, error)
 	List(namespace string) (pkgruntime.Object, error)
 	UpdateStatus(obj pkgruntime.Object) (pkgruntime.Object, error)

--- a/pkg/controller/sync/version/namespaced.go
+++ b/pkg/controller/sync/version/namespaced.go
@@ -42,11 +42,14 @@ func (a *namespacedVersionAdapter) List(namespace string) (pkgruntime.Object, er
 	return a.client.PropagatedVersions(namespace).List(metav1.ListOptions{})
 }
 
-func (a *namespacedVersionAdapter) NewVersion(qualifiedName util.QualifiedName, status *fedv1a1.PropagatedVersionStatus) pkgruntime.Object {
+func (a *namespacedVersionAdapter) NewVersion(qualifiedName util.QualifiedName, ownerReference metav1.OwnerReference, status *fedv1a1.PropagatedVersionStatus) pkgruntime.Object {
 	return &fedv1a1.PropagatedVersion{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: qualifiedName.Namespace,
 			Name:      qualifiedName.Name,
+			OwnerReferences: []metav1.OwnerReference{
+				ownerReference,
+			},
 		},
 		Status: *status,
 	}
@@ -70,10 +73,6 @@ func (a *namespacedVersionAdapter) Create(obj pkgruntime.Object) (pkgruntime.Obj
 
 func (a *namespacedVersionAdapter) Get(qualifiedName util.QualifiedName) (pkgruntime.Object, error) {
 	return a.client.PropagatedVersions(qualifiedName.Namespace).Get(qualifiedName.Name, metav1.GetOptions{})
-}
-
-func (a *namespacedVersionAdapter) Delete(qualifiedName util.QualifiedName) error {
-	return a.client.PropagatedVersions(qualifiedName.Namespace).Delete(qualifiedName.Name, nil)
 }
 
 func (a *namespacedVersionAdapter) UpdateStatus(obj pkgruntime.Object) (pkgruntime.Object, error) {

--- a/test/common/crudtester.go
+++ b/test/common/crudtester.go
@@ -291,23 +291,7 @@ func (c *FederatedTypeCrudTester) CheckDelete(template *unstructured.Unstructure
 		c.tl.Fatalf("Error deleting %s %q: %v", templateKind, qualifiedName, err)
 	}
 
-	// Version tracker should also be removed. Wait for it to be removed.
 	targetKind := c.typeConfig.GetTarget().Kind
-	versionName := common.PropagatedVersionName(targetKind, name)
-	err = wait.PollImmediate(c.waitInterval, waitTimeout, func() (bool, error) {
-		if targetKind == util.NamespaceKind {
-			_, err = c.fedClient.CoreV1alpha1().PropagatedVersions(name).Get(versionName, metav1.GetOptions{})
-		} else {
-			_, err = c.fedClient.CoreV1alpha1().PropagatedVersions(namespace).Get(versionName, metav1.GetOptions{})
-		}
-		if errors.IsNotFound(err) {
-			return true, nil
-		}
-		return false, err
-	})
-	if err != nil {
-		c.tl.Fatalf("Expecting PropagatedVersion %s to be deleted", versionName)
-	}
 
 	var stateMsg string = "present"
 	if deletingInCluster {


### PR DESCRIPTION
Previously `VersionManager` was explicitly deleting version resources, but the inability to lock across cache and API modifications left open the possibility of version resources being orphaned.  This PR switches to creating `PropagatedVersion` resources with an `ownerReference` for its template, which leverages the garbage collector to ensure (eventual) removal of a given template's version resource.