### PR TITLE
Enable CI testing with multiple clusters using kind

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ install:
   -
 
 script:
-  - bash -x ./scripts/pre-commit.sh
+  - CONFIGURE_INSECURE_REGISTRY=y bash -x ./scripts/pre-commit.sh
   - vendor/github.com/kubernetes/repo-infra/verify/verify-boilerplate.sh -- rootdir="$GOPATH/src/github.com/kubernetes-sigs/federation-v2" -v
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,6 @@ sudo: required
 services:
   - docker
 
-# Install dependencies for launching minikube cluster.
-before_install:
-  - sudo apt-get update
-  - sudo apt-get install -y socat ebtables
-
 # Install must be set to prevent default `go get` to run.
 # The dependencies have already been vendored by `dep` so
 # we don't need to fetch them.

--- a/scripts/download-e2e-binaries.sh
+++ b/scripts/download-e2e-binaries.sh
@@ -21,11 +21,6 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-# Use DEBUG=1 ./scripts/download-e2e-binaries.sh to get debug output
-[[ -z "${DEBUG:-""}" ]] || {
-  set -x
-}
-
 logEnd() {
   local msg='done.'
   [ "$1" -eq 0 ] || msg='Error downloading assets'

--- a/scripts/download-e2e-binaries.sh
+++ b/scripts/download-e2e-binaries.sh
@@ -22,10 +22,8 @@ set -o nounset
 set -o pipefail
 
 # Use DEBUG=1 ./scripts/download-e2e-binaries.sh to get debug output
-curl_args="-Ls"
 [[ -z "${DEBUG:-""}" ]] || {
   set -x
-  curl_args="-L"
 }
 
 logEnd() {
@@ -37,31 +35,21 @@ trap 'logEnd $?' EXIT
 
 echo "About to download some binaries. This might take a while..."
 
-root_dir="$(cd "$(dirname "$0")/.." ; pwd)"
-dest_dir="${root_dir}/bin"
-mkdir -p "${dest_dir}"
+GOBIN="$(go env GOPATH)/bin"
 
-# Minikube
-mk_version="0.28.1"
-mk_bin="minikube-linux-amd64"
-mk_url="https://github.com/kubernetes/minikube/releases/download/v${mk_version}/${mk_bin}"
-mk_dest="${dest_dir}/minikube"
-curl "${curl_args}" "${mk_url}" --output "${mk_dest}"
-chmod 755 "${mk_dest}"
-
-# crictl
-crictl_version="1.11.1"
-crictl_tgz="crictl-v1.11.1-linux-amd64.tar.gz"
-crictl_url="https://github.com/kubernetes-incubator/cri-tools/releases/download/v${crictl_version}/${crictl_tgz}"
-curl "${curl_args}O" "${crictl_url}" \
-  && tar xzfP "${crictl_tgz}" -C "${dest_dir}" \
-  && rm "${crictl_tgz}"
+# kind
+# TODO(font): kind does not have versioning yet.
+kind_version="4d7dded365359afeb1831292cd1a3a3e15fff0b2"
+kind_bin="kind"
+kind_url="sigs.k8s.io"
+go get -d ${kind_url}/${kind_bin}
+pushd ${GOPATH}/src/${kind_url}/${kind_bin}
+git checkout ${kind_version}
+popd
+go install ${kind_url}/${kind_bin}
 
 # Pull the busybox image (used in tests of workload types)
 docker pull busybox
 
-echo    "# destination:"
-echo    "#   ${dest_dir}"
-echo    "# versions:"
-echo -n "#   minikube:           "; ${dest_dir}/minikube version | awk '{print $3}'
-echo -n "#     crictl:           "; ${dest_dir}/crictl --version | awk '{print $3}'
+echo    "# bin destination:    ${GOBIN}"
+echo    "# kind installation:  ${GOBIN}/kind"

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -23,6 +23,10 @@ set -o pipefail
 source "$(dirname "${BASH_SOURCE}")/util.sh"
 ROOT_DIR="$(cd "$(dirname "$0")/.." ; pwd)"
 MAKE_CMD="make -C ${ROOT_DIR}"
+NUM_CLUSTERS="${NUM_CLUSTERS:-2}"
+JOIN_CLUSTERS="${JOIN_CLUSTERS:-}"
+CONFIGURE_INSECURE_REGISTRY="${CONFIGURE_INSECURE_REGISTRY:-}"
+CONTAINER_REGISTRY_HOST="${CONTAINER_REGISTRY_HOST:-172.17.0.1:5000}"
 MANAGED_E2E_TEST_CMD="go test -v ./test/e2e -args -ginkgo.v -single-call-timeout=1m -ginkgo.trace -ginkgo.randomizeAllSpecs"
 # Specifying a kube config allows the tests to target deployed (unmanaged) fixture
 UNMANAGED_E2E_TEST_CMD="${MANAGED_E2E_TEST_CMD} -kubeconfig=${HOME}/.kube/config"
@@ -40,17 +44,113 @@ function run-e2e-tests-with-managed-fixture() {
   ${MANAGED_E2E_TEST_CMD}
 }
 
-function launch-minikube-cluster() {
-  # Move crictl to system path as expected by kubeadm.
-  sudo mv ${TEST_ASSET_PATH}/crictl /usr/bin/
-  sudo bash -c "export PATH=${PATH}; minikube start -p cluster1 --kubernetes-version v1.11.0 --vm-driver=none --v=4"
+docker_daemon_config="/etc/docker/daemon.json"
 
-  # Change ownership of .kube and .minikube config to use without sudo.
-  sudo chown -R $USER $HOME/.kube
-  sudo chgrp -R $USER $HOME/.kube
+function create-and-configure-insecure-registry() {
+  # Run insecure registry as container
+  docker run -d -p 5000:5000 --restart=always --name registry registry:2
 
-  sudo chown -R $USER $HOME/.minikube
-  sudo chgrp -R $USER $HOME/.minikube
+  if [[ -z "${CONFIGURE_INSECURE_REGISTRY}" ]]; then
+    return
+  fi
+
+  if sudo test -f "${docker_daemon_config}"; then
+    echo <<EOF "Error: ${docker_daemon_config} exists and \
+CONFIGURE_INSECURE_REGISTRY=${CONFIGURE_INSECURE_REGISTRY}. This script needs \
+to add an 'insecure-registries' entry with host '${CONTAINER_REGISTRY_HOST}' to \
+${docker_daemon_config}. Please make the necessary changes or backup and try again."
+EOF
+    return 1
+  fi
+
+  configure-insecure-registry-and-reload "sudo bash -c" $(pgrep dockerd)
+}
+
+function configure-insecure-registry-and-reload() {
+  local cmd_context="${1}" # context to run command e.g. sudo, docker exec
+  local docker_pid="${2}"
+  ${cmd_context} "$(insecure-registry-config-cmd)"
+  ${cmd_context} "$(reload-docker-daemon-cmd "${docker_pid}")"
+}
+
+function insecure-registry-config-cmd() {
+  echo "cat <<EOF > ${docker_daemon_config}
+{
+    \"insecure-registries\": [\"${CONTAINER_REGISTRY_HOST}\"]
+}
+EOF
+"
+}
+
+function reload-docker-daemon-cmd() {
+  echo "kill -s SIGHUP ${1}"
+}
+
+function create-clusters() {
+  local num_clusters=${1}
+
+  for i in $(seq ${num_clusters}); do
+    # kind will create cluster with name: kind-${i}
+    kind create cluster --name ${i}
+    # TODO(font): remove once all workarounds are addressed.
+    fixup-cluster ${i}
+  done
+
+  # TODO(font): kind will create separate kubeconfig files for each cluster.
+  # Remove once https://github.com/kubernetes-sigs/kind/issues/113 is resolved.
+  kubectl config view --flatten > ~/.kube/config
+  unset KUBECONFIG
+
+  echo "Waiting for clusters to be ready"
+  check-clusters-ready ${num_clusters}
+
+  # TODO(font): Configure insecure registry on kind host cluster. Remove once
+  # https://github.com/kubernetes-sigs/kind/issues/110 is resolved.
+  configure-insecure-registry-on-cluster 1
+
+  # Initialize list of clusters to join
+  join-cluster-list > /dev/null
+}
+
+function fixup-cluster() {
+  local i=${1} # cluster num
+
+  local kubeconfig_path="$(kind get kubeconfig-path --name ${i})"
+  export KUBECONFIG="${KUBECONFIG:-}:${kubeconfig_path}"
+
+  # Simplify context name
+  kubectl config rename-context kubernetes-admin@kind-${i} kind-${i}
+
+  # TODO(font): Need to set container IP address in order for clusters to reach
+  # kube API servers in other clusters until
+  # https://github.com/kubernetes-sigs/kind/issues/111 is resolved.
+  local container_ip_addr=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' kind-${i}-control-plane)
+  sed -i "s/localhost/${container_ip_addr}/" ${kubeconfig_path}
+
+  # TODO(font): Need to rename auth user name to avoid conflicts when using
+  # multiple cluster kubeconfigs. Remove once
+  # https://github.com/kubernetes-sigs/kind/issues/112 is resolved.
+  sed -i "s/kubernetes-admin/kubernetes-kind-${i}-admin/" ${kubeconfig_path}
+}
+
+function check-clusters-ready() {
+  for i in $(seq ${1}); do
+    util::wait-for-condition 'ok' "kubectl --context kind-${i} get --raw=/healthz" 120
+  done
+}
+
+function configure-insecure-registry-on-cluster() {
+  configure-insecure-registry-and-reload "docker exec kind-${1}-control-plane bash -c" '$(pgrep dockerd)'
+}
+
+function join-cluster-list() {
+  if [[ -z "${JOIN_CLUSTERS}" ]]; then
+    for i in $(seq 2 ${NUM_CLUSTERS}); do
+      JOIN_CLUSTERS+="kind-${i} "
+    done
+    export JOIN_CLUSTERS=$(echo ${JOIN_CLUSTERS} | sed 's/ $//')
+  fi
+  echo "${JOIN_CLUSTERS}"
 }
 
 function run-e2e-tests-with-unmanaged-fixture() {
@@ -75,7 +175,7 @@ function check-install-yaml() {
   PATH="${PATH}:${base_dir}/bin" FEDERATION_NAMESPACE=federation-system \
     INSTALL_YAML=./hack/install-latest.yaml \
     ./scripts/generate-install-yaml.sh \
-    quay.io/kubernetes-multicluster/federation-v2:latest
+    ${CONTAINER_REGISTRY_HOST}/federation-v2:latest
   echo "Checking state of working tree after generating install yaml"
   check-git-state
 }
@@ -126,14 +226,14 @@ echo "Downloading e2e test dependencies"
 
 export PATH=${TEST_ASSET_PATH}:${PATH}
 
-echo "Launching minikube cluster"
-launch-minikube-cluster
+echo "Creating container registry on host"
+create-and-configure-insecure-registry
 
-echo "Waiting for minikube cluster to be ready"
-util::wait-for-condition 'ok' 'kubectl get --raw=/healthz' 120
+echo "Creating ${NUM_CLUSTERS} clusters"
+create-clusters ${NUM_CLUSTERS}
 
 echo "Deploying federation-v2"
-DOCKER_PUSH=false ./scripts/deploy-federation.sh quay.io/kubernetes-multicluster/federation-v2:e2e
+./scripts/deploy-federation.sh ${CONTAINER_REGISTRY_HOST}/federation-v2:e2e $(join-cluster-list)
 
 echo "Running go e2e tests with unmanaged fixture"
 run-e2e-tests-with-unmanaged-fixture
@@ -142,7 +242,7 @@ echo "Deleting federation-v2"
 ./scripts/delete-federation.sh
 
 echo "Deploying namespaced federation-v2"
-FEDERATION_NAMESPACE=foo NAMESPACED=y DOCKER_PUSH=false ./scripts/deploy-federation.sh quay.io/kubernetes-multicluster/federation-v2:e2e
+FEDERATION_NAMESPACE=foo NAMESPACED=y ./scripts/deploy-federation.sh ${CONTAINER_REGISTRY_HOST}/federation-v2:e2e $(join-cluster-list)
 
 echo "Running go e2e tests with unmanaged fixture"
 run-namespaced-e2e-tests-with-unmanaged-fixture


### PR DESCRIPTION
This adds support for running CI with multiple clusters using the new tool [`kind`](https://github.com/kubernetes-sigs/kind)(kubernetes in docker). You can also run the `pre-commit.sh` script locally as well. The number of clusters is 2 by default, but you can override this if you'd like to test with a different number.

There are a few `kind` workarounds that are implemented in this PR until these issues are resolved:
https://github.com/kubernetes-sigs/kind/issues/110
https://github.com/kubernetes-sigs/kind/issues/111
https://github.com/kubernetes-sigs/kind/issues/112
https://github.com/kubernetes-sigs/kind/issues/113

Also, adding a versioned release for `kind` is still WIP (PR is at https://github.com/kubernetes-sigs/kind/pull/81). For now we have to rely on a git sha.

Lastly, this adds ~3 minutes to the CI job run time. There is perhaps some savings by not having to launch a minikube cluster anymore, albeit with some `kind` workarounds for the time being, but this adds a crucial extra cluster to each test.

Next will be to add docs for a dev workflow.