### PR TITLE
install.yaml: fix have coherent namespace on tuto

### DIFF
--- a/docs/userguide.md
+++ b/docs/userguide.md
@@ -121,7 +121,7 @@ supported, along with the service and statefulset for the
 federation-controller-manager.
 
 ```bash
-kubectl apply --validate=false -f hack/install-latest.yaml
+kubectl -n federation-system apply --validate=false -f hack/install-latest.yaml
 ```
 
 **NOTE:** The validation fails for harmless reasons on kube >= 1.11 so ignore validation


### PR DESCRIPTION
`federation-system` should be used on install.yaml since there is a statefullset inside this config where it should having a correct permission for RBAC.