### PR TITLE
Introduce hyperfed command as a wrapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,4 @@
 /hack/install.yaml
 /hack/install-crds-latest.yaml
 /hack/install-namespaced.yaml
-/images/federation-v2/controller-manager
+/images/federation-v2/hyperfed

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1031,7 +1031,6 @@
     "k8s.io/client-go/kubernetes/scheme",
     "k8s.io/client-go/kubernetes/typed/core/v1",
     "k8s.io/client-go/plugin/pkg/client/auth",
-    "k8s.io/client-go/plugin/pkg/client/auth/gcp",
     "k8s.io/client-go/rest",
     "k8s.io/client-go/testing",
     "k8s.io/client-go/tools/cache",

--- a/cmd/controller-manager/app/controller-manager.go
+++ b/cmd/controller-manager/app/controller-manager.go
@@ -1,0 +1,151 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package app
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/golang/glog"
+	configlib "github.com/kubernetes-sigs/kubebuilder/pkg/config"
+	"github.com/kubernetes-sigs/kubebuilder/pkg/install"
+	"github.com/kubernetes-sigs/kubebuilder/pkg/signals"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	extv1b1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/apiserver/pkg/util/logs"
+
+	"github.com/kubernetes-sigs/federation-v2/cmd/controller-manager/app/options"
+	"github.com/kubernetes-sigs/federation-v2/pkg/controller/dnsendpoint"
+	"github.com/kubernetes-sigs/federation-v2/pkg/controller/federatedcluster"
+	"github.com/kubernetes-sigs/federation-v2/pkg/controller/federatedtypeconfig"
+	"github.com/kubernetes-sigs/federation-v2/pkg/controller/ingressdns"
+	"github.com/kubernetes-sigs/federation-v2/pkg/controller/schedulingmanager"
+	"github.com/kubernetes-sigs/federation-v2/pkg/controller/servicedns"
+	"github.com/kubernetes-sigs/federation-v2/pkg/features"
+	"github.com/kubernetes-sigs/federation-v2/pkg/inject"
+	"github.com/kubernetes-sigs/federation-v2/pkg/version"
+)
+
+// NewControllerManagerCommand creates a *cobra.Command object with default parameters
+func NewControllerManagerCommand() *cobra.Command {
+	verFlag := false
+	opts := options.NewOptions()
+
+	cmd := &cobra.Command{
+		Use: "controller-manager",
+		Long: `The Federation controller manager runs a bunch of controllers
+which watches federation CRD's and the corresponding resources in federation
+member clusters and does the necessary reconciliation`,
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Fprintf(os.Stdout, "Federation v2 controller-manager version: %s\n", fmt.Sprintf("%#v", version.Get()))
+			if verFlag {
+				os.Exit(0)
+			}
+			PrintFlags(cmd.Flags())
+
+			if err := Run(opts); err != nil {
+				fmt.Fprintf(os.Stderr, "%v\n", err)
+				os.Exit(1)
+			}
+		},
+	}
+
+	opts.AddFlags(cmd.Flags())
+	cmd.Flags().BoolVar(&verFlag, "version", false, "Prints the Version info of controller-manager")
+
+	return cmd
+}
+
+// Run runs the controller-manager with options. This should never exit.
+func Run(opts *options.Options) error {
+	logs.InitLogs()
+	defer logs.FlushLogs()
+
+	if err := utilfeature.DefaultFeatureGate.SetFromMap(opts.FeatureGates); err != nil {
+		glog.Fatalf("Invalid Feature Gate: %v", err)
+	}
+
+	stopChan := signals.SetupSignalHandler()
+
+	opts.Config.KubeConfig = configlib.GetConfigOrDie()
+
+	if opts.InstallCRDs {
+		if err := install.NewInstaller(opts.Config.KubeConfig).Install(&InstallStrategy{crds: inject.Injector.CRDs}); err != nil {
+			glog.Fatalf("Could not create CRDs: %v", err)
+		}
+	}
+
+	if opts.LimitedScope {
+		opts.Config.TargetNamespace = opts.Config.FederationNamespace
+		glog.Infof("Federation will be limited to the %q namespace", opts.Config.FederationNamespace)
+	} else {
+		opts.Config.TargetNamespace = metav1.NamespaceAll
+		glog.Info("Federation will target all namespaces")
+	}
+
+	federatedcluster.StartClusterController(opts.Config, stopChan, opts.ClusterMonitorPeriod)
+
+	if utilfeature.DefaultFeatureGate.Enabled(features.SchedulerPreferences) {
+		schedulingmanager.StartSchedulerController(opts.Config, stopChan)
+	}
+
+	if utilfeature.DefaultFeatureGate.Enabled(features.CrossClusterServiceDiscovery) {
+		if err := servicedns.StartController(opts.Config, stopChan); err != nil {
+			glog.Fatalf("Error starting dns controller: %v", err)
+		}
+
+		if err := dnsendpoint.StartServiceDNSEndpointController(opts.Config, stopChan); err != nil {
+			glog.Fatalf("Error starting dns endpoint controller: %v", err)
+		}
+	}
+
+	if utilfeature.DefaultFeatureGate.Enabled(features.FederatedIngress) {
+		if err := ingressdns.StartController(opts.Config, stopChan); err != nil {
+			glog.Fatalf("Error starting ingress dns controller: %v", err)
+		}
+
+		if err := dnsendpoint.StartIngressDNSEndpointController(opts.Config, stopChan); err != nil {
+			glog.Fatalf("Error starting ingress dns endpoint controller: %v", err)
+		}
+	}
+
+	if utilfeature.DefaultFeatureGate.Enabled(features.PushReconciler) {
+		federatedtypeconfig.StartController(opts.Config, stopChan)
+	}
+
+	// Blockforever
+	select {}
+}
+
+type InstallStrategy struct {
+	install.EmptyInstallStrategy
+	crds []*extv1b1.CustomResourceDefinition
+}
+
+func (s *InstallStrategy) GetCRDs() []*extv1b1.CustomResourceDefinition {
+	return s.crds
+}
+
+// PrintFlags logs the flags in the flagset
+func PrintFlags(flags *pflag.FlagSet) {
+	flags.VisitAll(func(flag *pflag.Flag) {
+		glog.V(1).Infof("FLAG: --%s=%q", flag.Name, flag.Value)
+	})
+}

