### PR TITLE
Added observedGeneration to FederatedCluster status

### DIFF
--- a/hack/install-latest.yaml
+++ b/hack/install-latest.yaml
@@ -150,6 +150,9 @@ spec:
                 - status
                 type: object
               type: array
+            observedGeneration:
+              format: int64
+              type: integer
             region:
               type: string
             zone:

--- a/pkg/apis/core/v1alpha1/federatedcluster_types.go
+++ b/pkg/apis/core/v1alpha1/federatedcluster_types.go
@@ -58,6 +58,9 @@ type FederatedClusterStatus struct {
 	// Region is the name of the region in which all of the nodes in the cluster exist.  e.g. 'us-east1'.
 	// +optional
 	Region string `json:"region,omitempty"`
+	// ObservedGeneration is the generation as observed by the controller consuming the FederatedCluster.
+	// +optional
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/apis/core/v1alpha1/zz_generated.kubebuilder.go
+++ b/pkg/apis/core/v1alpha1/zz_generated.kubebuilder.go
@@ -456,6 +456,10 @@ var (
 											}},
 									},
 								},
+								"observedGeneration": v1beta1.JSONSchemaProps{
+									Type:   "integer",
+									Format: "int64",
+								},
 								"region": v1beta1.JSONSchemaProps{
 									Type: "string",
 								},


### PR DESCRIPTION
Similar to `FederatedTypeConfig`, adding `ObservedGeneration` field in the status of `FederatedCluster` to allow users to determine whether the controller backing a resource has 'seen' the latest version of that resource's spec. This will increase understandability of the behavior of the system.