### PR TITLE
Run controllers based on system configuration

### DIFF
--- a/cmd/controller-manager/main.go
+++ b/cmd/controller-manager/main.go
@@ -38,11 +38,10 @@ import (
 	"github.com/kubernetes-sigs/federation-v2/pkg/controller/federatedcluster"
 	"github.com/kubernetes-sigs/federation-v2/pkg/controller/federatedtypeconfig"
 	"github.com/kubernetes-sigs/federation-v2/pkg/controller/ingressdns"
-	"github.com/kubernetes-sigs/federation-v2/pkg/controller/schedulingpreference"
+	"github.com/kubernetes-sigs/federation-v2/pkg/controller/schedulingmanager"
 	"github.com/kubernetes-sigs/federation-v2/pkg/controller/servicedns"
 	"github.com/kubernetes-sigs/federation-v2/pkg/controller/util"
 	"github.com/kubernetes-sigs/federation-v2/pkg/features"
-	"github.com/kubernetes-sigs/federation-v2/pkg/schedulingtypes"
 	"github.com/kubernetes-sigs/federation-v2/pkg/version"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	flagutil "k8s.io/apiserver/pkg/util/flag"
@@ -125,12 +124,7 @@ func main() {
 	federatedcluster.StartClusterController(controllerConfig, stopChan, clusterMonitorPeriod)
 
 	if utilfeature.DefaultFeatureGate.Enabled(features.SchedulerPreferences) {
-		for kind, schedulingType := range schedulingtypes.SchedulingTypes() {
-			err = schedulingpreference.StartSchedulingPreferenceController(controllerConfig, stopChan, kind, schedulingType.SchedulerFactory)
-			if err != nil {
-				glog.Fatalf("Error starting schedulingpreference controller for %q : %v", kind, err)
-			}
-		}
+		schedulingmanager.StartSchedulerController(controllerConfig, stopChan)
 	}
 
 	if utilfeature.DefaultFeatureGate.Enabled(features.CrossClusterServiceDiscovery) {

--- a/pkg/controller/schedulingmanager/controller.go
+++ b/pkg/controller/schedulingmanager/controller.go
@@ -1,0 +1,165 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package schedulingmanager
+
+import (
+	"fmt"
+
+	"github.com/golang/glog"
+	corev1a1 "github.com/kubernetes-sigs/federation-v2/pkg/apis/core/v1alpha1"
+	fedclientset "github.com/kubernetes-sigs/federation-v2/pkg/client/clientset/versioned"
+	corev1alpha1client "github.com/kubernetes-sigs/federation-v2/pkg/client/clientset/versioned/typed/core/v1alpha1"
+	"github.com/kubernetes-sigs/federation-v2/pkg/controller/schedulingpreference"
+	"github.com/kubernetes-sigs/federation-v2/pkg/controller/util"
+	"github.com/kubernetes-sigs/federation-v2/pkg/schedulingtypes"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	pkgruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	restclient "k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
+)
+
+var SchedulingRegistry = map[string]string{
+	"FederatedDeployment": schedulingtypes.RSPKind,
+	"FederatedReplicaSet": schedulingtypes.RSPKind,
+}
+
+type SchedulerController struct {
+	// Store for the FederatedTypeConfig objects
+	store cache.Store
+	// Informer for the FederatedTypeConfig objects
+	controller cache.Controller
+
+	worker util.ReconcileWorker
+
+	scheduler map[string]schedulingtypes.Scheduler
+
+	config   *util.ControllerConfig
+	stopChan <-chan struct{}
+}
+
+func StartSchedulerController(config *util.ControllerConfig, stopChan <-chan struct{}) {
+
+	userAgent := "SchedulerController"
+	kubeConfig := config.KubeConfig
+	restclient.AddUserAgent(kubeConfig, userAgent)
+	client := fedclientset.NewForConfigOrDie(kubeConfig).CoreV1alpha1()
+
+	controller := newController(config, client, stopChan)
+
+	glog.Infof("Starting scheduler controller")
+	controller.Run(stopChan)
+}
+
+func newController(config *util.ControllerConfig, client corev1alpha1client.CoreV1alpha1Interface, stopChan <-chan struct{}) *SchedulerController {
+	c := &SchedulerController{
+		scheduler: make(map[string]schedulingtypes.Scheduler),
+		config:    config,
+		stopChan:  stopChan,
+	}
+
+	fedNamespace := config.FederationNamespace
+	c.worker = util.NewReconcileWorker(c.reconcile, util.WorkerTiming{})
+
+	c.store, c.controller = cache.NewInformer(
+		&cache.ListWatch{
+			// Only watch the federation namespace to ensure
+			// restrictive authz can be applied to a namespaced
+			// control plane.
+			ListFunc: func(options metav1.ListOptions) (pkgruntime.Object, error) {
+				return client.FederatedTypeConfigs(fedNamespace).List(options)
+			},
+			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+				return client.FederatedTypeConfigs(fedNamespace).Watch(options)
+			},
+		},
+		&corev1a1.FederatedTypeConfig{},
+		util.NoResyncPeriod,
+		util.NewTriggerOnAllChanges(c.worker.EnqueueObject),
+	)
+
+	return c
+}
+
+// Run runs the Controller.
+func (c *SchedulerController) Run(stopChan <-chan struct{}) {
+	go c.controller.Run(stopChan)
+
+	// wait for the caches to synchronize before starting the worker
+	if !cache.WaitForCacheSync(stopChan, c.controller.HasSynced) {
+		runtime.HandleError(fmt.Errorf("Timed out waiting for cache to sync"))
+		return
+	}
+
+	c.worker.Run(stopChan)
+}
+
+func (c *SchedulerController) reconcile(qualifiedName util.QualifiedName) util.ReconciliationStatus {
+	key := qualifiedName.String()
+
+	glog.Infof("Running reconcile FederatedTypeConfig for %q", key)
+
+	cachedObj, exist, err := c.store.GetByKey(key)
+	if err != nil {
+		runtime.HandleError(fmt.Errorf("Failed to query FederatedTypeConfig store for %q: %v", key, err))
+		return util.StatusError
+	}
+	if !exist {
+		return util.StatusAllOK
+	}
+	typeConfig := cachedObj.(*corev1a1.FederatedTypeConfig)
+
+	deleted := typeConfig.DeletionTimestamp != nil
+	if deleted {
+		// Do not support deletion yet
+		return util.StatusAllOK
+	}
+
+	// set name and group for the type config target
+	corev1a1.SetFederatedTypeConfigDefaults(typeConfig)
+	apiResource := typeConfig.GetTarget()
+	templateKind := typeConfig.GetTemplate().Kind
+
+	kind, ok := SchedulingRegistry[templateKind]
+	if !ok {
+		// No any scheduler supported for this resource
+		return util.StatusAllOK
+	}
+	schedulingType, _ := schedulingtypes.SchedulingTypes()[kind]
+
+	// Scheduling preference controller is started on demand
+	_, ok = c.scheduler[kind]
+	if !ok {
+		scheduler, err := schedulingpreference.StartSchedulingPreferenceController(c.config, c.stopChan, kind, schedulingType.SchedulerFactory)
+		if err != nil {
+			runtime.HandleError(fmt.Errorf("Error starting schedulingpreference controller for %q : %v", kind, err))
+			return util.StatusError
+		}
+		c.scheduler[kind] = scheduler
+	}
+
+	glog.Infof("Start plugin with kind %s for scheduling type %s", templateKind, kind)
+	err = c.scheduler[kind].StartPlugin(templateKind, &apiResource, c.stopChan)
+	if err != nil {
+		runtime.HandleError(fmt.Errorf("Error starting plugin for %q : %v", templateKind, err))
+		return util.StatusError
+	}
+
+	return util.StatusAllOK
+}

--- a/pkg/controller/schedulingpreference/controller.go
+++ b/pkg/controller/schedulingpreference/controller.go
@@ -70,19 +70,19 @@ type SchedulingPreferenceController struct {
 }
 
 // SchedulingPreferenceController starts a new controller for given type of SchedulingPreferences
-func StartSchedulingPreferenceController(config *util.ControllerConfig, stopChan <-chan struct{}, kind string, schedulerFactory schedulingtypes.SchedulerFactory) error {
+func StartSchedulingPreferenceController(config *util.ControllerConfig, stopChan <-chan struct{}, kind string, schedulerFactory schedulingtypes.SchedulerFactory) (schedulingtypes.Scheduler, error) {
 	userAgent := fmt.Sprintf("%s-controller", kind)
 	fedClient, kubeClient, crClient := config.AllClients(userAgent)
 	controller, err := newSchedulingPreferenceController(config, kind, schedulerFactory, fedClient, kubeClient, crClient)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if config.MinimizeLatency {
 		controller.minimizeLatency()
 	}
 	glog.Infof(fmt.Sprintf("Starting replicaschedulingpreferences controller"))
 	controller.Run(stopChan)
-	return nil
+	return controller.scheduler, nil
 }
 
 // newSchedulingPreferenceController returns a new SchedulingPreference Controller for the given type

--- a/pkg/schedulingtypes/interface.go
+++ b/pkg/schedulingtypes/interface.go
@@ -36,6 +36,8 @@ type Scheduler interface {
 	HasSynced() bool
 	Stop()
 	Reconcile(obj pkgruntime.Object, qualifiedName QualifiedName) ReconciliationStatus
+
+	StartPlugin(kind string, apiResource *metav1.APIResource, stopChan <-chan struct{}) error
 }
 
 type SchedulerFactory func(fedClient fedclientset.Interface, kubeClient kubeclientset.Interface, crClient crclientset.Interface, namespaces FederationNamespaces, federationEventHandler, clusterEventHandler func(pkgruntime.Object), handlers *ClusterLifecycleHandlerFuncs) Scheduler

--- a/pkg/schedulingtypes/resources.go
+++ b/pkg/schedulingtypes/resources.go
@@ -21,7 +21,6 @@ import (
 	"strings"
 
 	fedv1a1 "github.com/kubernetes-sigs/federation-v2/pkg/apis/core/v1alpha1"
-	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	pkgruntime "k8s.io/apimachinery/pkg/runtime"
@@ -29,9 +28,7 @@ import (
 
 var (
 	FederatedDeployment = GetResourceKind(&fedv1a1.FederatedDeployment{})
-	Deployment          = GetResourceKind(&appsv1.Deployment{})
 	FederatedReplicaSet = GetResourceKind(&fedv1a1.FederatedReplicaSet{})
-	ReplicaSet          = GetResourceKind(&appsv1.ReplicaSet{})
 	Pod                 = GetResourceKind(&corev1.Pod{})
 )
 
@@ -41,23 +38,6 @@ var PodResource = &metav1.APIResource{
 	Version:    corev1.SchemeGroupVersion.Version,
 	Kind:       Pod,
 	Namespaced: true,
-}
-
-var ReplicaSechedulingResources = map[string]metav1.APIResource{
-	FederatedDeployment: {
-		Name:       GetPluralName(Deployment),
-		Group:      appsv1.SchemeGroupVersion.Group,
-		Version:    appsv1.SchemeGroupVersion.Version,
-		Kind:       Deployment,
-		Namespaced: true,
-	},
-	FederatedReplicaSet: {
-		Name:       GetPluralName(ReplicaSet),
-		Group:      appsv1.SchemeGroupVersion.Group,
-		Version:    appsv1.SchemeGroupVersion.Version,
-		Kind:       ReplicaSet,
-		Namespaced: true,
-	},
 }
 
 func GetResourceKind(obj pkgruntime.Object) string {

--- a/test/integration/replicaschedulingpreference_test.go
+++ b/test/integration/replicaschedulingpreference_test.go
@@ -110,7 +110,7 @@ var TestReplicaSchedulingPreference = func(t *testing.T) {
 
 func initRSPTest(tl common.TestLogger, fedFixture *framework.FederationFixture) (*framework.ControllerFixture, clientset.Interface) {
 	controllerConfig := fedFixture.ControllerConfig(tl)
-	fixture := framework.NewRSPControllerFixture(tl, controllerConfig)
+	fixture := framework.NewRSPControllerFixture(tl, controllerConfig, TypeConfigs)
 	kubeConfig := controllerConfig.KubeConfig
 	restclient.AddUserAgent(kubeConfig, "rsp-test")
 	client := clientset.NewForConfigOrDie(kubeConfig)


### PR DESCRIPTION
Fix #349.

Make scheduler plugins with correct adapters created when corresponding
federated resource enabled in federatedtypeconfig.

/cc @irfanurrehman @gyliu513 