--- a/cmd/controller-manager/app/options/options.go
+++ b/cmd/controller-manager/app/options/options.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package options contains flags and options for initializing controller-manager
+package options
+
+import (
+	"strings"
+	"time"
+
+	"github.com/spf13/pflag"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	flagutil "k8s.io/apiserver/pkg/util/flag"
+
+	"github.com/kubernetes-sigs/federation-v2/pkg/controller/util"
+)
+
+// Options contains everything necessary to create and run controller-manager.
+type Options struct {
+	Config               *util.ControllerConfig
+	FeatureGates         map[string]bool
+	ClusterMonitorPeriod time.Duration
+	LimitedScope         bool
+	InstallCRDs          bool
+}
+
+// AddFlags adds flags to fs and binds them to options.
+func (o *Options) AddFlags(fs *pflag.FlagSet) {
+	fs.BoolVar(&o.InstallCRDs, "install-crds", true, "install the CRDs used by the controller as part of startup")
+	fs.Var(flagutil.NewMapStringBool(&o.FeatureGates), "feature-gates", "A set of key=value pairs that describe feature gates for alpha/experimental features. "+
+		"Options are:\n"+strings.Join(utilfeature.DefaultFeatureGate.KnownFeatures(), "\n"))
+
+	fs.StringVar(&o.Config.FederationNamespace, "federation-namespace", util.DefaultFederationSystemNamespace, "The namespace the federation control plane is deployed in.")
+	fs.StringVar(&o.Config.ClusterNamespace, "registry-namespace", util.MulticlusterPublicNamespace, "The cluster registry namespace.")
+	fs.DurationVar(&o.Config.ClusterAvailableDelay, "cluster-available-delay", util.DefaultClusterAvailableDelay, "Time to wait before reconciling on a healthy cluster.")
+	fs.DurationVar(&o.Config.ClusterUnavailableDelay, "cluster-unavailable-delay", util.DefaultClusterUnavailableDelay, "Time to wait before giving up on an unhealthy cluster.")
+
+	fs.BoolVar(&o.LimitedScope, "limited-scope", false, "Whether the federation namespace will be the only target for federation.")
+	fs.DurationVar(&o.ClusterMonitorPeriod, "cluster-monitor-period", time.Second*40, "How often to monitor the cluster health")
+}
+
+func NewOptions() *Options {
+	return &Options{
+		Config:       new(util.ControllerConfig),
+		FeatureGates: make(map[string]bool),
+	}
+}

