### PR TITLE
Fix version manager iteration

### DIFF
--- a/pkg/controller/sync/version/adapter.go
+++ b/pkg/controller/sync/version/adapter.go
@@ -23,15 +23,8 @@ import (
 	"github.com/kubernetes-sigs/federation-v2/pkg/controller/util"
 )
 
-// Accepts an object, returns a boolean indication of whether the
-// object was processed successfully.
-type iterationHandler func(obj pkgruntime.Object) bool
-
 type VersionAdapter interface {
 	TypeName() string
-
-	// Iterate over a list of the concrete version type, calling the handler for each item.
-	Iterate(versionList pkgruntime.Object, handler iterationHandler) bool
 
 	// Create a new instance of the version type
 	NewVersion(qualifiedName util.QualifiedName, status *fedv1a1.PropagatedVersionStatus) pkgruntime.Object

--- a/pkg/controller/sync/version/namespaced.go
+++ b/pkg/controller/sync/version/namespaced.go
@@ -42,16 +42,6 @@ func (a *namespacedVersionAdapter) List(namespace string) (pkgruntime.Object, er
 	return a.client.PropagatedVersions(namespace).List(metav1.ListOptions{})
 }
 
-func (a *namespacedVersionAdapter) Iterate(versionList pkgruntime.Object, handler iterationHandler) bool {
-	propagatedVersionList := versionList.(*fedv1a1.PropagatedVersionList)
-	for _, version := range propagatedVersionList.Items {
-		if !handler(&version) {
-			return false
-		}
-	}
-	return true
-}
-
 func (a *namespacedVersionAdapter) NewVersion(qualifiedName util.QualifiedName, status *fedv1a1.PropagatedVersionStatus) pkgruntime.Object {
 	return &fedv1a1.PropagatedVersion{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
The `meta` package has methods for generically iterating over arbitrary list types, which removes the need for involving a type-specific adapter.