### PR TITLE
Refactor all controllers to accept a common config struct

### DIFF
--- a/cmd/controller-manager/main.go
+++ b/cmd/controller-manager/main.go
@@ -158,10 +158,7 @@ func main() {
 	}
 
 	if utilfeature.DefaultFeatureGate.Enabled(features.PushReconciler) {
-		err = federatedtypeconfig.StartController(controllerConfig, stopChan)
-		if err != nil {
-			glog.Fatalf("Error starting federated type config controller: %v", err)
-		}
+		federatedtypeconfig.StartController(controllerConfig, stopChan)
 	}
 
 	// Blockforever

--- a/pkg/controller/federatedtypeconfig/controller.go
+++ b/pkg/controller/federatedtypeconfig/controller.go
@@ -60,23 +60,19 @@ type Controller struct {
 }
 
 // StartController starts the Controller for managing FederatedTypeConfig objects.
-func StartController(config *util.ControllerConfig, stopChan <-chan struct{}) error {
+func StartController(config *util.ControllerConfig, stopChan <-chan struct{}) {
 	userAgent := "FederatedTypeConfig"
 	kubeConfig := config.KubeConfig
 	restclient.AddUserAgent(kubeConfig, userAgent)
 	client := fedclientset.NewForConfigOrDie(kubeConfig).CoreV1alpha1()
 
-	controller, err := newController(config, client)
-	if err != nil {
-		return err
-	}
+	controller := newController(config, client)
 	glog.Infof("Starting FederatedTypeConfig controller")
 	controller.Run(stopChan)
-	return nil
 }
 
 // newController returns a new controller to manage FederatedTypeConfig objects.
-func newController(config *util.ControllerConfig, client corev1alpha1client.CoreV1alpha1Interface) (*Controller, error) {
+func newController(config *util.ControllerConfig, client corev1alpha1client.CoreV1alpha1Interface) *Controller {
 	c := &Controller{
 		controllerConfig: config,
 		client:           client,
@@ -102,7 +98,7 @@ func newController(config *util.ControllerConfig, client corev1alpha1client.Core
 		util.NewTriggerOnAllChanges(c.worker.EnqueueObject),
 	)
 
-	return c, nil
+	return c
 }
 
 // Run runs the Controller.

--- a/pkg/controller/util/controllerconfig.go
+++ b/pkg/controller/util/controllerconfig.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"time"
+
+	kubeclientset "k8s.io/client-go/kubernetes"
+	restclient "k8s.io/client-go/rest"
+	crclientset "k8s.io/cluster-registry/pkg/client/clientset/versioned"
+
+	fedclientset "github.com/kubernetes-sigs/federation-v2/pkg/client/clientset/versioned"
+)
+
+// FederationNamespaces defines the namespace configuration shared by
+// most federation controllers.
+type FederationNamespaces struct {
+	FederationNamespace string
+	ClusterNamespace    string
+	TargetNamespace     string
+}
+
+// ControllerConfig defines the configuration common to federation
+// controllers.
+type ControllerConfig struct {
+	FederationNamespaces
+	KubeConfig              *restclient.Config
+	ClusterAvailableDelay   time.Duration
+	ClusterUnavailableDelay time.Duration
+	MinimizeLatency         bool
+}
+
+func (c *ControllerConfig) AllClients(userAgent string) (fedclientset.Interface, kubeclientset.Interface, crclientset.Interface) {
+	restclient.AddUserAgent(c.KubeConfig, userAgent)
+	fedClient := fedclientset.NewForConfigOrDie(c.KubeConfig)
+	kubeClient := kubeclientset.NewForConfigOrDie(c.KubeConfig)
+	crClient := crclientset.NewForConfigOrDie(c.KubeConfig)
+	return fedClient, kubeClient, crClient
+}

--- a/pkg/schedulingtypes/interface.go
+++ b/pkg/schedulingtypes/interface.go
@@ -38,4 +38,4 @@ type Scheduler interface {
 	Reconcile(obj pkgruntime.Object, qualifiedName QualifiedName) ReconciliationStatus
 }
 
-type SchedulerFactory func(fedClient fedclientset.Interface, kubeClient kubeclientset.Interface, crClient crclientset.Interface, fedNamespace, clusterNamespace, targetNamespace string, federationEventHandler, clusterEventHandler func(pkgruntime.Object), handlers *ClusterLifecycleHandlerFuncs) Scheduler
+type SchedulerFactory func(fedClient fedclientset.Interface, kubeClient kubeclientset.Interface, crClient crclientset.Interface, namespaces FederationNamespaces, federationEventHandler, clusterEventHandler func(pkgruntime.Object), handlers *ClusterLifecycleHandlerFuncs) Scheduler

--- a/pkg/schedulingtypes/plugin.go
+++ b/pkg/schedulingtypes/plugin.go
@@ -52,21 +52,21 @@ type Plugin struct {
 	adapter adapters.Adapter
 }
 
-func NewPlugin(adapter adapters.Adapter, apiResource *metav1.APIResource, fedClient fedclientset.Interface, kubeClient kubeclientset.Interface, crClient crclientset.Interface, fedNamespace, clusterNamespace, targetNamespace string, federationEventHandler, clusterEventHandler func(pkgruntime.Object), handlers *util.ClusterLifecycleHandlerFuncs) *Plugin {
+func NewPlugin(adapter adapters.Adapter, apiResource *metav1.APIResource, fedClient fedclientset.Interface, kubeClient kubeclientset.Interface, crClient crclientset.Interface, namespaces util.FederationNamespaces, federationEventHandler, clusterEventHandler func(pkgruntime.Object), handlers *util.ClusterLifecycleHandlerFuncs) *Plugin {
 	p := &Plugin{
 		targetInformer: util.NewFederatedInformer(
 			fedClient,
 			kubeClient,
 			crClient,
-			fedNamespace,
-			clusterNamespace,
-			targetNamespace,
+			namespaces,
 			apiResource,
 			clusterEventHandler,
 			handlers,
 		),
 		adapter: adapter,
 	}
+
+	targetNamespace := namespaces.TargetNamespace
 
 	p.templateStore, p.templateController = cache.NewInformer(
 		&cache.ListWatch{

--- a/pkg/schedulingtypes/replicascheduler.go
+++ b/pkg/schedulingtypes/replicascheduler.go
@@ -55,11 +55,11 @@ type ReplicaScheduler struct {
 	targetNamespace string
 }
 
-func NewReplicaScheduler(fedClient fedclientset.Interface, kubeClient kubeclientset.Interface, crClient crclientset.Interface, fedNamespace, clusterNamespace, targetNamespace string, federationEventHandler, clusterEventHandler func(pkgruntime.Object), handlers *ClusterLifecycleHandlerFuncs) Scheduler {
+func NewReplicaScheduler(fedClient fedclientset.Interface, kubeClient kubeclientset.Interface, crClient crclientset.Interface, namespaces FederationNamespaces, federationEventHandler, clusterEventHandler func(pkgruntime.Object), handlers *ClusterLifecycleHandlerFuncs) Scheduler {
 	scheduler := &ReplicaScheduler{
 		plugins:         make(map[string]*Plugin),
 		fedClient:       fedClient,
-		targetNamespace: targetNamespace,
+		targetNamespace: namespaces.TargetNamespace,
 	}
 
 	for name, apiResource := range ReplicaSechedulingResources {
@@ -76,9 +76,7 @@ func NewReplicaScheduler(fedClient fedclientset.Interface, kubeClient kubeclient
 			fedClient,
 			kubeClient,
 			crClient,
-			fedNamespace,
-			clusterNamespace,
-			targetNamespace,
+			namespaces,
 			federationEventHandler,
 			clusterEventHandler,
 			handlers,
@@ -93,9 +91,7 @@ func NewReplicaScheduler(fedClient fedclientset.Interface, kubeClient kubeclient
 		fedClient,
 		kubeClient,
 		crClient,
-		fedNamespace,
-		clusterNamespace,
-		targetNamespace,
+		namespaces,
 		PodResource,
 		func(pkgruntime.Object) {},
 		handlers,

--- a/test/e2e/framework/managed.go
+++ b/test/e2e/framework/managed.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/kubernetes-sigs/federation-v2/pkg/apis/core/typeconfig"
 	fedclientset "github.com/kubernetes-sigs/federation-v2/pkg/client/clientset/versioned"
+	"github.com/kubernetes-sigs/federation-v2/pkg/controller/util"
 	"github.com/kubernetes-sigs/federation-v2/test/common"
 	"github.com/kubernetes-sigs/federation-v2/test/integration/framework"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -137,19 +138,28 @@ func (f *ManagedFramework) TestNamespaceName() string {
 
 func (f *ManagedFramework) SetUpControllerFixture(typeConfig typeconfig.Interface) {
 	// TODO(marun) check TestContext.InMemoryControllers before setting up controller fixture
-	kubeConfig := fedFixture.KubeApi.NewConfig(f.logger)
-	fixture := framework.NewSyncControllerFixture(f.logger, typeConfig, kubeConfig, fedFixture.SystemNamespace, fedFixture.SystemNamespace, metav1.NamespaceAll)
+	fixture := framework.NewSyncControllerFixture(f.logger, f.controllerConfig(), typeConfig)
 	f.fixtures = append(f.fixtures, fixture)
 }
 
 func (f *ManagedFramework) SetUpServiceDNSControllerFixture() {
-	config := fedFixture.KubeApi.NewConfig(f.logger)
-	fixture := framework.NewServiceDNSControllerFixture(f.logger, config, fedFixture.SystemNamespace, fedFixture.SystemNamespace, metav1.NamespaceAll)
+	fixture := framework.NewServiceDNSControllerFixture(f.logger, f.controllerConfig())
 	f.fixtures = append(f.fixtures, fixture)
 }
 
 func (f *ManagedFramework) SetUpIngressDNSControllerFixture() {
-	config := fedFixture.KubeApi.NewConfig(f.logger)
-	fixture := framework.NewIngressDNSControllerFixture(f.logger, config, fedFixture.SystemNamespace, fedFixture.SystemNamespace, metav1.NamespaceAll)
+	fixture := framework.NewIngressDNSControllerFixture(f.logger, f.controllerConfig())
 	f.fixtures = append(f.fixtures, fixture)
+}
+
+func (f *ManagedFramework) controllerConfig() *util.ControllerConfig {
+	return &util.ControllerConfig{
+		FederationNamespaces: util.FederationNamespaces{
+			FederationNamespace: fedFixture.SystemNamespace,
+			ClusterNamespace:    fedFixture.SystemNamespace,
+			TargetNamespace:     metav1.NamespaceAll,
+		},
+		KubeConfig:      fedFixture.KubeApi.NewConfig(f.logger),
+		MinimizeLatency: true,
+	}
 }

--- a/test/integration/crud_test.go
+++ b/test/integration/crud_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/kubernetes-sigs/federation-v2/pkg/controller/util"
 	"github.com/kubernetes-sigs/federation-v2/test/common"
 	"github.com/kubernetes-sigs/federation-v2/test/integration/framework"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/rest"
 )
@@ -64,10 +63,11 @@ var TestCrud = func(t *testing.T) {
 // initCrudTest initializes common elements of a crud test
 func initCrudTest(tl common.TestLogger, fedFixture *framework.FederationFixture, typeConfig typeconfig.Interface, templateKind string) (
 	*framework.ControllerFixture, *common.FederatedTypeCrudTester) {
-	kubeConfig := fedFixture.KubeApi.NewConfig(tl)
-	fixture := framework.NewSyncControllerFixture(tl, typeConfig, kubeConfig, fedFixture.SystemNamespace, fedFixture.SystemNamespace, metav1.NamespaceAll)
+	controllerConfig := fedFixture.ControllerConfig(tl)
+	fixture := framework.NewSyncControllerFixture(tl, controllerConfig, typeConfig)
 
 	userAgent := fmt.Sprintf("test-%s-crud", strings.ToLower(templateKind))
+	kubeConfig := controllerConfig.KubeConfig
 	rest.AddUserAgent(kubeConfig, userAgent)
 	targetAPIResource := typeConfig.GetTarget()
 	clusterClients := fedFixture.ClusterDynamicClients(tl, &targetAPIResource, userAgent)

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/kubernetes-sigs/federation-v2/pkg/controller/util"
 	"github.com/kubernetes-sigs/federation-v2/test/common"
 	"github.com/kubernetes-sigs/federation-v2/test/integration/framework"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var FedFixture *framework.FederationFixture
@@ -58,8 +57,8 @@ func TestIntegration(t *testing.T) {
 	if namespaceTypeConfig == nil {
 		t.Fatal("Unable to find namespace type config")
 	}
-	kubeConfig := FedFixture.KubeApi.NewConfig(tl)
-	namespaceSyncFixture := framework.NewSyncControllerFixture(tl, namespaceTypeConfig, kubeConfig, FedFixture.SystemNamespace, FedFixture.SystemNamespace, metav1.NamespaceAll)
+	controllerConfig := FedFixture.ControllerConfig(tl)
+	namespaceSyncFixture := framework.NewSyncControllerFixture(tl, controllerConfig, namespaceTypeConfig)
 	defer namespaceSyncFixture.TearDown(tl)
 
 	t.Run("Parallel-Integration-Test-Group", func(t *testing.T) {

--- a/test/integration/replicaschedulingpreference_test.go
+++ b/test/integration/replicaschedulingpreference_test.go
@@ -109,10 +109,11 @@ var TestReplicaSchedulingPreference = func(t *testing.T) {
 }
 
 func initRSPTest(tl common.TestLogger, fedFixture *framework.FederationFixture) (*framework.ControllerFixture, clientset.Interface) {
-	config := fedFixture.KubeApi.NewConfig(tl)
-	fixture := framework.NewRSPControllerFixture(tl, config, fedFixture.SystemNamespace, fedFixture.SystemNamespace, metav1.NamespaceAll)
-	restclient.AddUserAgent(config, "rsp-test")
-	client := clientset.NewForConfigOrDie(config)
+	controllerConfig := fedFixture.ControllerConfig(tl)
+	fixture := framework.NewRSPControllerFixture(tl, controllerConfig)
+	kubeConfig := controllerConfig.KubeConfig
+	restclient.AddUserAgent(kubeConfig, "rsp-test")
+	client := clientset.NewForConfigOrDie(kubeConfig)
 
 	return fixture, client
 }

--- a/test/integration/servicedns_test.go
+++ b/test/integration/servicedns_test.go
@@ -32,7 +32,6 @@ import (
 	dnsv1a1 "github.com/kubernetes-sigs/federation-v2/pkg/apis/multiclusterdns/v1alpha1"
 	fedclientset "github.com/kubernetes-sigs/federation-v2/pkg/client/clientset/versioned"
 	"github.com/kubernetes-sigs/federation-v2/pkg/controller/servicedns"
-	"github.com/kubernetes-sigs/federation-v2/pkg/controller/util"
 	"github.com/kubernetes-sigs/federation-v2/test/common"
 	"github.com/kubernetes-sigs/federation-v2/test/integration/framework"
 )
@@ -166,12 +165,11 @@ func newServiceDNSTestFixture(tl common.TestLogger, fedFixture *framework.Federa
 		userAgent = "test-service-dns"
 	)
 
-	config := fedFixture.KubeApi.NewConfig(tl)
-
 	f := &serviceDNSControllerFixture{
 		stopChan: make(chan struct{}),
 	}
-	err := servicedns.StartController(config, fedFixture.SystemNamespace, fedFixture.SystemNamespace, metav1.NamespaceAll, f.stopChan, util.DefaultClusterAvailableDelay, util.DefaultClusterUnavailableDelay, true)
+	controllerConfig := fedFixture.ControllerConfig(tl)
+	err := servicedns.StartController(controllerConfig, f.stopChan)
 	if err != nil {
 		tl.Fatalf("Error starting service-dns controller: %v", err)
 	}


### PR DESCRIPTION
This is intended to simplify maintenance of controllers.  Inspired by an in-progress refactor of the rsp testing.