### PR TITLE
Add support for 'federate enable' to be configured from a file

### DIFF
--- a/pkg/kubefed2/federate/directive.go
+++ b/pkg/kubefed2/federate/directive.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package federate
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kubernetes-sigs/federation-v2/pkg/apis/core/common"
+	fedv1a1 "github.com/kubernetes-sigs/federation-v2/pkg/apis/core/v1alpha1"
+)
+
+// FederateDirectiveSpec defines the desired state of FederateDirective.
+type FederateDirectiveSpec struct {
+	// The API version of the target type.
+	// +optional
+	TargetVersion string `json:"targetVersion,omitempty"`
+
+	// Which field of the target type determines whether federation
+	// considers two resources to be equal.
+	ComparisonField common.VersionComparisonField `json:"comparisonField"`
+
+	// The name of the API group to use for generated federation primitives.
+	// +optional
+	PrimitiveGroup string `json:"primitiveGroup,omitempty"`
+
+	// The API version to use for generated federation primitives.
+	// +optional
+	PrimitiveVersion string `json:"primitiveVersion,omitempty"`
+
+	// The list of name:path pairs of the fields to override in target template.
+	// +optional
+	OverridePaths []fedv1a1.OverridePath `json:"overridePaths,omitempty"`
+}
+
+// TODO(marun) This should become a proper API type and drive enabling
+// type federation via a controller.  For now its only purpose is to
+// enable loading of configuration from disk.
+type FederateDirective struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	Spec FederateDirectiveSpec `json:"spec,omitempty"`
+}
+
+func (ft *FederateDirective) SetDefaults() {
+	ft.Spec.ComparisonField = defaultComparisonField
+	ft.Spec.PrimitiveGroup = defaultPrimitiveGroup
+	ft.Spec.PrimitiveVersion = defaultPrimitiveVersion
+}
+
+func NewFederateDirective() *FederateDirective {
+	ft := &FederateDirective{}
+	ft.SetDefaults()
+	return ft
+}

--- a/pkg/kubefed2/federate/util.go
+++ b/pkg/kubefed2/federate/util.go
@@ -18,14 +18,32 @@ package federate
 
 import (
 	"fmt"
+	"io"
+	"os"
 	"strings"
 
 	apiextv1b1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/rest"
 )
+
+func DecodeYAMLFromFile(filename string, obj interface{}) error {
+	f, err := os.Open(filename)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	return DecodeYAML(f, obj)
+}
+
+func DecodeYAML(r io.Reader, obj interface{}) error {
+	decoder := yaml.NewYAMLToJSONDecoder(r)
+	return decoder.Decode(obj)
+}
 
 func CrdForAPIResource(apiResource metav1.APIResource, validation *apiextv1b1.CustomResourceValidation) *apiextv1b1.CustomResourceDefinition {
 	scope := apiextv1b1.ClusterScoped

--- a/test/e2e/version.go
+++ b/test/e2e/version.go
@@ -40,8 +40,8 @@ import (
 	corev1alpha1 "github.com/kubernetes-sigs/federation-v2/pkg/client/clientset/versioned/typed/core/v1alpha1"
 	"github.com/kubernetes-sigs/federation-v2/pkg/controller/sync/version"
 	"github.com/kubernetes-sigs/federation-v2/pkg/controller/util"
+	"github.com/kubernetes-sigs/federation-v2/pkg/kubefed2/federate"
 	"github.com/kubernetes-sigs/federation-v2/test/common"
-	testcommon "github.com/kubernetes-sigs/federation-v2/test/common"
 	"github.com/kubernetes-sigs/federation-v2/test/e2e/framework"
 
 	. "github.com/onsi/ginkgo"
@@ -228,8 +228,8 @@ var _ = Describe("VersionManager", func() {
 				// sync controllers add a deletion finalizer to the
 				// created template that would complicate validating
 				// garbage collection.
-				var err error
-				template, err = testcommon.ReaderToObj(strings.NewReader(adapter.TemplateYAML()))
+				template = &unstructured.Unstructured{}
+				err := federate.DecodeYAML(strings.NewReader(adapter.TemplateYAML()), template)
 				if err != nil {
 					tl.Fatalf("Failed to parse template yaml: %v", err)
 				}


### PR DESCRIPTION
This is intended to simplify the encoding of configuration for the types whose propagation will be enabled be default.