### PR TITLE
Add flags to controller-manager to set cluster availability delays

### DIFF
--- a/cmd/controller-manager/main.go
+++ b/cmd/controller-manager/main.go
@@ -147,7 +147,7 @@ func main() {
 	}
 
 	if utilfeature.DefaultFeatureGate.Enabled(features.PushReconciler) {
-		err = federatedtypeconfig.StartController(config, fedNamespace, clusterNamespace, targetNamespace, stopChan)
+		err = federatedtypeconfig.StartController(config, fedNamespace, clusterNamespace, targetNamespace, stopChan, clusterAvailableDelay, clusterUnavailableDelay)
 		if err != nil {
 			glog.Fatalf("Error starting federated type config controller: %v", err)
 		}

--- a/cmd/controller-manager/main.go
+++ b/cmd/controller-manager/main.go
@@ -54,8 +54,8 @@ var featureGates map[string]bool
 var fedNamespace string
 var clusterNamespace string
 var limitedScope bool
-var clusterAvailableDelay int
-var clusterUnavailableDelay int
+var clusterAvailableDelay time.Duration
+var clusterUnavailableDelay time.Duration
 var installCRDs = flag.Bool("install-crds", true, "install the CRDs used by the controller as part of startup")
 
 // Controller-manager main.
@@ -66,8 +66,8 @@ func main() {
 	flag.StringVar(&fedNamespace, "federation-namespace", util.DefaultFederationSystemNamespace, "The namespace the federation control plane is deployed in.")
 	flag.StringVar(&clusterNamespace, "registry-namespace", util.MulticlusterPublicNamespace, "The cluster registry namespace.")
 	flag.BoolVar(&limitedScope, "limited-scope", false, "Whether the federation namespace will be the only target for federation.")
-	flag.IntVar(&clusterAvailableDelay, "cluster-available-delay", util.DefaultClusterAvailableDelay, "Time in seconds to wait before reconciling on a healthy cluster.")
-	flag.IntVar(&clusterUnavailableDelay, "cluster-unavailable-delay", util.DefaultClusterUnavailableDelay, "Time in seconds to wait before giving up on an unhealthy cluster.")
+	flag.DurationVar(&clusterAvailableDelay, "cluster-available-delay", util.DefaultClusterAvailableDelay, "Time to wait before reconciling on a healthy cluster.")
+	flag.DurationVar(&clusterUnavailableDelay, "cluster-unavailable-delay", util.DefaultClusterUnavailableDelay, "Time to wait before giving up on an unhealthy cluster.")
 
 	flag.Parse()
 	if *verFlag {
@@ -98,8 +98,8 @@ func main() {
 
 	glog.Infof("Federation namespace: %s", fedNamespace)
 	glog.Infof("Cluster registry namespace: %s", clusterNamespace)
-	glog.Infof("Cluster available delay: %d", clusterAvailableDelay)
-	glog.Infof("Cluster unavailable delay: %d", clusterUnavailableDelay)
+	glog.Infof("Cluster available delay: %v", clusterAvailableDelay)
+	glog.Infof("Cluster unavailable delay: %v", clusterUnavailableDelay)
 
 	targetNamespace := metav1.NamespaceAll
 	if limitedScope {

--- a/cmd/controller-manager/main.go
+++ b/cmd/controller-manager/main.go
@@ -54,6 +54,8 @@ var featureGates map[string]bool
 var fedNamespace string
 var clusterNamespace string
 var limitedScope bool
+var clusterAvailableDelay int
+var clusterUnavailableDelay int
 var installCRDs = flag.Bool("install-crds", true, "install the CRDs used by the controller as part of startup")
 
 // Controller-manager main.
@@ -64,6 +66,8 @@ func main() {
 	flag.StringVar(&fedNamespace, "federation-namespace", util.DefaultFederationSystemNamespace, "The namespace the federation control plane is deployed in.")
 	flag.StringVar(&clusterNamespace, "registry-namespace", util.MulticlusterPublicNamespace, "The cluster registry namespace.")
 	flag.BoolVar(&limitedScope, "limited-scope", false, "Whether the federation namespace will be the only target for federation.")
+	flag.IntVar(&clusterAvailableDelay, "cluster-available-delay", util.DefaultClusterAvailableDelay, "Time in seconds to wait before reconciling on a healthy cluster.")
+	flag.IntVar(&clusterUnavailableDelay, "cluster-unavailable-delay", util.DefaultClusterUnavailableDelay, "Time in seconds to wait before giving up on an unhealthy cluster.")
 
 	flag.Parse()
 	if *verFlag {
@@ -94,6 +98,8 @@ func main() {
 
 	glog.Infof("Federation namespace: %s", fedNamespace)
 	glog.Infof("Cluster registry namespace: %s", clusterNamespace)
+	glog.Infof("Cluster available delay: %d", clusterAvailableDelay)
+	glog.Infof("Cluster unavailable delay: %d", clusterUnavailableDelay)
 
 	targetNamespace := metav1.NamespaceAll
 	if limitedScope {
@@ -109,7 +115,7 @@ func main() {
 
 	if utilfeature.DefaultFeatureGate.Enabled(features.SchedulerPreferences) {
 		for kind, schedulingType := range schedulingtypes.SchedulingTypes() {
-			err = schedulingpreference.StartSchedulingPreferenceController(kind, schedulingType.SchedulerFactory, config, fedNamespace, clusterNamespace, targetNamespace, stopChan, true)
+			err = schedulingpreference.StartSchedulingPreferenceController(kind, schedulingType.SchedulerFactory, config, fedNamespace, clusterNamespace, targetNamespace, stopChan, clusterAvailableDelay, clusterUnavailableDelay, false)
 			if err != nil {
 				glog.Fatalf("Error starting schedulingpreference controller for %q : %v", kind, err)
 			}
@@ -117,7 +123,7 @@ func main() {
 	}
 
 	if utilfeature.DefaultFeatureGate.Enabled(features.CrossClusterServiceDiscovery) {
-		err = servicedns.StartController(config, fedNamespace, clusterNamespace, targetNamespace, stopChan, false)
+		err = servicedns.StartController(config, fedNamespace, clusterNamespace, targetNamespace, stopChan, clusterAvailableDelay, clusterUnavailableDelay, false)
 		if err != nil {
 			glog.Fatalf("Error starting dns controller: %v", err)
 		}
@@ -129,7 +135,7 @@ func main() {
 	}
 
 	if utilfeature.DefaultFeatureGate.Enabled(features.FederatedIngress) {
-		err = ingressdns.StartController(config, fedNamespace, clusterNamespace, targetNamespace, stopChan, false)
+		err = ingressdns.StartController(config, fedNamespace, clusterNamespace, targetNamespace, stopChan, clusterAvailableDelay, clusterUnavailableDelay, false)
 		if err != nil {
 			glog.Fatalf("Error starting ingress dns controller: %v", err)
 		}

--- a/pkg/controller/ingressdns/controller.go
+++ b/pkg/controller/ingressdns/controller.go
@@ -71,14 +71,14 @@ type Controller struct {
 }
 
 // StartController starts the Controller for managing IngressDNSRecord objects.
-func StartController(config *restclient.Config, fedNamespace, clusterNamespace, targetNamespace string, stopChan <-chan struct{}, minimizeLatency bool) error {
+func StartController(config *restclient.Config, fedNamespace, clusterNamespace, targetNamespace string, stopChan <-chan struct{}, clusterAvailableDelay, clusterUnavailableDelay int, minimizeLatency bool) error {
 	userAgent := "IngressDNS"
 	restclient.AddUserAgent(config, userAgent)
 	fedClient := fedclientset.NewForConfigOrDie(config)
 	kubeClient := kubeclientset.NewForConfigOrDie(config)
 	crClient := crclientset.NewForConfigOrDie(config)
 
-	controller, err := newController(fedClient, kubeClient, crClient, fedNamespace, clusterNamespace, targetNamespace)
+	controller, err := newController(fedClient, kubeClient, crClient, fedNamespace, clusterNamespace, targetNamespace, clusterAvailableDelay, clusterUnavailableDelay)
 	if err != nil {
 		return err
 	}
@@ -91,11 +91,11 @@ func StartController(config *restclient.Config, fedNamespace, clusterNamespace, 
 }
 
 // newController returns a new controller to manage IngressDNSRecord objects.
-func newController(fedClient fedclientset.Interface, kubeClient kubeclientset.Interface, crClient crclientset.Interface, fedNamespace, clusterNamespace, targetNamespace string) (*Controller, error) {
+func newController(fedClient fedclientset.Interface, kubeClient kubeclientset.Interface, crClient crclientset.Interface, fedNamespace, clusterNamespace, targetNamespace string, clusterAvailableDelay, clusterUnavailableDelay int) (*Controller, error) {
 	s := &Controller{
 		fedClient:               fedClient,
-		clusterAvailableDelay:   time.Second * 20,
-		clusterUnavailableDelay: time.Second * 60,
+		clusterAvailableDelay:   time.Second * time.Duration(clusterAvailableDelay),
+		clusterUnavailableDelay: time.Second * time.Duration(clusterUnavailableDelay),
 		smallDelay:              time.Second * 3,
 	}
 

--- a/pkg/controller/ingressdns/controller.go
+++ b/pkg/controller/ingressdns/controller.go
@@ -71,7 +71,7 @@ type Controller struct {
 }
 
 // StartController starts the Controller for managing IngressDNSRecord objects.
-func StartController(config *restclient.Config, fedNamespace, clusterNamespace, targetNamespace string, stopChan <-chan struct{}, clusterAvailableDelay, clusterUnavailableDelay int, minimizeLatency bool) error {
+func StartController(config *restclient.Config, fedNamespace, clusterNamespace, targetNamespace string, stopChan <-chan struct{}, clusterAvailableDelay, clusterUnavailableDelay time.Duration, minimizeLatency bool) error {
 	userAgent := "IngressDNS"
 	restclient.AddUserAgent(config, userAgent)
 	fedClient := fedclientset.NewForConfigOrDie(config)
@@ -91,11 +91,11 @@ func StartController(config *restclient.Config, fedNamespace, clusterNamespace, 
 }
 
 // newController returns a new controller to manage IngressDNSRecord objects.
-func newController(fedClient fedclientset.Interface, kubeClient kubeclientset.Interface, crClient crclientset.Interface, fedNamespace, clusterNamespace, targetNamespace string, clusterAvailableDelay, clusterUnavailableDelay int) (*Controller, error) {
+func newController(fedClient fedclientset.Interface, kubeClient kubeclientset.Interface, crClient crclientset.Interface, fedNamespace, clusterNamespace, targetNamespace string, clusterAvailableDelay, clusterUnavailableDelay time.Duration) (*Controller, error) {
 	s := &Controller{
 		fedClient:               fedClient,
-		clusterAvailableDelay:   time.Second * time.Duration(clusterAvailableDelay),
-		clusterUnavailableDelay: time.Second * time.Duration(clusterUnavailableDelay),
+		clusterAvailableDelay:   clusterAvailableDelay,
+		clusterUnavailableDelay: clusterUnavailableDelay,
 		smallDelay:              time.Second * 3,
 	}
 

--- a/pkg/controller/schedulingpreference/controller.go
+++ b/pkg/controller/schedulingpreference/controller.go
@@ -71,7 +71,7 @@ type SchedulingPreferenceController struct {
 }
 
 // SchedulingPreferenceController starts a new controller for given type of SchedulingPreferences
-func StartSchedulingPreferenceController(kind string, schedulerFactory schedulingtypes.SchedulerFactory, config *restclient.Config, fedNamespace, clusterNamespace, targetNamespace string, stopChan <-chan struct{}, clusterAvailableDelay, clusterUnavailableDelay int, minimizeLatency bool) error {
+func StartSchedulingPreferenceController(kind string, schedulerFactory schedulingtypes.SchedulerFactory, config *restclient.Config, fedNamespace, clusterNamespace, targetNamespace string, stopChan <-chan struct{}, clusterAvailableDelay, clusterUnavailableDelay time.Duration, minimizeLatency bool) error {
 	restclient.AddUserAgent(config, fmt.Sprintf("%s-controller", kind))
 	fedClient := fedclientset.NewForConfigOrDie(config)
 	kubeClient := kubeclientset.NewForConfigOrDie(config)
@@ -89,14 +89,14 @@ func StartSchedulingPreferenceController(kind string, schedulerFactory schedulin
 }
 
 // newSchedulingPreferenceController returns a new SchedulingPreference Controller for the given type
-func newSchedulingPreferenceController(kind string, schedulerFactory schedulingtypes.SchedulerFactory, fedClient fedclientset.Interface, kubeClient kubeclientset.Interface, crClient crclientset.Interface, fedNamespace, clusterNamespace, targetNamespace string, clusterAvailableDelay, clusterUnavailableDelay int) (*SchedulingPreferenceController, error) {
+func newSchedulingPreferenceController(kind string, schedulerFactory schedulingtypes.SchedulerFactory, fedClient fedclientset.Interface, kubeClient kubeclientset.Interface, crClient crclientset.Interface, fedNamespace, clusterNamespace, targetNamespace string, clusterAvailableDelay, clusterUnavailableDelay time.Duration) (*SchedulingPreferenceController, error) {
 	broadcaster := record.NewBroadcaster()
 	broadcaster.StartRecordingToSink(&typedcorev1.EventSinkImpl{Interface: kubeClient.CoreV1().Events("")})
 	recorder := broadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: fmt.Sprintf("replicaschedulingpreference-controller")})
 
 	s := &SchedulingPreferenceController{
-		clusterAvailableDelay:   time.Second * time.Duration(clusterAvailableDelay),
-		clusterUnavailableDelay: time.Second * time.Duration(clusterUnavailableDelay),
+		clusterAvailableDelay:   clusterAvailableDelay,
+		clusterUnavailableDelay: clusterUnavailableDelay,
 		smallDelay:              time.Second * 3,
 		updateTimeout:           time.Second * 30,
 		eventRecorder:           recorder,

--- a/pkg/controller/servicedns/controller.go
+++ b/pkg/controller/servicedns/controller.go
@@ -73,14 +73,14 @@ type Controller struct {
 }
 
 // StartController starts the Controller for managing ServiceDNSRecord objects.
-func StartController(config *restclient.Config, fedNamespace, clusterNamespace, targetNamespace string, stopChan <-chan struct{}, minimizeLatency bool) error {
+func StartController(config *restclient.Config, fedNamespace, clusterNamespace, targetNamespace string, stopChan <-chan struct{}, clusterAvailableDelay, clusterUnavailableDelay int, minimizeLatency bool) error {
 	userAgent := "ServiceDNS"
 	restclient.AddUserAgent(config, userAgent)
 	fedClient := fedclientset.NewForConfigOrDie(config)
 	kubeClient := kubeclientset.NewForConfigOrDie(config)
 	crClient := crclientset.NewForConfigOrDie(config)
 
-	controller, err := newController(fedClient, kubeClient, crClient, fedNamespace, clusterNamespace, targetNamespace)
+	controller, err := newController(fedClient, kubeClient, crClient, fedNamespace, clusterNamespace, targetNamespace, clusterAvailableDelay, clusterUnavailableDelay)
 	if err != nil {
 		return err
 	}
@@ -93,11 +93,11 @@ func StartController(config *restclient.Config, fedNamespace, clusterNamespace, 
 }
 
 // newController returns a new controller to manage ServiceDNSRecord objects.
-func newController(fedClient fedclientset.Interface, kubeClient kubeclientset.Interface, crClient crclientset.Interface, fedNamespace, clusterNamespace, targetNamespace string) (*Controller, error) {
+func newController(fedClient fedclientset.Interface, kubeClient kubeclientset.Interface, crClient crclientset.Interface, fedNamespace, clusterNamespace, targetNamespace string, clusterAvailableDelay, clusterUnavailableDelay int) (*Controller, error) {
 	s := &Controller{
 		fedClient:               fedClient,
-		clusterAvailableDelay:   time.Second * 20,
-		clusterUnavailableDelay: time.Second * 60,
+		clusterAvailableDelay:   time.Second * time.Duration(clusterAvailableDelay),
+		clusterUnavailableDelay: time.Second * time.Duration(clusterUnavailableDelay),
 		smallDelay:              time.Second * 3,
 	}
 

--- a/pkg/controller/servicedns/controller.go
+++ b/pkg/controller/servicedns/controller.go
@@ -73,7 +73,7 @@ type Controller struct {
 }
 
 // StartController starts the Controller for managing ServiceDNSRecord objects.
-func StartController(config *restclient.Config, fedNamespace, clusterNamespace, targetNamespace string, stopChan <-chan struct{}, clusterAvailableDelay, clusterUnavailableDelay int, minimizeLatency bool) error {
+func StartController(config *restclient.Config, fedNamespace, clusterNamespace, targetNamespace string, stopChan <-chan struct{}, clusterAvailableDelay, clusterUnavailableDelay time.Duration, minimizeLatency bool) error {
 	userAgent := "ServiceDNS"
 	restclient.AddUserAgent(config, userAgent)
 	fedClient := fedclientset.NewForConfigOrDie(config)
@@ -93,11 +93,11 @@ func StartController(config *restclient.Config, fedNamespace, clusterNamespace, 
 }
 
 // newController returns a new controller to manage ServiceDNSRecord objects.
-func newController(fedClient fedclientset.Interface, kubeClient kubeclientset.Interface, crClient crclientset.Interface, fedNamespace, clusterNamespace, targetNamespace string, clusterAvailableDelay, clusterUnavailableDelay int) (*Controller, error) {
+func newController(fedClient fedclientset.Interface, kubeClient kubeclientset.Interface, crClient crclientset.Interface, fedNamespace, clusterNamespace, targetNamespace string, clusterAvailableDelay, clusterUnavailableDelay time.Duration) (*Controller, error) {
 	s := &Controller{
 		fedClient:               fedClient,
-		clusterAvailableDelay:   time.Second * time.Duration(clusterAvailableDelay),
-		clusterUnavailableDelay: time.Second * time.Duration(clusterUnavailableDelay),
+		clusterAvailableDelay:   clusterAvailableDelay,
+		clusterUnavailableDelay: clusterUnavailableDelay,
 		smallDelay:              time.Second * 3,
 	}
 

--- a/pkg/controller/util/cluster_util.go
+++ b/pkg/controller/util/cluster_util.go
@@ -37,8 +37,8 @@ import (
 const (
 	DefaultFederationSystemNamespace = "federation-system"
 	MulticlusterPublicNamespace      = "kube-multicluster-public"
-	DefaultClusterAvailableDelay     = 20
-	DefaultClusterUnavailableDelay   = 60
+	DefaultClusterAvailableDelay     = 20 * time.Second
+	DefaultClusterUnavailableDelay   = 60 * time.Second
 
 	KubeAPIQPS              = 20.0
 	KubeAPIBurst            = 30

--- a/pkg/controller/util/cluster_util.go
+++ b/pkg/controller/util/cluster_util.go
@@ -37,6 +37,8 @@ import (
 const (
 	DefaultFederationSystemNamespace = "federation-system"
 	MulticlusterPublicNamespace      = "kube-multicluster-public"
+	DefaultClusterAvailableDelay     = 20
+	DefaultClusterUnavailableDelay   = 60
 
 	KubeAPIQPS              = 20.0
 	KubeAPIBurst            = 30

--- a/test/integration/framework/controller.go
+++ b/test/integration/framework/controller.go
@@ -54,7 +54,7 @@ func NewServiceDNSControllerFixture(tl common.TestLogger, config *restclient.Con
 	f := &ControllerFixture{
 		stopChan: make(chan struct{}),
 	}
-	err := servicedns.StartController(config, fedNamespace, clusterNamespace, targetNamespace, f.stopChan, true)
+	err := servicedns.StartController(config, fedNamespace, clusterNamespace, targetNamespace, f.stopChan, 20, 60, true)
 	if err != nil {
 		tl.Fatalf("Error starting service dns controller: %v", err)
 	}
@@ -70,7 +70,7 @@ func NewIngressDNSControllerFixture(tl common.TestLogger, config *restclient.Con
 	f := &ControllerFixture{
 		stopChan: make(chan struct{}),
 	}
-	err := ingressdns.StartController(config, fedNamespace, clusterNamespace, targetNamespace, f.stopChan, true)
+	err := ingressdns.StartController(config, fedNamespace, clusterNamespace, targetNamespace, f.stopChan, 20, 60, true)
 	if err != nil {
 		tl.Fatalf("Error starting ingress dns controller: %v", err)
 	}
@@ -97,7 +97,7 @@ func NewRSPControllerFixture(tl common.TestLogger, config *restclient.Config, fe
 		stopChan: make(chan struct{}),
 	}
 	kind := schedulingtypes.RSPKind
-	err := schedulingpreference.StartSchedulingPreferenceController(kind, schedulingtypes.GetSchedulerFactory(kind), config, fedNamespace, clusterNamespace, targetNamespace, f.stopChan, true)
+	err := schedulingpreference.StartSchedulingPreferenceController(kind, schedulingtypes.GetSchedulerFactory(kind), config, fedNamespace, clusterNamespace, targetNamespace, f.stopChan, 20, 60, true)
 	if err != nil {
 		tl.Fatalf("Error starting ReplicaSchedulingPreference controller: %v", err)
 	}

--- a/test/integration/framework/controller.go
+++ b/test/integration/framework/controller.go
@@ -26,6 +26,7 @@ import (
 	"github.com/kubernetes-sigs/federation-v2/pkg/controller/schedulingpreference"
 	"github.com/kubernetes-sigs/federation-v2/pkg/controller/servicedns"
 	"github.com/kubernetes-sigs/federation-v2/pkg/controller/sync"
+	"github.com/kubernetes-sigs/federation-v2/pkg/controller/util"
 	"github.com/kubernetes-sigs/federation-v2/pkg/schedulingtypes"
 	"github.com/kubernetes-sigs/federation-v2/test/common"
 	restclient "k8s.io/client-go/rest"
@@ -54,7 +55,7 @@ func NewServiceDNSControllerFixture(tl common.TestLogger, config *restclient.Con
 	f := &ControllerFixture{
 		stopChan: make(chan struct{}),
 	}
-	err := servicedns.StartController(config, fedNamespace, clusterNamespace, targetNamespace, f.stopChan, 20, 60, true)
+	err := servicedns.StartController(config, fedNamespace, clusterNamespace, targetNamespace, f.stopChan, util.DefaultClusterAvailableDelay, util.DefaultClusterUnavailableDelay, true)
 	if err != nil {
 		tl.Fatalf("Error starting service dns controller: %v", err)
 	}
@@ -70,7 +71,7 @@ func NewIngressDNSControllerFixture(tl common.TestLogger, config *restclient.Con
 	f := &ControllerFixture{
 		stopChan: make(chan struct{}),
 	}
-	err := ingressdns.StartController(config, fedNamespace, clusterNamespace, targetNamespace, f.stopChan, 20, 60, true)
+	err := ingressdns.StartController(config, fedNamespace, clusterNamespace, targetNamespace, f.stopChan, util.DefaultClusterAvailableDelay, util.DefaultClusterUnavailableDelay, true)
 	if err != nil {
 		tl.Fatalf("Error starting ingress dns controller: %v", err)
 	}
@@ -97,7 +98,7 @@ func NewRSPControllerFixture(tl common.TestLogger, config *restclient.Config, fe
 		stopChan: make(chan struct{}),
 	}
 	kind := schedulingtypes.RSPKind
-	err := schedulingpreference.StartSchedulingPreferenceController(kind, schedulingtypes.GetSchedulerFactory(kind), config, fedNamespace, clusterNamespace, targetNamespace, f.stopChan, 20, 60, true)
+	err := schedulingpreference.StartSchedulingPreferenceController(kind, schedulingtypes.GetSchedulerFactory(kind), config, fedNamespace, clusterNamespace, targetNamespace, f.stopChan, util.DefaultClusterAvailableDelay, util.DefaultClusterUnavailableDelay, true)
 	if err != nil {
 		tl.Fatalf("Error starting ReplicaSchedulingPreference controller: %v", err)
 	}

--- a/test/integration/framework/controller.go
+++ b/test/integration/framework/controller.go
@@ -43,7 +43,7 @@ func NewSyncControllerFixture(tl common.TestLogger, typeConfig typeconfig.Interf
 	f := &ControllerFixture{
 		stopChan: make(chan struct{}),
 	}
-	err := sync.StartFederationSyncController(typeConfig, kubeConfig, fedNamespace, clusterNamespace, targetNamespace, f.stopChan, true)
+	err := sync.StartFederationSyncController(typeConfig, kubeConfig, fedNamespace, clusterNamespace, targetNamespace, f.stopChan, util.DefaultClusterAvailableDelay, util.DefaultClusterUnavailableDelay, true)
 	if err != nil {
 		tl.Fatalf("Error starting sync controller: %v", err)
 	}

--- a/test/integration/servicedns_test.go
+++ b/test/integration/servicedns_test.go
@@ -152,7 +152,7 @@ func newServiceDNSTestFixture(tl common.TestLogger, fedFixture *framework.Federa
 	f := &serviceDNSControllerFixture{
 		stopChan: make(chan struct{}),
 	}
-	err := servicedns.StartController(config, fedFixture.SystemNamespace, fedFixture.SystemNamespace, metav1.NamespaceAll, f.stopChan, true)
+	err := servicedns.StartController(config, fedFixture.SystemNamespace, fedFixture.SystemNamespace, metav1.NamespaceAll, f.stopChan, 20, 60, true)
 	if err != nil {
 		tl.Fatalf("Error starting service-dns controller: %v", err)
 	}

--- a/test/integration/servicedns_test.go
+++ b/test/integration/servicedns_test.go
@@ -32,6 +32,7 @@ import (
 	dnsv1a1 "github.com/kubernetes-sigs/federation-v2/pkg/apis/multiclusterdns/v1alpha1"
 	fedclientset "github.com/kubernetes-sigs/federation-v2/pkg/client/clientset/versioned"
 	"github.com/kubernetes-sigs/federation-v2/pkg/controller/servicedns"
+	"github.com/kubernetes-sigs/federation-v2/pkg/controller/util"
 	"github.com/kubernetes-sigs/federation-v2/test/common"
 	"github.com/kubernetes-sigs/federation-v2/test/integration/framework"
 )
@@ -152,7 +153,7 @@ func newServiceDNSTestFixture(tl common.TestLogger, fedFixture *framework.Federa
 	f := &serviceDNSControllerFixture{
 		stopChan: make(chan struct{}),
 	}
-	err := servicedns.StartController(config, fedFixture.SystemNamespace, fedFixture.SystemNamespace, metav1.NamespaceAll, f.stopChan, 20, 60, true)
+	err := servicedns.StartController(config, fedFixture.SystemNamespace, fedFixture.SystemNamespace, metav1.NamespaceAll, f.stopChan, util.DefaultClusterAvailableDelay, util.DefaultClusterUnavailableDelay, true)
 	if err != nil {
 		tl.Fatalf("Error starting service-dns controller: %v", err)
 	}


### PR DESCRIPTION
I have tested using negative values for the delay arguments, it works just as if the delay were set to 0 seconds.

Closes #356.