### PR TITLE
Add informational output to federate subcommands

### DIFF
--- a/pkg/kubefed2/federate/disable.go
+++ b/pkg/kubefed2/federate/disable.go
@@ -127,7 +127,7 @@ func (j *disableType) Run(cmdOut io.Writer, config util.FedConfig) error {
 		Name:      groupQualifiedName(*apiResource),
 	}
 
-	err = DisableFederation(hostConfig, typeConfigName, j.delete, j.DryRun)
+	err = DisableFederation(cmdOut, hostConfig, typeConfigName, j.delete, j.DryRun)
 	if err != nil {
 		return err
 	}
@@ -135,7 +135,7 @@ func (j *disableType) Run(cmdOut io.Writer, config util.FedConfig) error {
 	return nil
 }
 
-func DisableFederation(config *rest.Config, typeConfigName ctlutil.QualifiedName, delete, dryRun bool) error {
+func DisableFederation(cmdOut io.Writer, config *rest.Config, typeConfigName ctlutil.QualifiedName, delete, dryRun bool) error {
 	fedClient, err := util.FedClientset(config)
 	if err != nil {
 		return fmt.Errorf("Failed to get federation clientset: %v", err)
@@ -149,26 +149,38 @@ func DisableFederation(config *rest.Config, typeConfigName ctlutil.QualifiedName
 		return nil
 	}
 
-	typeConfig.Spec.PropagationEnabled = false
-	_, err = fedClient.CoreV1alpha1().FederatedTypeConfigs(typeConfig.Namespace).Update(typeConfig)
-	if err != nil {
-		return fmt.Errorf("Error disabling propagation for FederatedTypeConfig %q: %v", typeConfigName, err)
+	write := func(data string) {
+		if cmdOut != nil {
+			cmdOut.Write([]byte(data))
+		}
+	}
+
+	if typeConfig.Spec.PropagationEnabled {
+		typeConfig.Spec.PropagationEnabled = false
+		_, err = fedClient.CoreV1alpha1().FederatedTypeConfigs(typeConfig.Namespace).Update(typeConfig)
+		if err != nil {
+			return fmt.Errorf("Error disabling propagation for FederatedTypeConfig %q: %v", typeConfigName, err)
+		}
+		write(fmt.Sprintf("Disabled propagation for FederatedTypeConfig %q\n", typeConfigName))
+	} else {
+		write(fmt.Sprintf("Propagation already disabled for FederatedTypeConfig %q\n", typeConfigName))
 	}
 	if !delete {
 		return nil
 	}
 
 	// TODO(marun) consider waiting for the sync controller to be stopped before attempting deletion
-	deletePrimitives(config, typeConfig)
+	deletePrimitives(config, typeConfig, write)
 	err = fedClient.CoreV1alpha1().FederatedTypeConfigs(typeConfigName.Namespace).Delete(typeConfigName.Name, nil)
 	if err != nil {
 		return fmt.Errorf("Error deleting FederatedTypeConfig %q: %v", typeConfigName, err)
 	}
+	write(fmt.Sprintf("federatedtypeconfig %q deleted\n", typeConfigName))
 
 	return nil
 }
 
-func deletePrimitives(config *rest.Config, typeConfig typeconfig.Interface) error {
+func deletePrimitives(config *rest.Config, typeConfig typeconfig.Interface, write func(string)) error {
 	client, err := apiextv1b1client.NewForConfig(config)
 	if err != nil {
 		return fmt.Errorf("Error creating crd client: %v", err)
@@ -181,7 +193,9 @@ func deletePrimitives(config *rest.Config, typeConfig typeconfig.Interface) erro
 		if err != nil && !errors.IsNotFound(err) {
 			glog.Errorf("Failed to delete crd %q: %v", crdName, err)
 			failedDeletion = append(failedDeletion, crdName)
+			continue
 		}
+		write(fmt.Sprintf("customresourcedefinition %q deleted\n", crdName))
 	}
 	if len(failedDeletion) > 0 {
 		return fmt.Errorf("The following crds were not deleted successfully (see error log for details): %v", failedDeletion)

--- a/test/e2e/crd.go
+++ b/test/e2e/crd.go
@@ -140,7 +140,7 @@ func validateCrdCrud(f framework.FederationFramework, targetCrdKind string, name
 	}
 	typeConfig := resources.TypeConfig
 
-	err = federate.CreateResources(hostConfig, resources)
+	err = federate.CreateResources(nil, hostConfig, resources)
 	if err != nil {
 		tl.Fatalf("Error creating resources to enable federation of target type %q: %v", targetAPIResource.Kind, err)
 	}
@@ -151,7 +151,7 @@ func validateCrdCrud(f framework.FederationFramework, targetCrdKind string, name
 		// CRDs is attempted even if the removal of any one CRD fails.
 		objectMeta := typeConfig.GetObjectMeta()
 		qualifiedName := util.QualifiedName{Namespace: objectMeta.Namespace, Name: objectMeta.Name}
-		err := federate.DisableFederation(hostConfig, qualifiedName, delete, dryRun)
+		err := federate.DisableFederation(nil, hostConfig, qualifiedName, delete, dryRun)
 		if err != nil {
 			tl.Fatalf("Error disabling federation of target type %q: %v", targetAPIResource.Kind, err)
 		}


### PR DESCRIPTION
This is intended to be in keeping with the output provided when creating and deleting resources with kubectl.