### PR TITLE
Set observedGeneration in the federatedTypeConfig controller

### DIFF
--- a/hack/install-latest.yaml
+++ b/hack/install-latest.yaml
@@ -1193,6 +1193,10 @@ spec:
             observedGeneration:
               format: int64
               type: integer
+            propagationController:
+              type: string
+            statusController:
+              type: string
           type: object
   version: v1alpha1
 status:

--- a/pkg/apis/core/v1alpha1/federatedtypeconfig_types.go
+++ b/pkg/apis/core/v1alpha1/federatedtypeconfig_types.go
@@ -95,11 +95,27 @@ type OverridePath struct {
 	Path string `json:"path"`
 }
 
+// ControllerStatus defines the current state of the controller
+type ControllerStatus string
+
+const (
+	// ControllerStatusRunning means controller is in "running" state
+	ControllerStatusRunning ControllerStatus = "Running"
+	// ControllerStatusNotRunning means controller is in "notrunning" state
+	ControllerStatusNotRunning ControllerStatus = "NotRunning"
+)
+
 // FederatedTypeConfigStatus defines the observed state of FederatedTypeConfig
 type FederatedTypeConfigStatus struct {
 	// ObservedGeneration is the generation as observed by the controller consuming the FederatedTypeConfig.
 	// +optional
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
+	// PropagationController tracks the status of the sync controller.
+	// +optional
+	PropagationController ControllerStatus `json:"propagationController,omitempty"`
+	// StatusController tracks the status of the status controller.
+	// +optional
+	StatusController ControllerStatus `json:"statusController,omitempty"`
 }
 
 // +genclient

--- a/pkg/apis/core/v1alpha1/zz_generated.kubebuilder.go
+++ b/pkg/apis/core/v1alpha1/zz_generated.kubebuilder.go
@@ -1739,6 +1739,12 @@ var (
 									Type:   "integer",
 									Format: "int64",
 								},
+								"propagationController": v1beta1.JSONSchemaProps{
+									Type: "string",
+								},
+								"statusController": v1beta1.JSONSchemaProps{
+									Type: "string",
+								},
 							},
 						},
 					},


### PR DESCRIPTION
Following up #345 
 FederatedTypeConfig controller should set the observedGeneration in its control loop.