### PR TITLE
Remove test-specific setup from the e2e framework

### DIFF
--- a/test/e2e/crud.go
+++ b/test/e2e/crud.go
@@ -76,7 +76,12 @@ func initCrudTest(f framework.FederationFramework, tl common.TestLogger,
 	override *unstructured.Unstructured) {
 
 	// Initialize in-memory controllers if configuration requires
-	f.SetUpControllerFixture(typeConfig)
+	fixture := f.SetUpSyncControllerFixture(typeConfig)
+	f.RegisterFixture(fixture)
+	// Avoid running more than one sync controller for namespaces
+	if typeConfig.GetTarget().Kind != util.NamespaceKind {
+		f.SetUpNamespaceSyncControllerFixture()
+	}
 
 	templateKind := typeConfig.GetTemplate().Kind
 

--- a/test/e2e/framework/test_context.go
+++ b/test/e2e/framework/test_context.go
@@ -39,7 +39,11 @@ type TestContextType struct {
 	LimitedScopeInMemoryControllers bool
 }
 
-var TestContext TestContextType
+func (t *TestContextType) RunControllers() bool {
+	return t.TestManagedFederation || t.InMemoryControllers
+}
+
+var TestContext *TestContextType = &TestContextType{}
 
 func registerFlags(t *TestContextType) {
 	flag.BoolVar(&t.TestManagedFederation, "test-managed-federation",
@@ -75,7 +79,7 @@ func validateFlags(t *TestContextType) {
 }
 
 func ParseFlags() {
-	registerFlags(&TestContext)
+	registerFlags(TestContext)
 	flag.Parse()
-	validateFlags(&TestContext)
+	validateFlags(TestContext)
 }

--- a/test/e2e/ingressdns.go
+++ b/test/e2e/ingressdns.go
@@ -31,6 +31,7 @@ import (
 	"github.com/kubernetes-sigs/federation-v2/pkg/controller/dnsendpoint"
 	"github.com/kubernetes-sigs/federation-v2/test/common"
 	"github.com/kubernetes-sigs/federation-v2/test/e2e/framework"
+	intframework "github.com/kubernetes-sigs/federation-v2/test/integration/framework"
 
 	. "github.com/onsi/ginkgo"
 )
@@ -53,7 +54,11 @@ var _ = Describe("IngressDNS", func() {
 
 	BeforeEach(func() {
 		fedClient = f.FedClient(userAgent)
-		f.SetUpIngressDNSControllerFixture()
+		if framework.TestContext.RunControllers() {
+			fixture := intframework.NewIngressDNSControllerFixture(tl, f.ControllerConfig())
+			f.RegisterFixture(fixture)
+			f.SetUpNamespaceSyncControllerFixture()
+		}
 		namespace = f.TestNamespaceName()
 		dnsClient = fedClient.MulticlusterdnsV1alpha1().IngressDNSRecords(namespace)
 	})

--- a/test/e2e/servicedns.go
+++ b/test/e2e/servicedns.go
@@ -32,6 +32,7 @@ import (
 	"github.com/kubernetes-sigs/federation-v2/pkg/controller/dnsendpoint"
 	"github.com/kubernetes-sigs/federation-v2/test/common"
 	"github.com/kubernetes-sigs/federation-v2/test/e2e/framework"
+	intframework "github.com/kubernetes-sigs/federation-v2/test/integration/framework"
 
 	. "github.com/onsi/ginkgo"
 )
@@ -71,7 +72,11 @@ var _ = Describe("ServiceDNS", func() {
 				Zone:   cluster.Status.Zone,
 			}
 		}
-		f.SetUpServiceDNSControllerFixture()
+		if framework.TestContext.RunControllers() {
+			fixture := intframework.NewServiceDNSControllerFixture(tl, f.ControllerConfig())
+			f.RegisterFixture(fixture)
+			f.SetUpNamespaceSyncControllerFixture()
+		}
 		domainObj := common.NewDomainObject(federation, Domain)
 		_, err = domainClient.Create(domainObj)
 		framework.ExpectNoError(err, "Error creating Domain object")


### PR DESCRIPTION
Previously the e2e framework was responsible for setting and tearing down controller fixture even when it wasn't common to more than one test.  This PR moves the responsibility for setup and teardown to the tests to keep the framework simple and focused on shared utility. 