### PR TITLE
Always load the namespace type config from the api

### DIFF
--- a/test/e2e/framework/managed.go
+++ b/test/e2e/framework/managed.go
@@ -143,6 +143,6 @@ func (f *ManagedFramework) TestNamespaceName() string {
 	return f.testNamespaceName
 }
 
-func (f *ManagedFramework) SetUpSyncControllerFixture(typeConfig typeconfig.Interface) managed.TestFixture {
-	return managed.NewSyncControllerFixture(f.logger, f.ControllerConfig(), typeConfig)
+func (f *ManagedFramework) setUpSyncControllerFixture(typeConfig typeconfig.Interface, namespacePlacement *metav1.APIResource) managed.TestFixture {
+	return managed.NewSyncControllerFixture(f.logger, f.ControllerConfig(), typeConfig, namespacePlacement)
 }

--- a/test/e2e/framework/managed/controller.go
+++ b/test/e2e/framework/managed/controller.go
@@ -19,6 +19,8 @@ package managed
 import (
 	"time"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/kubernetes-sigs/federation-v2/pkg/apis/core/typeconfig"
 	"github.com/kubernetes-sigs/federation-v2/pkg/controller/dnsendpoint"
 	"github.com/kubernetes-sigs/federation-v2/pkg/controller/federatedcluster"
@@ -37,11 +39,11 @@ type ControllerFixture struct {
 }
 
 // NewSyncControllerFixture initializes a new sync controller fixture.
-func NewSyncControllerFixture(tl common.TestLogger, controllerConfig *util.ControllerConfig, typeConfig typeconfig.Interface) *ControllerFixture {
+func NewSyncControllerFixture(tl common.TestLogger, controllerConfig *util.ControllerConfig, typeConfig typeconfig.Interface, namespacePlacement *metav1.APIResource) *ControllerFixture {
 	f := &ControllerFixture{
 		stopChan: make(chan struct{}),
 	}
-	err := sync.StartFederationSyncController(controllerConfig, f.stopChan, typeConfig)
+	err := sync.StartFederationSyncController(controllerConfig, f.stopChan, typeConfig, namespacePlacement)
 	if err != nil {
 		tl.Fatalf("Error starting sync controller: %v", err)
 	}

--- a/test/e2e/framework/unmanaged.go
+++ b/test/e2e/framework/unmanaged.go
@@ -273,7 +273,7 @@ func (f *UnmanagedFramework) inMemoryTargetNamespace() string {
 	return metav1.NamespaceAll
 }
 
-func (f *UnmanagedFramework) SetUpSyncControllerFixture(typeConfig typeconfig.Interface) managed.TestFixture {
+func (f *UnmanagedFramework) setUpSyncControllerFixture(typeConfig typeconfig.Interface, namespacePlacement *metav1.APIResource) managed.TestFixture {
 	// Hybrid setup where just the sync controller is run and we do not rely on
 	// the already deployed (unmanaged) controller manager. Only do this if
 	// in-memory-controllers is true.
@@ -283,7 +283,7 @@ func (f *UnmanagedFramework) SetUpSyncControllerFixture(typeConfig typeconfig.In
 		if typeConfig.GetTarget().Kind == util.NamespaceKind {
 			controllerConfig.TargetNamespace = metav1.NamespaceAll
 		}
-		return managed.NewSyncControllerFixture(f.logger, controllerConfig, typeConfig)
+		return managed.NewSyncControllerFixture(f.logger, controllerConfig, typeConfig, namespacePlacement)
 	}
 	return nil
 }

--- a/test/e2e/placement.go
+++ b/test/e2e/placement.go
@@ -100,11 +100,11 @@ var _ = Describe("Placement", func() {
 		}
 
 		namespacePlacement := &unstructured.Unstructured{}
-		// TODO(marun) Source this from the ns type config
+		placementAPIResource := f.NamespaceTypeConfigOrDie().GetPlacement()
 		namespacePlacement.SetGroupVersionKind(schema.GroupVersionKind{
-			Group:   "primitives.federation.k8s.io",
-			Kind:    "FederatedNamespacePlacement",
-			Version: "v1alpha1",
+			Group:   placementAPIResource.Group,
+			Kind:    placementAPIResource.Kind,
+			Version: placementAPIResource.Version,
 		})
 		namespacePlacement.SetNamespace(namespace)
 		namespacePlacement.SetName(namespace)


### PR DESCRIPTION
Since the namespace type config is generated as of #426, it seems wise to avoid hard-coding the api definition for namespace placement and always load it from the API. 