### PR TITLE
Add 'kubefed2 federate' command

### DIFF
--- a/pkg/apis/core/typeconfig/interface.go
+++ b/pkg/apis/core/typeconfig/interface.go
@@ -23,6 +23,7 @@ import (
 
 // Interface defines how to interact with a FederatedTypeConfig
 type Interface interface {
+	GetObjectMeta() metav1.ObjectMeta
 	GetTarget() metav1.APIResource
 	GetNamespaced() bool
 	GetComparisonField() common.VersionComparisonField

--- a/pkg/apis/core/v1alpha1/federatedtypeconfig_types.go
+++ b/pkg/apis/core/v1alpha1/federatedtypeconfig_types.go
@@ -164,6 +164,10 @@ func PluralName(kind string) string {
 	return fmt.Sprintf("%ss", lowerKind)
 }
 
+func (f *FederatedTypeConfig) GetObjectMeta() metav1.ObjectMeta {
+	return f.ObjectMeta
+}
+
 func (f *FederatedTypeConfig) GetTarget() metav1.APIResource {
 	return apiResourceToMeta(f.Spec.Target, f.Spec.Namespaced)
 }

--- a/pkg/kubefed2/federate.go
+++ b/pkg/kubefed2/federate.go
@@ -1,0 +1,435 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubefed2
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/golang/glog"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	apiextv1b1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	apiextv1b1client "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/rest"
+
+	apicommon "github.com/kubernetes-sigs/federation-v2/pkg/apis/core/common"
+	"github.com/kubernetes-sigs/federation-v2/pkg/apis/core/typeconfig"
+	fedv1a1 "github.com/kubernetes-sigs/federation-v2/pkg/apis/core/v1alpha1"
+	ctlutil "github.com/kubernetes-sigs/federation-v2/pkg/controller/util"
+	"github.com/kubernetes-sigs/federation-v2/pkg/kubefed2/options"
+	"github.com/kubernetes-sigs/federation-v2/pkg/kubefed2/util"
+)
+
+var (
+	federate_long = `
+	Federate enables a Kubernetes API type (including a CRD) to be
+	propagated to members of a federation.  Federation primitives will be
+	generated as CRDs and a FederatedTypeConfig will be created to
+	configure a sync controller.
+
+    Current context is assumed to be a Kubernetes cluster
+    hosting the federation control plane. Please use the
+    --host-cluster-context flag otherwise.`
+
+	federate_example = `
+	# Enable federation of a Kubernetes type by specifying the name,
+	# shortname, or kind of the target type. The context of the
+	# federation control plane's host cluster must be supplied if it
+	# is not the current context.
+	kubefed2 federate NAME --host-cluster-context=bar`
+)
+
+type federateType struct {
+	options.SubcommandOptions
+	federateTypeOptions
+}
+
+type federateTypeOptions struct {
+	targetName         string
+	rawComparisonField string
+	comparisonField    apicommon.VersionComparisonField
+	rawOverridePaths   string
+	overridePaths      []string
+	templateVersion    string
+	templateGroup      string
+	useExistingCRDs    bool
+}
+
+// Bind adds the join specific arguments to the flagset passed in as an
+// argument.
+func (o *federateTypeOptions) Bind(flags *pflag.FlagSet) {
+	flags.StringVar(&o.rawComparisonField, "comparison-field", string(apicommon.ResourceVersionField),
+		fmt.Sprintf("The field in the target type to compare for equality. Valid values are %q (default) and %q.",
+			apicommon.ResourceVersionField, apicommon.GenerationField,
+		),
+	)
+	flags.StringVar(&o.rawOverridePaths, "override-paths", "", "A common-separated list of dot-separated paths (e.g. spec.completions,spec.parallelism).")
+	flags.StringVar(&o.templateGroup, "template-group", "generated.federation.k8s.io", "The name of the API group of the target API type.")
+	flags.StringVar(&o.templateVersion, "template-version", "v1alpha1", "The API version of the target API type.")
+	flags.BoolVar(&o.useExistingCRDs, "use-existing-crds", false, "Whether to reuse existing primitive CRDs.")
+}
+
+// NewCmdFederate defines the `federate` command that enables
+// federation of a Kubernetes API type.
+func NewCmdFederate(cmdOut io.Writer, config util.FedConfig) *cobra.Command {
+	opts := &federateType{}
+
+	cmd := &cobra.Command{
+		Use:     "federate NAME",
+		Short:   "Enable propagation of a Kubernetes API type",
+		Long:    federate_long,
+		Example: federate_example,
+		Run: func(cmd *cobra.Command, args []string) {
+			err := opts.Complete(args)
+			if err != nil {
+				glog.Fatalf("error: %v", err)
+			}
+
+			err = opts.Run(cmdOut, config)
+			if err != nil {
+				glog.Fatalf("error: %v", err)
+			}
+		},
+	}
+
+	flags := cmd.Flags()
+	opts.CommonBind(flags)
+	opts.Bind(flags)
+
+	return cmd
+}
+
+// Complete ensures that options are valid and marshals them if necessary.
+func (j *federateType) Complete(args []string) error {
+	if len(args) == 0 {
+		return fmt.Errorf("NAME is required")
+	}
+	j.targetName = args[0]
+
+	if j.rawComparisonField == string(apicommon.ResourceVersionField) ||
+		j.rawComparisonField == string(apicommon.GenerationField) {
+		j.comparisonField = apicommon.VersionComparisonField(j.rawComparisonField)
+	} else {
+		return fmt.Errorf("--comparison-field must be %q or %q",
+			apicommon.ResourceVersionField, apicommon.GenerationField,
+		)
+	}
+	if len(j.rawOverridePaths) > 0 {
+		j.overridePaths = strings.Split(j.rawOverridePaths, ",")
+	}
+	if len(j.templateGroup) == 0 {
+		return fmt.Errorf("--template-group is a mandatory parameter ")
+	}
+	if len(j.templateVersion) == 0 {
+		return fmt.Errorf("--template-version is a mandatory parameter")
+	}
+
+	return nil
+}
+
+// Run is the implementation of the `federate` command.
+func (j *federateType) Run(cmdOut io.Writer, config util.FedConfig) error {
+	hostConfig, err := config.HostConfig(j.HostClusterContext, j.Kubeconfig)
+	if err != nil {
+		return fmt.Errorf("Failed to get host cluster config: %v", err)
+	}
+
+	_, err = EnableFederation(hostConfig, j.FederationNamespace, j.targetName, j.templateGroup,
+		j.templateVersion, j.comparisonField, j.overridePaths, j.useExistingCRDs, j.DryRun)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// TODO(marun) Allow updates to the configuration for a type that has
+// already been enabled for federation.  This would likely involve
+// updating the version of the target type and the validation of the schema.
+func EnableFederation(config *rest.Config, federationNamespace, key, templateGroup,
+	templateVersion string, comparisonField apicommon.VersionComparisonField,
+	overridePaths []string, useExisting, dryRun bool) (typeconfig.Interface, error) {
+
+	apiResource, err := lookupAPIResource(config, key)
+	if err != nil {
+		return nil, err
+	}
+	glog.V(2).Infof("Found resource %q", resourceKey(*apiResource))
+
+	typeConfig := TypeConfigForTarget(*apiResource, comparisonField, overridePaths, templateGroup, templateVersion)
+
+	if dryRun {
+		// Avoid mutating the API
+		return nil, nil
+	}
+
+	crdClient, err := apiextv1b1client.NewForConfig(config)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to create crd clientset: %v", err)
+	}
+	// TODO(marun) Retrieve the validation schema of the target and
+	// use it in constructing the schema for the template.
+	err = CreatePrimitives(crdClient, typeConfig, useExisting)
+	if err != nil {
+		return nil, err
+	}
+
+	fedClient, err := util.FedClientset(config)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to get federation clientset: %v", err)
+	}
+	concreteTypeConfig := typeConfig.(*fedv1a1.FederatedTypeConfig)
+	createdTypeConfig, err := fedClient.CoreV1alpha1().FederatedTypeConfigs(federationNamespace).Create(concreteTypeConfig)
+	if err != nil {
+		return nil, fmt.Errorf("Error creating FederatedTypeConfig %q: %v", concreteTypeConfig.Name, err)
+	}
+
+	return createdTypeConfig, nil
+}
+
+// TODO(marun) expose via subcommand
+func DisableFederation(config *rest.Config, typeConfigName ctlutil.QualifiedName, delete, dryRun bool) error {
+	fedClient, err := util.FedClientset(config)
+	if err != nil {
+		return fmt.Errorf("Failed to get federation clientset: %v", err)
+	}
+	typeConfig, err := fedClient.CoreV1alpha1().FederatedTypeConfigs(typeConfigName.Namespace).Get(typeConfigName.Name, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("Error retrieving FederatedTypeConfig %q: %v", typeConfigName, err)
+	}
+
+	if dryRun {
+		return nil
+	}
+
+	typeConfig.Spec.PropagationEnabled = false
+	_, err = fedClient.CoreV1alpha1().FederatedTypeConfigs(typeConfig.Namespace).Update(typeConfig)
+	if err != nil {
+		return fmt.Errorf("Error disabling propagation for FederatedTypeConfig %q: %v", typeConfigName, err)
+	}
+
+	// TODO(marun) consider waiting for the sync controller to be stopped before attempting deletion
+	if delete {
+		deletePrimitives(config, typeConfig)
+		err = fedClient.CoreV1alpha1().FederatedTypeConfigs(typeConfigName.Namespace).Delete(typeConfigName.Name, nil)
+		if err != nil {
+			return fmt.Errorf("Error deleting FederatedTypeConfig %q: %v", typeConfigName, err)
+		}
+	}
+
+	return nil
+}
+
+func deletePrimitives(config *rest.Config, typeConfig typeconfig.Interface) error {
+	client, err := apiextv1b1client.NewForConfig(config)
+	if err != nil {
+		return fmt.Errorf("Error creating crd client: %v", err)
+	}
+
+	crdNames := primitiveCRDNames(typeConfig)
+	for _, crdName := range crdNames {
+		err := client.CustomResourceDefinitions().Delete(crdName, nil)
+		if err != nil && !errors.IsNotFound(err) {
+			return fmt.Errorf("Failed to delete crd %q: %v", crdName, err)
+		}
+	}
+
+	return nil
+}
+
+func primitiveCRDNames(typeConfig typeconfig.Interface) []string {
+	names := []string{
+		groupQualifiedName(typeConfig.GetTemplate()),
+		groupQualifiedName(typeConfig.GetPlacement()),
+	}
+	overrideAPIResource := typeConfig.GetOverride()
+	if overrideAPIResource != nil {
+		names = append(names, groupQualifiedName(*overrideAPIResource))
+	}
+	return names
+}
+
+func lookupAPIResource(config *rest.Config, key string) (*metav1.APIResource, error) {
+	client, err := discovery.NewDiscoveryClientForConfig(config)
+	if err != nil {
+		return nil, fmt.Errorf("Error creating discovery client: %v", err)
+	}
+
+	// TODO(marun) Allow the targeting of a specific group
+	// TODO(marun) Allow the targeting of a specific version
+
+	resourceLists, err := client.ServerPreferredResources()
+	if err != nil {
+		return nil, fmt.Errorf("Error listing api resources: %v", err)
+	}
+
+	// TODO(marun) Consider using a caching scheme ala kubectl
+	var targetResource *metav1.APIResource
+	for _, resourceList := range resourceLists {
+		for _, resource := range resourceList.APIResources {
+			if key == resource.Name ||
+				key == resource.SingularName ||
+				key == resource.Kind ||
+				key == strings.ToLower(resource.Kind) {
+
+				targetResource = &resource
+				break
+			}
+			for _, shortName := range resource.ShortNames {
+				if key == shortName {
+					targetResource = &resource
+					break
+				}
+			}
+			if targetResource != nil {
+				break
+			}
+		}
+		if targetResource != nil {
+			// The list holds the GroupVersion for its list of APIResources
+			gv, err := schema.ParseGroupVersion(resourceList.GroupVersion)
+			if err != nil {
+				return nil, fmt.Errorf("Error parsing GroupVersion: %v", err)
+			}
+			targetResource.Group = gv.Group
+			targetResource.Version = gv.Version
+			break
+		}
+	}
+
+	if targetResource != nil {
+		return targetResource, nil
+	}
+	return nil, fmt.Errorf("Unable to find api resource named %q.", key)
+}
+
+func resourceKey(apiResource metav1.APIResource) string {
+	var group string
+	if apiResource.Group == "" {
+		group = "core"
+	} else {
+		group = apiResource.Group
+	}
+	var version string
+	if apiResource.Version == "" {
+		version = "v1"
+	} else {
+		version = apiResource.Version
+	}
+	return fmt.Sprintf("%s.%s/%s", apiResource.Name, group, version)
+}
+
+func CreatePrimitives(client *apiextv1b1client.ApiextensionsV1beta1Client, typeConfig typeconfig.Interface, useExisting bool) error {
+	err := CreateCrdFromResource(client, typeConfig.GetTemplate(), useExisting)
+	if err != nil {
+		return err
+	}
+	err = CreateCrdFromResource(client, typeConfig.GetPlacement(), useExisting)
+	if err != nil {
+		return err
+	}
+	overrideAPIResource := typeConfig.GetOverride()
+	if overrideAPIResource == nil {
+		return nil
+	}
+	return CreateCrdFromResource(client, *overrideAPIResource, useExisting)
+}
+
+func CreateCrdFromResource(client *apiextv1b1client.ApiextensionsV1beta1Client, apiResource metav1.APIResource, useExisting bool) error {
+	crd := CrdForAPIResource(apiResource)
+	_, err := client.CustomResourceDefinitions().Create(crd)
+	// TODO(marun) Update the crd to ensure the validation schema can be updated to the latest target type
+	if err == nil || useExisting && errors.IsAlreadyExists(err) {
+		return nil
+	}
+	return fmt.Errorf("Error creating CRD %q: %v", crd.Name, err)
+}
+
+func TypeConfigForTarget(apiResource metav1.APIResource, comparisonField apicommon.VersionComparisonField, overridePaths []string, templateGroup, templateVersion string) typeconfig.Interface {
+	kind := apiResource.Kind
+	typeConfig := &fedv1a1.FederatedTypeConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: groupQualifiedName(apiResource),
+		},
+		Spec: fedv1a1.FederatedTypeConfigSpec{
+			Target: fedv1a1.APIResource{
+				Version: apiResource.Version,
+				Kind:    kind,
+			},
+			Namespaced:         apiResource.Namespaced,
+			ComparisonField:    comparisonField,
+			PropagationEnabled: true,
+			Template: fedv1a1.APIResource{
+				Group:   templateGroup,
+				Version: templateVersion,
+				Kind:    fmt.Sprintf("Federated%s", kind),
+			},
+			Placement: fedv1a1.APIResource{
+				Kind: fmt.Sprintf("Federated%sPlacement", kind),
+			},
+		},
+	}
+	if len(overridePaths) > 0 {
+		typeConfig.Spec.Override = &fedv1a1.APIResource{
+			Kind: fmt.Sprintf("Federated%sOverride", kind),
+		}
+		specPaths := []fedv1a1.OverridePath{}
+		for _, overridePath := range overridePaths {
+			specPaths = append(specPaths, fedv1a1.OverridePath{Path: overridePath})
+		}
+		typeConfig.Spec.OverridePaths = specPaths
+	}
+	// Set defaults that would normally be set by the api
+	fedv1a1.SetFederatedTypeConfigDefaults(typeConfig)
+	return typeConfig
+}
+
+func CrdForAPIResource(apiResource metav1.APIResource) *apiextv1b1.CustomResourceDefinition {
+	scope := apiextv1b1.ClusterScoped
+	if apiResource.Namespaced {
+		scope = apiextv1b1.NamespaceScoped
+	}
+	return &apiextv1b1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: groupQualifiedName(apiResource),
+		},
+		Spec: apiextv1b1.CustomResourceDefinitionSpec{
+			Group:   apiResource.Group,
+			Version: apiResource.Version,
+			Scope:   scope,
+			Names: apiextv1b1.CustomResourceDefinitionNames{
+				Plural:   apiResource.Name,
+				Singular: apiResource.SingularName,
+				Kind:     apiResource.Kind,
+			},
+		},
+	}
+}
+
+func groupQualifiedName(apiResource metav1.APIResource) string {
+	if len(apiResource.Group) == 0 {
+		return apiResource.Name
+	}
+	return fmt.Sprintf("%s.%s", apiResource.Name, apiResource.Group)
+}

