### PR TITLE
Add option to output yaml to 'kubefed federate enable'

### DIFF
--- a/pkg/kubefed2/federate/util.go
+++ b/pkg/kubefed2/federate/util.go
@@ -33,6 +33,12 @@ func CrdForAPIResource(apiResource metav1.APIResource) *apiextv1b1.CustomResourc
 		scope = apiextv1b1.NamespaceScoped
 	}
 	return &apiextv1b1.CustomResourceDefinition{
+		// Explicitly including TypeMeta will ensure it will be
+		// serialized properly to yaml.
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "CustomResourceDefinition",
+			APIVersion: "apiextensions.k8s.io/v1beta1",
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name: groupQualifiedName(apiResource),
 		},

--- a/test/e2e/crd.go
+++ b/test/e2e/crd.go
@@ -123,9 +123,9 @@ func validateCrdCrud(f framework.FederationFramework, targetCrdKind string, name
 
 	overridePaths := []string{"spec.bar"}
 	typeConfig, err := federate.EnableFederation(
-		hostConfig, f.FederationSystemNamespace(), targetAPIResource.Name,
+		nil, hostConfig, f.FederationSystemNamespace(), targetAPIResource.Name,
 		targetAPIResource.Group, targetAPIResource.Version,
-		apicommon.ResourceVersionField, overridePaths, false,
+		apicommon.ResourceVersionField, overridePaths, false, false,
 	)
 	if err != nil {
 		tl.Fatalf("Error enabling federation of target type %q: %v", targetAPIResource.Kind, err)


### PR DESCRIPTION
This will allow separation of defining and creating resources that enable federation of a type, and aid in automating addition of validation schema to primitive crds.