### PR TITLE
Adds FederatedClusterRole Examples and Test Fixture 

### DIFF
--- a/example/sample1/federatedclusterrole-placement.yaml
+++ b/example/sample1/federatedclusterrole-placement.yaml
@@ -1,11 +1,8 @@
-apiVersion: v1
-kind: List
-items:
-- apiVersion: generated.federation.k8s.io/v1alpha1
-  kind: FederatedClusterRolePlacement
-  metadata:
-    name: test-clusterrole
-  spec:
-    clusterNames:
-    - cluster2
-    - cluster1
+apiVersion: generated.federation.k8s.io/v1alpha1
+kind: FederatedClusterRolePlacement
+metadata:
+  name: test-clusterrole
+spec:
+  clusterNames:
+  - cluster2
+  - cluster1

--- a/example/sample1/federatedclusterrole-placement.yaml
+++ b/example/sample1/federatedclusterrole-placement.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: List
+items:
+- apiVersion: generated.federation.k8s.io/v1alpha1
+  kind: FederatedClusterRolePlacement
+  metadata:
+    name: test-clusterrole
+  spec:
+    clusterNames:
+    - cluster2
+    - cluster1

--- a/example/sample1/federatedclusterrole-template.yaml
+++ b/example/sample1/federatedclusterrole-template.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: List
+items:
+- apiVersion: generated.federation.k8s.io/v1alpha1
+  kind: FederatedClusterRole
+  metadata:
+    name: test-clusterrole
+  spec:
+    template:
+      rules:
+      - apiGroups:
+        - '*'
+        resources:
+        - '*'
+        verbs:
+        - '*'

--- a/example/sample1/federatedclusterrole-template.yaml
+++ b/example/sample1/federatedclusterrole-template.yaml
@@ -1,16 +1,13 @@
-apiVersion: v1
-kind: List
-items:
-- apiVersion: generated.federation.k8s.io/v1alpha1
-  kind: FederatedClusterRole
-  metadata:
-    name: test-clusterrole
-  spec:
-    template:
-      rules:
-      - apiGroups:
-        - '*'
-        resources:
-        - '*'
-        verbs:
-        - '*'
+apiVersion: generated.federation.k8s.io/v1alpha1
+kind: FederatedClusterRole
+metadata:
+  name: test-clusterrole
+spec:
+  template:
+    rules:
+    - apiGroups:
+      - '*'
+      resources:
+      - '*'
+      verbs:
+      - '*'

--- a/test/common/fixtures/clusterrole-template.yaml
+++ b/test/common/fixtures/clusterrole-template.yaml
@@ -1,0 +1,13 @@
+apiVersion: generated.federation.k8s.io/v1alpha1
+kind: FederatedClusterRole
+metadata:
+  name: placeholder
+spec:
+  template:
+    rules:
+    - apiGroups:
+      - '*'
+      resources:
+      - '*'
+      verbs:
+      - '*'


### PR DESCRIPTION
__NOTE:__ This PR is not ready for review until https://github.com/kubernetes-sigs/federation-v2/pull/340 has merged.

Adds examples and test fixture for `FederatedClusterRole` and `FederatedClusterRolePlacement` resources using `generated.federation.k8s.io` API.