--- a/pkg/kubefed2/federate/disable.go
+++ b/pkg/kubefed2/federate/disable.go
@@ -116,7 +116,7 @@ func (j *disableType) Run(cmdOut io.Writer, config util.FedConfig) error {
 		return fmt.Errorf("Failed to get host cluster config: %v", err)
 	}
 
-	apiResource, err := lookupAPIResource(hostConfig, j.targetName)
+	apiResource, err := LookupAPIResource(hostConfig, j.targetName)
 	if err != nil {
 		return err
 	}

--- a/pkg/kubefed2/federate/disable.go
+++ b/pkg/kubefed2/federate/disable.go
@@ -1,0 +1,203 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package federate
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/golang/glog"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	apiextv1b1client "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
+
+	"github.com/kubernetes-sigs/federation-v2/pkg/apis/core/typeconfig"
+	ctlutil "github.com/kubernetes-sigs/federation-v2/pkg/controller/util"
+	"github.com/kubernetes-sigs/federation-v2/pkg/kubefed2/options"
+	"github.com/kubernetes-sigs/federation-v2/pkg/kubefed2/util"
+)
+
+var (
+	disable_long = `
+		Disables propagation of a Kubernetes API type.  This command
+		can also optionally delete the API resources added by the enable
+		command.
+
+		Current context is assumed to be a Kubernetes cluster hosting
+		the federation control plane. Please use the
+		--host-cluster-context flag otherwise.`
+
+	disable_example = `
+		# Disable propagation of the Service type
+		kubefed2 federate disable Service
+
+		# Disable propagation of the Service type and delete API resources
+		kubefed2 federate disable Service --delete-from-api`
+)
+
+type disableType struct {
+	options.SubcommandOptions
+	disableTypeOptions
+}
+
+type disableTypeOptions struct {
+	targetName string
+	delete     bool
+}
+
+// Bind adds the join specific arguments to the flagset passed in as an
+// argument.
+func (o *disableTypeOptions) Bind(flags *pflag.FlagSet) {
+	flags.BoolVar(&o.delete, "delete-from-api", false, "Whether to remove the API resources added by 'enable'.")
+}
+
+// NewCmdFederateDisable defines the `federate disable` command that
+// disables federation of a Kubernetes API type.
+func NewCmdFederateDisable(cmdOut io.Writer, config util.FedConfig) *cobra.Command {
+	opts := &disableType{}
+
+	cmd := &cobra.Command{
+		Use:     "disable NAME",
+		Short:   "Disables propagation of a Kubernetes API type",
+		Long:    disable_long,
+		Example: disable_example,
+		Run: func(cmd *cobra.Command, args []string) {
+			err := opts.Complete(args)
+			if err != nil {
+				glog.Fatalf("error: %v", err)
+			}
+
+			err = opts.Run(cmdOut, config)
+			if err != nil {
+				glog.Fatalf("error: %v", err)
+			}
+		},
+	}
+
+	flags := cmd.Flags()
+	opts.CommonBind(flags)
+	opts.Bind(flags)
+
+	return cmd
+}
+
+// Complete ensures that options are valid and marshals them if necessary.
+func (j *disableType) Complete(args []string) error {
+	if len(args) == 0 {
+		return fmt.Errorf("NAME is required")
+	}
+	j.targetName = args[0]
+
+	return nil
+}
+
+// Run is the implementation of the `federate disable` command.
+func (j *disableType) Run(cmdOut io.Writer, config util.FedConfig) error {
+	hostConfig, err := config.HostConfig(j.HostClusterContext, j.Kubeconfig)
+	if err != nil {
+		return fmt.Errorf("Failed to get host cluster config: %v", err)
+	}
+
+	apiResource, err := lookupAPIResource(hostConfig, j.targetName)
+	if err != nil {
+		return err
+	}
+	glog.V(2).Infof("Found resource %q", resourceKey(*apiResource))
+
+	typeConfigName := ctlutil.QualifiedName{
+		Namespace: j.FederationNamespace,
+		Name:      groupQualifiedName(*apiResource),
+	}
+
+	err = DisableFederation(hostConfig, typeConfigName, j.delete, j.DryRun)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func DisableFederation(config *rest.Config, typeConfigName ctlutil.QualifiedName, delete, dryRun bool) error {
+	fedClient, err := util.FedClientset(config)
+	if err != nil {
+		return fmt.Errorf("Failed to get federation clientset: %v", err)
+	}
+	typeConfig, err := fedClient.CoreV1alpha1().FederatedTypeConfigs(typeConfigName.Namespace).Get(typeConfigName.Name, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("Error retrieving FederatedTypeConfig %q: %v", typeConfigName, err)
+	}
+
+	if dryRun {
+		return nil
+	}
+
+	typeConfig.Spec.PropagationEnabled = false
+	_, err = fedClient.CoreV1alpha1().FederatedTypeConfigs(typeConfig.Namespace).Update(typeConfig)
+	if err != nil {
+		return fmt.Errorf("Error disabling propagation for FederatedTypeConfig %q: %v", typeConfigName, err)
+	}
+	if !delete {
+		return nil
+	}
+
+	// TODO(marun) consider waiting for the sync controller to be stopped before attempting deletion
+	deletePrimitives(config, typeConfig)
+	err = fedClient.CoreV1alpha1().FederatedTypeConfigs(typeConfigName.Namespace).Delete(typeConfigName.Name, nil)
+	if err != nil {
+		return fmt.Errorf("Error deleting FederatedTypeConfig %q: %v", typeConfigName, err)
+	}
+
+	return nil
+}
+
+func deletePrimitives(config *rest.Config, typeConfig typeconfig.Interface) error {
+	client, err := apiextv1b1client.NewForConfig(config)
+	if err != nil {
+		return fmt.Errorf("Error creating crd client: %v", err)
+	}
+
+	failedDeletion := []string{}
+	crdNames := primitiveCRDNames(typeConfig)
+	for _, crdName := range crdNames {
+		err := client.CustomResourceDefinitions().Delete(crdName, nil)
+		if err != nil && !errors.IsNotFound(err) {
+			glog.Errorf("Failed to delete crd %q: %v", crdName, err)
+			failedDeletion = append(failedDeletion, crdName)
+		}
+	}
+	if len(failedDeletion) > 0 {
+		return fmt.Errorf("The following crds were not deleted successfully (see error log for details): %v", failedDeletion)
+	}
+
+	return nil
+}
+
+func primitiveCRDNames(typeConfig typeconfig.Interface) []string {
+	names := []string{
+		groupQualifiedName(typeConfig.GetTemplate()),
+		groupQualifiedName(typeConfig.GetPlacement()),
+	}
+	overrideAPIResource := typeConfig.GetOverride()
+	if overrideAPIResource != nil {
+		names = append(names, groupQualifiedName(*overrideAPIResource))
+	}
+	return names
+}

--- a/pkg/kubefed2/federate/enable.go
+++ b/pkg/kubefed2/federate/enable.go
@@ -164,7 +164,7 @@ func EnableFederation(config *rest.Config, federationNamespace, key, templateGro
 	templateVersion string, comparisonField apicommon.VersionComparisonField,
 	overridePaths []string, useExisting, dryRun bool) (typeconfig.Interface, error) {
 
-	apiResource, err := lookupAPIResource(config, key)
+	apiResource, err := LookupAPIResource(config, key)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kubefed2/federate/enable.go
+++ b/pkg/kubefed2/federate/enable.go
@@ -25,18 +25,14 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
-	apiextv1b1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	apiextv1b1client "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/rest"
 
 	apicommon "github.com/kubernetes-sigs/federation-v2/pkg/apis/core/common"
 	"github.com/kubernetes-sigs/federation-v2/pkg/apis/core/typeconfig"
 	fedv1a1 "github.com/kubernetes-sigs/federation-v2/pkg/apis/core/v1alpha1"
-	ctlutil "github.com/kubernetes-sigs/federation-v2/pkg/controller/util"
 	"github.com/kubernetes-sigs/federation-v2/pkg/kubefed2/options"
 	"github.com/kubernetes-sigs/federation-v2/pkg/kubefed2/util"
 )
@@ -174,7 +170,7 @@ func EnableFederation(config *rest.Config, federationNamespace, key, templateGro
 	}
 	glog.V(2).Infof("Found resource %q", resourceKey(*apiResource))
 
-	typeConfig := TypeConfigForTarget(*apiResource, comparisonField, overridePaths, templateGroup, templateVersion)
+	typeConfig := typeConfigForTarget(*apiResource, comparisonField, overridePaths, templateGroup, templateVersion)
 
 	if dryRun {
 		// Avoid mutating the API
@@ -187,7 +183,7 @@ func EnableFederation(config *rest.Config, federationNamespace, key, templateGro
 	}
 	// TODO(marun) Retrieve the validation schema of the target and
 	// use it in constructing the schema for the template.
-	err = CreatePrimitives(crdClient, typeConfig, useExisting)
+	err = createPrimitives(crdClient, typeConfig, useExisting)
 	if err != nil {
 		return nil, err
 	}
@@ -205,165 +201,7 @@ func EnableFederation(config *rest.Config, federationNamespace, key, templateGro
 	return createdTypeConfig, nil
 }
 
-// TODO(marun) expose via subcommand
-func DisableFederation(config *rest.Config, typeConfigName ctlutil.QualifiedName, delete, dryRun bool) error {
-	fedClient, err := util.FedClientset(config)
-	if err != nil {
-		return fmt.Errorf("Failed to get federation clientset: %v", err)
-	}
-	typeConfig, err := fedClient.CoreV1alpha1().FederatedTypeConfigs(typeConfigName.Namespace).Get(typeConfigName.Name, metav1.GetOptions{})
-	if err != nil {
-		return fmt.Errorf("Error retrieving FederatedTypeConfig %q: %v", typeConfigName, err)
-	}
-
-	if dryRun {
-		return nil
-	}
-
-	typeConfig.Spec.PropagationEnabled = false
-	_, err = fedClient.CoreV1alpha1().FederatedTypeConfigs(typeConfig.Namespace).Update(typeConfig)
-	if err != nil {
-		return fmt.Errorf("Error disabling propagation for FederatedTypeConfig %q: %v", typeConfigName, err)
-	}
-
-	// TODO(marun) consider waiting for the sync controller to be stopped before attempting deletion
-	if delete {
-		deletePrimitives(config, typeConfig)
-		err = fedClient.CoreV1alpha1().FederatedTypeConfigs(typeConfigName.Namespace).Delete(typeConfigName.Name, nil)
-		if err != nil {
-			return fmt.Errorf("Error deleting FederatedTypeConfig %q: %v", typeConfigName, err)
-		}
-	}
-
-	return nil
-}
-
-func deletePrimitives(config *rest.Config, typeConfig typeconfig.Interface) error {
-	client, err := apiextv1b1client.NewForConfig(config)
-	if err != nil {
-		return fmt.Errorf("Error creating crd client: %v", err)
-	}
-
-	crdNames := primitiveCRDNames(typeConfig)
-	for _, crdName := range crdNames {
-		err := client.CustomResourceDefinitions().Delete(crdName, nil)
-		if err != nil && !errors.IsNotFound(err) {
-			return fmt.Errorf("Failed to delete crd %q: %v", crdName, err)
-		}
-	}
-
-	return nil
-}
-
-func primitiveCRDNames(typeConfig typeconfig.Interface) []string {
-	names := []string{
-		groupQualifiedName(typeConfig.GetTemplate()),
-		groupQualifiedName(typeConfig.GetPlacement()),
-	}
-	overrideAPIResource := typeConfig.GetOverride()
-	if overrideAPIResource != nil {
-		names = append(names, groupQualifiedName(*overrideAPIResource))
-	}
-	return names
-}
-
-func lookupAPIResource(config *rest.Config, key string) (*metav1.APIResource, error) {
-	client, err := discovery.NewDiscoveryClientForConfig(config)
-	if err != nil {
-		return nil, fmt.Errorf("Error creating discovery client: %v", err)
-	}
-
-	// TODO(marun) Allow the targeting of a specific group
-	// TODO(marun) Allow the targeting of a specific version
-
-	resourceLists, err := client.ServerPreferredResources()
-	if err != nil {
-		return nil, fmt.Errorf("Error listing api resources: %v", err)
-	}
-
-	// TODO(marun) Consider using a caching scheme ala kubectl
-	var targetResource *metav1.APIResource
-	for _, resourceList := range resourceLists {
-		for _, resource := range resourceList.APIResources {
-			if key == resource.Name ||
-				key == resource.SingularName ||
-				key == resource.Kind ||
-				key == strings.ToLower(resource.Kind) {
-
-				targetResource = &resource
-				break
-			}
-			for _, shortName := range resource.ShortNames {
-				if key == shortName {
-					targetResource = &resource
-					break
-				}
-			}
-			if targetResource != nil {
-				break
-			}
-		}
-		if targetResource != nil {
-			// The list holds the GroupVersion for its list of APIResources
-			gv, err := schema.ParseGroupVersion(resourceList.GroupVersion)
-			if err != nil {
-				return nil, fmt.Errorf("Error parsing GroupVersion: %v", err)
-			}
-			targetResource.Group = gv.Group
-			targetResource.Version = gv.Version
-			break
-		}
-	}
-
-	if targetResource != nil {
-		return targetResource, nil
-	}
-	return nil, fmt.Errorf("Unable to find api resource named %q.", key)
-}
-
-func resourceKey(apiResource metav1.APIResource) string {
-	var group string
-	if apiResource.Group == "" {
-		group = "core"
-	} else {
-		group = apiResource.Group
-	}
-	var version string
-	if apiResource.Version == "" {
-		version = "v1"
-	} else {
-		version = apiResource.Version
-	}
-	return fmt.Sprintf("%s.%s/%s", apiResource.Name, group, version)
-}
-
-func CreatePrimitives(client *apiextv1b1client.ApiextensionsV1beta1Client, typeConfig typeconfig.Interface, useExisting bool) error {
-	err := CreateCrdFromResource(client, typeConfig.GetTemplate(), useExisting)
-	if err != nil {
-		return err
-	}
-	err = CreateCrdFromResource(client, typeConfig.GetPlacement(), useExisting)
-	if err != nil {
-		return err
-	}
-	overrideAPIResource := typeConfig.GetOverride()
-	if overrideAPIResource == nil {
-		return nil
-	}
-	return CreateCrdFromResource(client, *overrideAPIResource, useExisting)
-}
-
-func CreateCrdFromResource(client *apiextv1b1client.ApiextensionsV1beta1Client, apiResource metav1.APIResource, useExisting bool) error {
-	crd := CrdForAPIResource(apiResource)
-	_, err := client.CustomResourceDefinitions().Create(crd)
-	// TODO(marun) Update the crd to ensure the validation schema can be updated to the latest target type
-	if err == nil || useExisting && errors.IsAlreadyExists(err) {
-		return nil
-	}
-	return fmt.Errorf("Error creating CRD %q: %v", crd.Name, err)
-}
-
-func TypeConfigForTarget(apiResource metav1.APIResource, comparisonField apicommon.VersionComparisonField, overridePaths []string, templateGroup, templateVersion string) typeconfig.Interface {
+func typeConfigForTarget(apiResource metav1.APIResource, comparisonField apicommon.VersionComparisonField, overridePaths []string, templateGroup, templateVersion string) typeconfig.Interface {
 	kind := apiResource.Kind
 	typeConfig := &fedv1a1.FederatedTypeConfig{
 		ObjectMeta: metav1.ObjectMeta{
@@ -402,31 +240,28 @@ func TypeConfigForTarget(apiResource metav1.APIResource, comparisonField apicomm
 	return typeConfig
 }
 
-func CrdForAPIResource(apiResource metav1.APIResource) *apiextv1b1.CustomResourceDefinition {
-	scope := apiextv1b1.ClusterScoped
-	if apiResource.Namespaced {
-		scope = apiextv1b1.NamespaceScoped
+func createPrimitives(client *apiextv1b1client.ApiextensionsV1beta1Client, typeConfig typeconfig.Interface, useExisting bool) error {
+	err := createCrdFromResource(client, typeConfig.GetTemplate(), useExisting)
+	if err != nil {
+		return err
 	}
-	return &apiextv1b1.CustomResourceDefinition{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: groupQualifiedName(apiResource),
-		},
-		Spec: apiextv1b1.CustomResourceDefinitionSpec{
-			Group:   apiResource.Group,
-			Version: apiResource.Version,
-			Scope:   scope,
-			Names: apiextv1b1.CustomResourceDefinitionNames{
-				Plural:   apiResource.Name,
-				Singular: apiResource.SingularName,
-				Kind:     apiResource.Kind,
-			},
-		},
+	err = createCrdFromResource(client, typeConfig.GetPlacement(), useExisting)
+	if err != nil {
+		return err
 	}
+	overrideAPIResource := typeConfig.GetOverride()
+	if overrideAPIResource == nil {
+		return nil
+	}
+	return createCrdFromResource(client, *overrideAPIResource, useExisting)
 }
 
-func groupQualifiedName(apiResource metav1.APIResource) string {
-	if len(apiResource.Group) == 0 {
-		return apiResource.Name
+func createCrdFromResource(client *apiextv1b1client.ApiextensionsV1beta1Client, apiResource metav1.APIResource, useExisting bool) error {
+	crd := CrdForAPIResource(apiResource)
+	_, err := client.CustomResourceDefinitions().Create(crd)
+	// TODO(marun) Update the crd to ensure the validation schema can be updated to the latest target type
+	if err == nil || useExisting && errors.IsAlreadyExists(err) {
+		return nil
 	}
-	return fmt.Sprintf("%s.%s", apiResource.Name, apiResource.Group)
+	return fmt.Errorf("Error creating CRD %q: %v", crd.Name, err)
 }

--- a/pkg/kubefed2/federate/enable.go
+++ b/pkg/kubefed2/federate/enable.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package kubefed2
+package federate
 
 import (
 	"fmt"
@@ -42,30 +42,27 @@ import (
 )
 
 var (
-	federate_long = `
-	Federate enables a Kubernetes API type (including a CRD) to be
-	propagated to members of a federation.  Federation primitives will be
-	generated as CRDs and a FederatedTypeConfig will be created to
-	configure a sync controller.
+	enable_long = `
+		Enables a Kubernetes API type (including a CRD) to be propagated
+		to members of a federation.  Federation primitives will be
+		generated as CRDs and a FederatedTypeConfig will be created to
+		configure a sync controller.
 
-    Current context is assumed to be a Kubernetes cluster
-    hosting the federation control plane. Please use the
-    --host-cluster-context flag otherwise.`
+		Current context is assumed to be a Kubernetes cluster hosting
+		the federation control plane. Please use the
+		--host-cluster-context flag otherwise.`
 
-	federate_example = `
-	# Enable federation of a Kubernetes type by specifying the name,
-	# shortname, or kind of the target type. The context of the
-	# federation control plane's host cluster must be supplied if it
-	# is not the current context.
-	kubefed2 federate NAME --host-cluster-context=bar`
+	enable_example = `
+		# Enable federation of Services with service type overrideable
+		kubefed2 federate enable Service --override-paths=spec.type --host-cluster-context=cluster1`
 )
 
-type federateType struct {
+type enableType struct {
 	options.SubcommandOptions
-	federateTypeOptions
+	enableTypeOptions
 }
 
-type federateTypeOptions struct {
+type enableTypeOptions struct {
 	targetName         string
 	rawComparisonField string
 	comparisonField    apicommon.VersionComparisonField
@@ -78,7 +75,7 @@ type federateTypeOptions struct {
 
 // Bind adds the join specific arguments to the flagset passed in as an
 // argument.
-func (o *federateTypeOptions) Bind(flags *pflag.FlagSet) {
+func (o *enableTypeOptions) Bind(flags *pflag.FlagSet) {
 	flags.StringVar(&o.rawComparisonField, "comparison-field", string(apicommon.ResourceVersionField),
 		fmt.Sprintf("The field in the target type to compare for equality. Valid values are %q (default) and %q.",
 			apicommon.ResourceVersionField, apicommon.GenerationField,
@@ -90,16 +87,16 @@ func (o *federateTypeOptions) Bind(flags *pflag.FlagSet) {
 	flags.BoolVar(&o.useExistingCRDs, "use-existing-crds", false, "Whether to reuse existing primitive CRDs.")
 }
 
-// NewCmdFederate defines the `federate` command that enables
-// federation of a Kubernetes API type.
-func NewCmdFederate(cmdOut io.Writer, config util.FedConfig) *cobra.Command {
-	opts := &federateType{}
+// NewCmdFederateEnable defines the `federate enable` command that
+// enables federation of a Kubernetes API type.
+func NewCmdFederateEnable(cmdOut io.Writer, config util.FedConfig) *cobra.Command {
+	opts := &enableType{}
 
 	cmd := &cobra.Command{
-		Use:     "federate NAME",
-		Short:   "Enable propagation of a Kubernetes API type",
-		Long:    federate_long,
-		Example: federate_example,
+		Use:     "enable NAME",
+		Short:   "Enables propagation of a Kubernetes API type",
+		Long:    enable_long,
+		Example: enable_example,
 		Run: func(cmd *cobra.Command, args []string) {
 			err := opts.Complete(args)
 			if err != nil {
@@ -121,7 +118,7 @@ func NewCmdFederate(cmdOut io.Writer, config util.FedConfig) *cobra.Command {
 }
 
 // Complete ensures that options are valid and marshals them if necessary.
-func (j *federateType) Complete(args []string) error {
+func (j *enableType) Complete(args []string) error {
 	if len(args) == 0 {
 		return fmt.Errorf("NAME is required")
 	}
@@ -148,8 +145,8 @@ func (j *federateType) Complete(args []string) error {
 	return nil
 }
 
-// Run is the implementation of the `federate` command.
-func (j *federateType) Run(cmdOut io.Writer, config util.FedConfig) error {
+// Run is the implementation of the `federate enable` command.
+func (j *enableType) Run(cmdOut io.Writer, config util.FedConfig) error {
 	hostConfig, err := config.HostConfig(j.HostClusterContext, j.Kubeconfig)
 	if err != nil {
 		return fmt.Errorf("Failed to get host cluster config: %v", err)

--- a/pkg/kubefed2/federate/federate.go
+++ b/pkg/kubefed2/federate/federate.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package federate
+
+import (
+	"io"
+
+	"github.com/golang/glog"
+	"github.com/spf13/cobra"
+
+	"github.com/kubernetes-sigs/federation-v2/pkg/kubefed2/util"
+)
+
+var (
+	federate_long = `
+        Enables/disables propagation of Kubernetes API types (including CRDs)
+        to multiple clusters.
+
+        Current context is assumed to be a Kubernetes cluster
+        hosting the federation control plane. Please use the
+        --host-cluster-context flag otherwise.`
+)
+
+// NewCmdFederate creates a command object for the "federate" action,
+// and adds all child commands to it.
+func NewCmdFederate(cmdOut io.Writer, config util.FedConfig) *cobra.Command {
+
+	cmd := &cobra.Command{
+		Use: "federate SUBCOMMAND",
+		DisableFlagsInUseLine: true,
+		Short: "Enable/disable propagation of Kubernetes types to multiple clusters",
+		Long:  federate_long,
+		Run: func(_ *cobra.Command, args []string) {
+			if len(args) < 1 {
+				glog.Fatalf("missing subcommand; \"federate\" is not meant to be run on its own")
+			} else {
+				glog.Fatalf("invalid subcommand: %q", args[0])
+			}
+		},
+	}
+
+	cmd.AddCommand(NewCmdFederateEnable(cmdOut, config))
+
+	return cmd
+}

--- a/pkg/kubefed2/federate/federate.go
+++ b/pkg/kubefed2/federate/federate.go
@@ -54,6 +54,7 @@ func NewCmdFederate(cmdOut io.Writer, config util.FedConfig) *cobra.Command {
 	}
 
 	cmd.AddCommand(NewCmdFederateEnable(cmdOut, config))
+	cmd.AddCommand(NewCmdFederateDisable(cmdOut, config))
 
 	return cmd
 }

--- a/pkg/kubefed2/federate/util.go
+++ b/pkg/kubefed2/federate/util.go
@@ -1,0 +1,126 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package federate
+
+import (
+	"fmt"
+	"strings"
+
+	apiextv1b1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/rest"
+)
+
+func CrdForAPIResource(apiResource metav1.APIResource) *apiextv1b1.CustomResourceDefinition {
+	scope := apiextv1b1.ClusterScoped
+	if apiResource.Namespaced {
+		scope = apiextv1b1.NamespaceScoped
+	}
+	return &apiextv1b1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: groupQualifiedName(apiResource),
+		},
+		Spec: apiextv1b1.CustomResourceDefinitionSpec{
+			Group:   apiResource.Group,
+			Version: apiResource.Version,
+			Scope:   scope,
+			Names: apiextv1b1.CustomResourceDefinitionNames{
+				Plural: apiResource.Name,
+				Kind:   apiResource.Kind,
+			},
+		},
+	}
+}
+
+func lookupAPIResource(config *rest.Config, key string) (*metav1.APIResource, error) {
+	client, err := discovery.NewDiscoveryClientForConfig(config)
+	if err != nil {
+		return nil, fmt.Errorf("Error creating discovery client: %v", err)
+	}
+
+	// TODO(marun) Allow the targeting of a specific group
+	// TODO(marun) Allow the targeting of a specific version
+
+	resourceLists, err := client.ServerPreferredResources()
+	if err != nil {
+		return nil, fmt.Errorf("Error listing api resources: %v", err)
+	}
+
+	// TODO(marun) Consider using a caching scheme ala kubectl
+	lowerKey := strings.ToLower(key)
+	var targetResource *metav1.APIResource
+	for _, resourceList := range resourceLists {
+		for _, resource := range resourceList.APIResources {
+			if lowerKey == resource.Name ||
+				lowerKey == resource.SingularName ||
+				lowerKey == strings.ToLower(resource.Kind) {
+
+				targetResource = &resource
+				break
+			}
+			for _, shortName := range resource.ShortNames {
+				if lowerKey == strings.ToLower(shortName) {
+					targetResource = &resource
+					break
+				}
+			}
+			if targetResource != nil {
+				break
+			}
+		}
+		if targetResource != nil {
+			// The list holds the GroupVersion for its list of APIResources
+			gv, err := schema.ParseGroupVersion(resourceList.GroupVersion)
+			if err != nil {
+				return nil, fmt.Errorf("Error parsing GroupVersion: %v", err)
+			}
+			targetResource.Group = gv.Group
+			targetResource.Version = gv.Version
+			break
+		}
+	}
+
+	if targetResource != nil {
+		return targetResource, nil
+	}
+	return nil, fmt.Errorf("Unable to find api resource named %q.", key)
+}
+
+func resourceKey(apiResource metav1.APIResource) string {
+	var group string
+	if len(apiResource.Group) == 0 {
+		group = "core"
+	} else {
+		group = apiResource.Group
+	}
+	var version string
+	if len(apiResource.Version) == 0 {
+		version = "v1"
+	} else {
+		version = apiResource.Version
+	}
+	return fmt.Sprintf("%s.%s/%s", apiResource.Name, group, version)
+}
+
+func groupQualifiedName(apiResource metav1.APIResource) string {
+	if len(apiResource.Group) == 0 {
+		return apiResource.Name
+	}
+	return fmt.Sprintf("%s.%s", apiResource.Name, apiResource.Group)
+}

--- a/pkg/kubefed2/federate/util.go
+++ b/pkg/kubefed2/federate/util.go
@@ -48,7 +48,7 @@ func CrdForAPIResource(apiResource metav1.APIResource) *apiextv1b1.CustomResourc
 	}
 }
 
-func lookupAPIResource(config *rest.Config, key string) (*metav1.APIResource, error) {
+func LookupAPIResource(config *rest.Config, key string) (*metav1.APIResource, error) {
 	client, err := discovery.NewDiscoveryClientForConfig(config)
 	if err != nil {
 		return nil, fmt.Errorf("Error creating discovery client: %v", err)

--- a/pkg/kubefed2/join.go
+++ b/pkg/kubefed2/join.go
@@ -49,8 +49,8 @@ var (
 		Join adds a cluster to a federation.
 
 		Current context is assumed to be a Kubernetes cluster
-		with an aggregated federation API server. Please use
-		the --host-cluster-context flag otherwise.`
+		hosting the federation control plane. Please use the
+		--host-cluster-context flag otherwise.`
 	join_example = `
 		# Join a cluster to a federation by specifying the
 		# cluster name and the context name of the federation

--- a/pkg/kubefed2/kubefed2.go
+++ b/pkg/kubefed2/kubefed2.go
@@ -20,11 +20,13 @@ import (
 	"flag"
 	"io"
 
-	"github.com/kubernetes-sigs/federation-v2/pkg/kubefed2/util"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	apiserverflag "k8s.io/apiserver/pkg/util/flag"
 	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/kubernetes-sigs/federation-v2/pkg/kubefed2/federate"
+	"github.com/kubernetes-sigs/federation-v2/pkg/kubefed2/util"
 )
 
 // NewKubeFed2Command creates the `kubefed2` command and its nested children.
@@ -51,7 +53,7 @@ func NewKubeFed2Command(out io.Writer) *cobra.Command {
 	flag.CommandLine.Parse(nil)
 
 	fedConfig := util.NewFedConfig(clientcmd.NewDefaultPathOptions())
-	rootCmd.AddCommand(NewCmdFederate(out, fedConfig))
+	rootCmd.AddCommand(federate.NewCmdFederate(out, fedConfig))
 	rootCmd.AddCommand(NewCmdJoin(out, fedConfig))
 	rootCmd.AddCommand(NewCmdUnjoin(out, fedConfig))
 	rootCmd.AddCommand(NewCmdVersion(out))

--- a/pkg/kubefed2/kubefed2.go
+++ b/pkg/kubefed2/kubefed2.go
@@ -50,8 +50,10 @@ func NewKubeFed2Command(out io.Writer) *cobra.Command {
 	// Prevent glog errors about logging before parsing.
 	flag.CommandLine.Parse(nil)
 
-	rootCmd.AddCommand(NewCmdJoin(out, util.NewFedConfig(clientcmd.NewDefaultPathOptions())))
-	rootCmd.AddCommand(NewCmdUnjoin(out, util.NewFedConfig(clientcmd.NewDefaultPathOptions())))
+	fedConfig := util.NewFedConfig(clientcmd.NewDefaultPathOptions())
+	rootCmd.AddCommand(NewCmdFederate(out, fedConfig))
+	rootCmd.AddCommand(NewCmdJoin(out, fedConfig))
+	rootCmd.AddCommand(NewCmdUnjoin(out, fedConfig))
 	rootCmd.AddCommand(NewCmdVersion(out))
 
 	return rootCmd

--- a/test/e2e/crd.go
+++ b/test/e2e/crd.go
@@ -33,7 +33,7 @@ import (
 
 	fedv1a1 "github.com/kubernetes-sigs/federation-v2/pkg/apis/core/v1alpha1"
 	"github.com/kubernetes-sigs/federation-v2/pkg/controller/util"
-	"github.com/kubernetes-sigs/federation-v2/pkg/kubefed2"
+	"github.com/kubernetes-sigs/federation-v2/pkg/kubefed2/federate"
 	"github.com/kubernetes-sigs/federation-v2/test/common"
 	"github.com/kubernetes-sigs/federation-v2/test/e2e/framework"
 
@@ -88,7 +88,7 @@ func validateCrdCrud(f framework.FederationFramework, targetCrdKind string, name
 		Name:       fedv1a1.PluralName(targetCrdKind),
 		Namespaced: namespaced,
 	}
-	targetCrd := kubefed2.CrdForAPIResource(targetAPIResource)
+	targetCrd := federate.CrdForAPIResource(targetAPIResource)
 
 	userAgent := fmt.Sprintf("test-%s-crud", strings.ToLower(targetCrdKind))
 
@@ -109,7 +109,7 @@ func validateCrdCrud(f framework.FederationFramework, targetCrdKind string, name
 
 	hostConfig := f.KubeConfig()
 	overridePaths := []string{"spec.bar"}
-	typeConfig, err := kubefed2.EnableFederation(
+	typeConfig, err := federate.EnableFederation(
 		hostConfig, f.FederationSystemNamespace(), targetAPIResource.Name,
 		targetAPIResource.Group, targetAPIResource.Version,
 		apicommon.ResourceVersionField, overridePaths, false, false,
@@ -124,7 +124,7 @@ func validateCrdCrud(f framework.FederationFramework, targetCrdKind string, name
 		// CRDs is attempted even if the removal of any one CRD fails.
 		objectMeta := typeConfig.GetObjectMeta()
 		qualifiedName := util.QualifiedName{Namespace: objectMeta.Namespace, Name: objectMeta.Name}
-		err := kubefed2.DisableFederation(hostConfig, qualifiedName, delete, dryRun)
+		err := federate.DisableFederation(hostConfig, qualifiedName, delete, dryRun)
 		if err != nil {
 			tl.Fatalf("Error disabling federation of target type %q: %v", targetAPIResource.Kind, err)
 		}

--- a/test/e2e/crd.go
+++ b/test/e2e/crd.go
@@ -125,7 +125,7 @@ func validateCrdCrud(f framework.FederationFramework, targetCrdKind string, name
 	typeConfig, err := federate.EnableFederation(
 		hostConfig, f.FederationSystemNamespace(), targetAPIResource.Name,
 		targetAPIResource.Group, targetAPIResource.Version,
-		apicommon.ResourceVersionField, overridePaths, false, false,
+		apicommon.ResourceVersionField, overridePaths, false,
 	)
 	if err != nil {
 		tl.Fatalf("Error enabling federation of target type %q: %v", targetAPIResource.Kind, err)

--- a/test/e2e/crd.go
+++ b/test/e2e/crd.go
@@ -20,6 +20,9 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/pborman/uuid"
+
+	apicommon "github.com/kubernetes-sigs/federation-v2/pkg/apis/core/common"
 	apiextv1b1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	apiextv1b1client "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -28,9 +31,9 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/dynamic"
 
-	apicommon "github.com/kubernetes-sigs/federation-v2/pkg/apis/core/common"
 	fedv1a1 "github.com/kubernetes-sigs/federation-v2/pkg/apis/core/v1alpha1"
 	"github.com/kubernetes-sigs/federation-v2/pkg/controller/util"
+	"github.com/kubernetes-sigs/federation-v2/pkg/kubefed2"
 	"github.com/kubernetes-sigs/federation-v2/test/common"
 	"github.com/kubernetes-sigs/federation-v2/test/e2e/framework"
 
@@ -40,13 +43,13 @@ import (
 var _ = Describe("Federated CRD resources", func() {
 	f := framework.NewFederationFramework("crd-resources")
 
-	scopes := []apiextv1b1.ResourceScope{
-		apiextv1b1.ClusterScoped,
-		apiextv1b1.NamespaceScoped,
+	namespaceScoped := []bool{
+		true,
+		false,
 	}
-	for i, _ := range scopes {
-		scope := scopes[i]
-		Describe(fmt.Sprintf("with scope=%s", scope), func() {
+	for i, _ := range namespaceScoped {
+		namespaced := namespaceScoped[i]
+		Describe(fmt.Sprintf("with namespaced=%v", namespaced), func() {
 			It("should be created, read, updated and deleted successfully", func() {
 				if framework.TestContext.LimitedScope {
 					// The service account of member clusters for
@@ -58,80 +61,70 @@ var _ = Describe("Federated CRD resources", func() {
 					framework.Skipf("Validation of cr federation is not supported for namespaced federation.")
 				}
 
-				targetCrdKind := "FedTestCrd"
-				if scope == apiextv1b1.ClusterScoped {
-					targetCrdKind = fmt.Sprintf("%s%s", scope, targetCrdKind)
+				// Ensure the name the target is unique to avoid
+				// affecting subsequent test runs if cleanup fails.
+				targetCrdKind := fmt.Sprintf("TestFedTarget-%s", uuid.New()[0:10])
+
+				if !namespaced {
+					targetCrdKind = fmt.Sprintf("Cluster%s", targetCrdKind)
 				}
-				validateCrdCrud(f, targetCrdKind, scope)
+				validateCrdCrud(f, targetCrdKind, namespaced)
 			})
 		})
 	}
+
 })
 
-func validateCrdCrud(f framework.FederationFramework, targetCrdKind string, scope apiextv1b1.ResourceScope) {
+func validateCrdCrud(f framework.FederationFramework, targetCrdKind string, namespaced bool) {
 	tl := framework.NewE2ELogger()
 
-	targetCrd := newTestCrd(targetCrdKind, scope)
-	targetCrdName := targetCrd.GetName()
+	targetAPIResource := metav1.APIResource{
+		Group:      "example.com",
+		Version:    "v1alpha1",
+		Kind:       targetCrdKind,
+		Name:       fedv1a1.PluralName(targetCrdKind),
+		Namespaced: namespaced,
+	}
+	targetCrd := kubefed2.CrdForAPIResource(targetAPIResource)
 
 	userAgent := fmt.Sprintf("test-%s-crud", strings.ToLower(targetCrdKind))
 
 	// Create the target crd in all clusters
 	var pools []dynamic.ClientPool
 	var hostPool dynamic.ClientPool
-	var hostCrdClient *apiextv1b1client.ApiextensionsV1beta1Client
 	for clusterName, clusterConfig := range f.ClusterConfigs(userAgent) {
 		pool := dynamic.NewDynamicClientPool(clusterConfig.Config)
 		pools = append(pools, pool)
 		crdClient := apiextv1b1client.NewForConfigOrDie(clusterConfig.Config)
 		if clusterConfig.IsPrimary {
 			hostPool = pool
-			hostCrdClient = crdClient
 			createCrdForHost(tl, crdClient, targetCrd)
 		} else {
 			createCrd(tl, crdClient, targetCrd, clusterName)
 		}
 	}
 
-	// Create a template crd
-	templateKind := fmt.Sprintf("Federated%s", targetCrdKind)
-	templateCrd := newTestCrd(templateKind, scope)
-	createCrdForHost(tl, hostCrdClient, templateCrd)
-
-	// Create a placement crd
-	placementKind := fmt.Sprintf("Federated%sPlacement", targetCrdKind)
-	placementCrd := newTestCrd(placementKind, scope)
-	createCrdForHost(tl, hostCrdClient, placementCrd)
-
-	// Create a type config for these types
-	version := "v1alpha1"
-	fedNamespace := f.FederationSystemNamespace()
-	typeConfig := &fedv1a1.FederatedTypeConfig{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      targetCrdName,
-			Namespace: fedNamespace,
-		},
-		Spec: fedv1a1.FederatedTypeConfigSpec{
-			Target: fedv1a1.APIResource{
-				Version: version,
-				Kind:    targetCrdKind,
-			},
-			Namespaced:         scope == apiextv1b1.NamespaceScoped,
-			ComparisonField:    apicommon.ResourceVersionField,
-			PropagationEnabled: true,
-			Template: fedv1a1.APIResource{
-				Group:   "example.com",
-				Version: version,
-				Kind:    templateKind,
-			},
-			Placement: fedv1a1.APIResource{
-				Kind: placementKind,
-			},
-		},
+	hostConfig := f.KubeConfig()
+	typeConfig, err := kubefed2.EnableFederation(
+		hostConfig, f.FederationSystemNamespace(), targetAPIResource.Name,
+		targetAPIResource.Group, targetAPIResource.Version,
+		apicommon.ResourceVersionField, nil, false, false,
+	)
+	if err != nil {
+		tl.Fatalf("Error enabling federation of target type %q: %v", targetAPIResource.Kind, err)
 	}
-
-	// Set defaults that would normally be set by the api
-	fedv1a1.SetFederatedTypeConfigDefaults(typeConfig)
+	framework.AddCleanupAction(func() {
+		delete := true
+		dryRun := false
+		// TODO(marun) Make this more resilient so that removal of all
+		// CRDs is attempted even if the removal of any one CRD fails.
+		objectMeta := typeConfig.GetObjectMeta()
+		qualifiedName := util.QualifiedName{Namespace: objectMeta.Namespace, Name: objectMeta.Name}
+		err := kubefed2.DisableFederation(hostConfig, qualifiedName, delete, dryRun)
+		if err != nil {
+			tl.Fatalf("Error disabling federation of target type %q: %v", targetAPIResource.Kind, err)
+		}
+	})
 
 	// Wait for the CRDs to become available in the API
 	for _, pool := range pools {
@@ -140,18 +133,8 @@ func validateCrdCrud(f framework.FederationFramework, targetCrdKind string, scop
 	waitForCrd(hostPool, tl, typeConfig.GetTemplate())
 	waitForCrd(hostPool, tl, typeConfig.GetPlacement())
 
-	// If not using in-memory controllers, create the type
-	// config in the api to ensure a propagation controller
-	// will be started for the crd.
-	if !framework.TestContext.InMemoryControllers {
-		fedClient := f.FedClient(userAgent)
-		_, err := fedClient.CoreV1alpha1().FederatedTypeConfigs(fedNamespace).Create(typeConfig)
-		if err != nil {
-			tl.Fatalf("Error creating FederatedTypeConfig for type %q: %v", targetCrdName, err)
-		}
-		defer fedClient.CoreV1alpha1().FederatedTypeConfigs(fedNamespace).Delete(typeConfig.Name, nil)
-		// TODO(marun) Wait until the controller has started
-	}
+	// TODO(marun) If not using in-memory controllers, wait until the
+	// controller has started.
 
 	testObjectFunc := func(namespace string, clusterNames []string) (template, placement, override *unstructured.Unstructured, err error) {
 		templateYaml := `
@@ -164,12 +147,12 @@ spec:
     spec:
       bar: baz
 `
-		data := fmt.Sprintf(templateYaml, "example.com/v1alpha1", templateKind)
+		data := fmt.Sprintf(templateYaml, "example.com/v1alpha1", typeConfig.GetTemplate().Kind)
 		template, err = common.ReaderToObj(strings.NewReader(data))
 		if err != nil {
 			return nil, nil, nil, fmt.Errorf("Error reading test template: %v", err)
 		}
-		if scope == apiextv1b1.NamespaceScoped {
+		if namespaced {
 			template.SetNamespace(namespace)
 		}
 
@@ -183,26 +166,6 @@ spec:
 
 	validateCrud(f, tl, typeConfig, testObjectFunc)
 
-}
-
-func newTestCrd(kind string, scope apiextv1b1.ResourceScope) *apiextv1b1.CustomResourceDefinition {
-	plural := fedv1a1.PluralName(kind)
-	group := "example.com"
-	return &apiextv1b1.CustomResourceDefinition{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: fmt.Sprintf("%s.%s", plural, group),
-		},
-		Spec: apiextv1b1.CustomResourceDefinitionSpec{
-			Group:   group,
-			Version: "v1alpha1",
-			Scope:   scope,
-			Names: apiextv1b1.CustomResourceDefinitionNames{
-				Plural:   plural,
-				Singular: strings.ToLower(kind),
-				Kind:     kind,
-			},
-		},
-	}
 }
 
 func waitForCrd(pool dynamic.ClientPool, tl common.TestLogger, apiResource metav1.APIResource) {
@@ -227,23 +190,26 @@ func createCrdForHost(tl common.TestLogger, client *apiextv1b1client.Apiextensio
 }
 
 func createCrd(tl common.TestLogger, client *apiextv1b1client.ApiextensionsV1beta1Client, crd *apiextv1b1.CustomResourceDefinition, clusterName string) *apiextv1b1.CustomResourceDefinition {
-	clusterMsg := "host cluster"
-	if len(clusterName) > 0 {
-		clusterMsg = fmt.Sprintf("cluster %q", clusterName)
-	}
 	createdCrd, err := client.CustomResourceDefinitions().Create(crd)
 	if err != nil {
-		tl.Fatalf("Error creating crd %s in %s: %v", crd.Name, clusterMsg, err)
+		tl.Fatalf("Error creating crd %s in %s: %v", crd.Name, clusterMsg(clusterName), err)
 	}
+	ensureCRDRemoval(tl, client, createdCrd.Name, clusterName)
+	return createdCrd
+}
 
-	// Using a cleanup action is more reliable than defer()
+func ensureCRDRemoval(tl common.TestLogger, client *apiextv1b1client.ApiextensionsV1beta1Client, crdName, clusterName string) {
 	framework.AddCleanupAction(func() {
-		crdName := createdCrd.Name
 		err := client.CustomResourceDefinitions().Delete(crdName, nil)
 		if err != nil {
-			tl.Errorf("Error deleting crd %q in %s: %v", crdName, clusterMsg, err)
+			tl.Errorf("Error deleting crd %q in %s: %v", crdName, clusterMsg(clusterName), err)
 		}
 	})
+}
 
-	return createdCrd
+func clusterMsg(clusterName string) string {
+	if len(clusterName) > 0 {
+		return fmt.Sprintf("cluster %q", clusterName)
+	}
+	return "host cluster"
 }

--- a/test/e2e/crd.go
+++ b/test/e2e/crd.go
@@ -108,6 +108,19 @@ func validateCrdCrud(f framework.FederationFramework, targetCrdKind string, name
 	}
 
 	hostConfig := f.KubeConfig()
+
+	targetName := targetAPIResource.Name
+	err := wait.PollImmediate(framework.PollInterval, framework.TestContext.SingleCallTimeout, func() (bool, error) {
+		_, err := federate.LookupAPIResource(hostConfig, targetName)
+		if err != nil {
+			tl.Logf("An error was reported while waiting for target type %q to be published as an available resource: %v", targetName, err)
+		}
+		return (err == nil), nil
+	})
+	if err != nil {
+		tl.Fatalf("Timed out waiting for target type %q to be published as an available resource", targetName)
+	}
+
 	overridePaths := []string{"spec.bar"}
 	typeConfig, err := federate.EnableFederation(
 		hostConfig, f.FederationSystemNamespace(), targetAPIResource.Name,


### PR DESCRIPTION
`kubefed2 federate` is intended to create the CRDs and FederatedTypeConfig necessary to federate a given target type.  This should remove the need to commit code to the repo to support types that are not expected to be referred to by controller code.

It will still likely make sense to include sample test fixture and examples in the tree, just not CRDs and FederatedTypeConfigs.

This code has been tested to work, but at present the CRDs are being generated without a validation schema (TODO).  Propagation still works without this.

A first pass of #60.