### PR TITLE
Adds FederatedClusterRoleBinding Examples and Test Fixture

### DIFF
--- a/example/sample1/federatedclusterrolebinding-placement.yaml
+++ b/example/sample1/federatedclusterrolebinding-placement.yaml
@@ -1,0 +1,8 @@
+apiVersion: generated.federation.k8s.io/v1alpha1
+kind: FederatedClusterRoleBindingPlacement
+metadata:
+  name: test-clusterrolebinding
+spec:
+  clusterNames:
+  - cluster2
+  - cluster1

--- a/example/sample1/federatedclusterrolebinding-template.yaml
+++ b/example/sample1/federatedclusterrolebinding-template.yaml
@@ -1,0 +1,12 @@
+apiVersion: generated.federation.k8s.io/v1alpha1
+kind: FederatedClusterRoleBinding
+metadata:
+  name: test-clusterrolebinding
+spec:
+  template:
+    subjects:
+    - kind: Group
+      name: test-user
+    roleRef:
+      kind: ClusterRole
+      name: cluster-admin

--- a/test/common/fixtures/clusterrolebinding-template.yaml
+++ b/test/common/fixtures/clusterrolebinding-template.yaml
@@ -1,0 +1,12 @@
+apiVersion: generated.federation.k8s.io/v1alpha1
+kind: FederatedClusterRoleBinding
+metadata:
+  name: placeholder
+spec:
+  template:
+    subjects:
+    - kind: Group
+      name: test-user
+    roleRef:
+      kind: ClusterRole
+      name: cluster-admin


### PR DESCRIPTION
__NOTE:__ This PR is not ready for review until https://github.com/kubernetes-sigs/federation-v2/pull/340 has merged.

Adds examples and test fixture for `FederatedClusterRoleBinding` and `FederatedClusterRoleBindingPlacement` resources using `generated.federation.k8s.io` API.