--- a/cmd/hyperfed/main.go
+++ b/cmd/hyperfed/main.go
@@ -1,0 +1,134 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// A binary that can morph into all of the other federation-v2 binaries. You can
+// also soft-link to it busybox style.
+//
+package main
+
+import (
+	"errors"
+	goflag "flag"
+	"fmt"
+	"math/rand"
+	"os"
+	"path"
+	"path/filepath"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	utilflag "k8s.io/apiserver/pkg/util/flag"
+	"k8s.io/apiserver/pkg/util/logs"
+	_ "k8s.io/client-go/plugin/pkg/client/auth" // Load all client auth plugins for GCP, Azure, Openstack, etc
+
+	"github.com/kubernetes-sigs/federation-v2/cmd/controller-manager/app"
+	"github.com/kubernetes-sigs/federation-v2/pkg/kubefed2"
+)
+
+func main() {
+	rand.Seed(time.Now().UnixNano())
+
+	hyperfedCommand, allCommandFns := NewHyperFedCommand()
+
+	pflag.CommandLine.SetNormalizeFunc(utilflag.WordSepNormalizeFunc)
+	pflag.CommandLine.AddGoFlagSet(goflag.CommandLine)
+
+	logs.InitLogs()
+	defer logs.FlushLogs()
+
+	basename := filepath.Base(os.Args[0])
+	if err := commandFor(basename, hyperfedCommand, allCommandFns).Execute(); err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+}
+
+func commandFor(basename string, defaultCommand *cobra.Command, commands []func() *cobra.Command) *cobra.Command {
+	for _, commandFn := range commands {
+		command := commandFn()
+		if command.Name() == basename {
+			return command
+		}
+		for _, alias := range command.Aliases {
+			if alias == basename {
+				return command
+			}
+		}
+	}
+
+	return defaultCommand
+}
+
+// NewHyperFedCommand is the entry point for hyperfed
+func NewHyperFedCommand() (*cobra.Command, []func() *cobra.Command) {
+	controller := func() *cobra.Command { return app.NewControllerManagerCommand() }
+	kubefed2Cmd := func() *cobra.Command { return kubefed2.NewKubeFed2Command(os.Stdout) }
+
+	commandFns := []func() *cobra.Command{
+		controller,
+		kubefed2Cmd,
+	}
+
+	makeSymlinksFlag := false
+	cmd := &cobra.Command{
+		Use:   "hyperfed",
+		Short: "Combined binary for federation-v2",
+		Run: func(cmd *cobra.Command, args []string) {
+			if len(args) != 0 || !makeSymlinksFlag {
+				cmd.Help()
+				os.Exit(1)
+			}
+
+			if err := makeSymlinks(os.Args[0], commandFns); err != nil {
+				fmt.Fprintf(os.Stderr, "%v\n", err.Error())
+			}
+		},
+	}
+	cmd.Flags().BoolVar(&makeSymlinksFlag, "make-symlinks", makeSymlinksFlag, "create a symlink for each server in current directory")
+	cmd.Flags().MarkHidden("make-symlinks") // hide this flag from appearing in servers' usage output
+
+	for i := range commandFns {
+		cmd.AddCommand(commandFns[i]())
+	}
+
+	return cmd, commandFns
+}
+
+// makeSymlinks will create a symlink for each command in the local directory.
+func makeSymlinks(targetName string, commandFns []func() *cobra.Command) error {
+	wd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+
+	var errs bool
+	for _, commandFn := range commandFns {
+		command := commandFn()
+		link := path.Join(wd, command.Name())
+
+		err := os.Symlink(targetName, link)
+		if err != nil {
+			errs = true
+			fmt.Println(err)
+		}
+	}
+
+	if errs {
+		return errors.New("Error creating one or more symlinks.")
+	}
+	return nil
+}

--- a/cmd/kubefed2/kubefed2.go
+++ b/cmd/kubefed2/kubefed2.go
@@ -21,17 +21,17 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/kubernetes-sigs/federation-v2/pkg/kubefed2"
 	"k8s.io/apiserver/pkg/util/logs"
