### PR TITLE
Remove duplicate default values in controller-manager help text

### DIFF
--- a/cmd/controller-manager/main.go
+++ b/cmd/controller-manager/main.go
@@ -61,10 +61,8 @@ func main() {
 	verFlag := flag.Bool("version", false, "Prints the version info of controller-manager")
 	flag.Var(flagutil.NewMapStringBool(&featureGates), "feature-gates", "A set of key=value pairs that describe feature gates for alpha/experimental features. "+
 		"Options are:\n"+strings.Join(utilfeature.DefaultFeatureGate.KnownFeatures(), "\n"))
-	flag.StringVar(&fedNamespace, "federation-namespace", util.DefaultFederationSystemNamespace,
-		fmt.Sprintf("The namespace the federation control plane is deployed in.  If unset, will default to %q.", util.DefaultFederationSystemNamespace))
-	flag.StringVar(&clusterNamespace, "registry-namespace", util.MulticlusterPublicNamespace,
-		fmt.Sprintf("The cluster registry namespace.  If unset, will default to %q.", util.MulticlusterPublicNamespace))
+	flag.StringVar(&fedNamespace, "federation-namespace", util.DefaultFederationSystemNamespace, "The namespace the federation control plane is deployed in.")
+	flag.StringVar(&clusterNamespace, "registry-namespace", util.MulticlusterPublicNamespace, "The cluster registry namespace.")
 	flag.BoolVar(&limitedScope, "limited-scope", false, "Whether the federation namespace will be the only target for federation.")
 
 	flag.Parse()


### PR DESCRIPTION
Default values are already printed by `flag`, shown in #356.

Changed help texts:
```
$ docker run thartland/federation-v2:test --help
Usage of ./controller-manager:
..........
  -federation-namespace string
        The namespace the federation control plane is deployed in. (default "federation-system")
..........
  -registry-namespace string
        The cluster registry namespace. (default "kube-multicluster-public")
..........
```