### PR TITLE
Add option to skip download-binaries in pre-commit.sh

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ install:
   -
 
 script:
-  - CONFIGURE_INSECURE_REGISTRY=y bash -x ./scripts/pre-commit.sh
+  - CONFIGURE_INSECURE_REGISTRY=y DOWNLOAD_BINARIES=y bash -x ./scripts/pre-commit.sh
   - vendor/github.com/kubernetes/repo-infra/verify/verify-boilerplate.sh -- rootdir="$GOPATH/src/github.com/kubernetes-sigs/federation-v2" -v
 
 after_success:

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -33,6 +33,7 @@ MANAGED_E2E_TEST_CMD="go test -v ./test/e2e -args -ginkgo.v -single-call-timeout
 UNMANAGED_E2E_TEST_CMD="${MANAGED_E2E_TEST_CMD} -kubeconfig=${HOME}/.kube/config"
 
 function build-binaries() {
+  ${MAKE_CMD} hyperfed
   ${MAKE_CMD} controller
   ${MAKE_CMD} kubefed2
 }

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -25,6 +25,7 @@ ROOT_DIR="$(cd "$(dirname "$0")/.." ; pwd)"
 MAKE_CMD="make -C ${ROOT_DIR}"
 NUM_CLUSTERS="${NUM_CLUSTERS:-2}"
 JOIN_CLUSTERS="${JOIN_CLUSTERS:-}"
+DOWNLOAD_BINARIES="${DOWNLOAD_BINARIES:-}"
 CONFIGURE_INSECURE_REGISTRY="${CONFIGURE_INSECURE_REGISTRY:-}"
 CONTAINER_REGISTRY_HOST="${CONTAINER_REGISTRY_HOST:-172.17.0.1:5000}"
 MANAGED_E2E_TEST_CMD="go test -v ./test/e2e -args -ginkgo.v -single-call-timeout=1m -ginkgo.trace -ginkgo.randomizeAllSpecs"
@@ -34,6 +35,14 @@ UNMANAGED_E2E_TEST_CMD="${MANAGED_E2E_TEST_CMD} -kubeconfig=${HOME}/.kube/config
 function build-binaries() {
   ${MAKE_CMD} controller
   ${MAKE_CMD} kubefed2
+}
+
+function download-dependencies() {
+  if [[ -z "${DOWNLOAD_BINARIES}" ]]; then
+    return
+  fi
+
+  ./scripts/download-binaries.sh
 }
 
 function run-e2e-tests-with-managed-fixture() {
@@ -201,7 +210,7 @@ cd "$base_dir" || {
 }
 
 echo "Downloading test dependencies"
-./scripts/download-binaries.sh
+download-dependencies
 
 echo "Checking initial state of working tree"
 check-git-state


### PR DESCRIPTION
Add option to skip download-binaries in pre-commit.sh, so that when the script is called in development environment, we need not keep downloading the binaries every time.

Also added a check to successfully build hyperfed binary.

/cc @font @marun 