-	_ "k8s.io/client-go/plugin/pkg/client/auth" // Load all client auth plugins for GCP, Azure, etc
+	_ "k8s.io/client-go/plugin/pkg/client/auth" // Load all client auth plugins for GCP, Azure, Openstack, etc
+
+	"github.com/kubernetes-sigs/federation-v2/pkg/kubefed2"
 )
 
 func main() {
 	logs.InitLogs()
 	defer logs.FlushLogs()
 
-	err := kubefed2.NewKubeFed2Command(os.Stdout).Execute()
-	if err != nil {
+	if err := kubefed2.NewKubeFed2Command(os.Stdout).Execute(); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)
 	}

--- a/docs/development.md
+++ b/docs/development.md
@@ -262,7 +262,7 @@ Run the following commands using the committed `images/federation-v2/Dockerfile`
 and push a container image to use for deployment:
 
 ```bash
-CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o images/federation-v2/controller-manager cmd/controller-manager/main.go
+CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o images/federation-v2/hyperfed cmd/hyperfed/main.go
 docker build images/federation-v2 -t <containerregistry>/<username>/federation-v2:test
 docker push <containerregistry>/<username>/federation-v2:test
 ```

--- a/images/federation-v2/Dockerfile
+++ b/images/federation-v2/Dockerfile
@@ -15,7 +15,11 @@
 
 FROM alpine:latest
 RUN apk --no-cache add ca-certificates
+
 WORKDIR /root/
-COPY /controller-manager .
+COPY /hyperfed .
+RUN ln -s hyperfed controller-manager \
+ && ln -s hyperfed kubefed2
+
 ENTRYPOINT ["./controller-manager"]
 CMD ["--install-crds=false"]

--- a/scripts/deploy-federation.sh
+++ b/scripts/deploy-federation.sh
@@ -101,7 +101,7 @@ fi
 if [[ ! "${USE_LATEST}" ]]; then
   base_dir="$(cd "$(dirname "$0")/.." ; pwd)"
   dockerfile_dir="${base_dir}/images/federation-v2"
-  CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o "${dockerfile_dir}"/controller-manager "${base_dir}"/cmd/controller-manager/main.go
+  CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o "${dockerfile_dir}"/hyperfed "${base_dir}"/cmd/hyperfed/main.go
   docker build ${dockerfile_dir} -t "${IMAGE_NAME}"
   ${DOCKER_PUSH_CMD}
 fi

--- a/scripts/imagebuild.sh
+++ b/scripts/imagebuild.sh
@@ -21,7 +21,7 @@ set -o pipefail
 base_dir="$(cd "$(dirname "$0")/.." ; pwd)"
 dockerfile_dir="${base_dir}/images/federation-v2"
 
-[ -f "$base_dir/bin/controller-manager" ] || { echo "$base_dir/bin/controller-manager not found" ; exit 1 ;}
+[ -f "$base_dir/bin/hyperfed" ] || { echo "$base_dir/bin/hyperfed not found" ; exit 1 ;}
 echo "travis tag: ${TRAVIS_TAG}"
 echo "travis branch:${TRAVIS_BRANCH}"
 if [[ "${TRAVIS_TAG}" =~ ^v([0-9]\.)+([0-9])[-a-zA-Z0-9]*([.0-9])* ]]; then
@@ -41,8 +41,8 @@ echo "Starting image build"
 export REGISTRY=quay.io/
 export REPO=kubernetes-multicluster
 
-echo "Copy controller manager"
-cp ${base_dir}/bin/controller-manager ${dockerfile_dir}/controller-manager
+echo "Copy hyperfed"
+cp ${base_dir}/bin/hyperfed ${dockerfile_dir}/hyperfed
 
 echo "Logging into registry ${REGISTRY///}"
 docker login -u "${QUAY_USERNAME}" -p "${QUAY_PASSWORD}" quay.io
@@ -60,4 +60,4 @@ if [ "$LATEST" == "latest" ]; then
    docker push ${REGISTRY}${REPO}/federation-v2:${LATEST}
 fi
 
-rm ${dockerfile_dir}/controller-manager
+rm ${dockerfile_dir}/hyperfed


### PR DESCRIPTION
similar to `hyperkube` command in k8s, `hyperfed` command is introduced as a wrapper for controller-manager and kubefed2 binaries. This is according to the comment in https://github.com/kubernetes-sigs/federation-v2/pull/416#issuecomment-438718379

