### PR TITLE
Fixed examples in the sample1 folder

### DIFF
--- a/docs/userguide.md
+++ b/docs/userguide.md
@@ -206,6 +206,12 @@ Create all the test resources by running:
 ```bash
 kubectl apply -R -f example/sample1
 ```
+**NOTE:** If you get the following error while creating a test resource i.e.
+```
+unable to recognize "example/sample1/Federated<type>-placement.yaml": no matches for kind "Federated<type>Placement" in version "primitives.federation.k8s.io/v1alpha1", 
+
+```
+then it indicates that a given type may need to be federated by `kubefed2 federate enable <type>`
 
 ### Check Status of Resources
 

--- a/example/sample1/federatedclusterrole-placement.yaml
+++ b/example/sample1/federatedclusterrole-placement.yaml
@@ -1,4 +1,4 @@
-apiVersion: generated.federation.k8s.io/v1alpha1
+apiVersion: primitives.federation.k8s.io/v1alpha1
 kind: FederatedClusterRolePlacement
 metadata:
   name: test-clusterrole

--- a/example/sample1/federatedclusterrole-template.yaml
+++ b/example/sample1/federatedclusterrole-template.yaml
@@ -1,4 +1,4 @@
-apiVersion: generated.federation.k8s.io/v1alpha1
+apiVersion: primitives.federation.k8s.io/v1alpha1
 kind: FederatedClusterRole
 metadata:
   name: test-clusterrole

--- a/example/sample1/federatedclusterrolebinding-placement.yaml
+++ b/example/sample1/federatedclusterrolebinding-placement.yaml
@@ -1,4 +1,4 @@
-apiVersion: generated.federation.k8s.io/v1alpha1
+apiVersion: primitives.federation.k8s.io/v1alpha1
 kind: FederatedClusterRoleBindingPlacement
 metadata:
   name: test-clusterrolebinding

--- a/example/sample1/federatedclusterrolebinding-template.yaml
+++ b/example/sample1/federatedclusterrolebinding-template.yaml
@@ -1,4 +1,4 @@
-apiVersion: generated.federation.k8s.io/v1alpha1
+apiVersion: primitives.federation.k8s.io/v1alpha1
 kind: FederatedClusterRoleBinding
 metadata:
   name: test-clusterrolebinding

--- a/example/sample1/federatedconfigmap-override.yaml
+++ b/example/sample1/federatedconfigmap-override.yaml
@@ -5,6 +5,6 @@ metadata:
   namespace: test-namespace
 spec:
   overrides:
-    clusterName: cluster2
+  - clusterName: cluster2
     data:
       foo: bar


### PR DESCRIPTION
I was trying to create the test resources using the command below:
```bash
kubectl apply -R -f example/sample1
```
and the command was failing due to the following errors:
```
Error from server (Invalid): error when creating "example/sample1/federatedconfigmap-override.yaml": FederatedConfigMapOverride.core.federation.k8s.io "test-configmap" is invalid: []: Invalid value: map[string]interface {}{"apiVersion":"core.federation.k8s.io/v1alpha1", "kind":"FederatedConfigMapOverride", "metadata":map[string]interface {}{"clusterName":"", "name":"test-configmap", "namespace":"test-namespace", "creationTimestamp":"2018-11-15T18:02:41Z", "annotations":map[string]interface {}{"kubectl.kubernetes.io/last-applied-configuration":"{\"apiVersion\":\"core.federation.k8s.io/v1alpha1\",\"kind\":\"FederatedConfigMapOverride\",\"metadata\":{\"annotations\":{},\"name\":\"test-configmap\",\"namespace\":\"test-namespace\"},\"spec\":{\"overrides\":{\"clusterName\":\"cluster2\",\"data\":{\"foo\":\"bar\"}}}}\n"}, "generation":1, "uid":"a556a156-e900-11e8-bc3d-0800279c789d", "selfLink":""}, "spec":map[string]interface {}{"overrides":map[string]interface {}{"clusterName":"cluster2", "data":map[string]interface {}{"foo":"bar"}}}}: validation failure list:
spec.overrides in body must be of type array: "object"

[unable to recognize "example/sample1/federatedclusterrole-placement.yaml": no matches for kind "FederatedClusterRolePlacement" in version "generated.federation.k8s.io/v1alpha1", unable to recognize "example/sample1/federatedclusterrole-template.yaml": no matches for kind "FederatedClusterRole" in version "generated.federation.k8s.io/v1alpha1", unable to recognize "example/sample1/federatedclusterrolebinding-placement.yaml": no matches for kind "FederatedClusterRoleBindingPlacement" in version "generated.federation.k8s.io/v1alpha1", unable to recognize "example/sample1/federatedclusterrolebinding-template.yaml": no matches for kind "FederatedClusterRoleBinding" in version "generated.federation.k8s.io/v1alpha1"]

```
so creating this PR to address these issues.