### PR TITLE
Add images/federation-v2/controller-manager to git ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 /hack/install-crds-latest.yaml
 /hack/install-namespaced.yaml
 /images/federation-v2/hyperfed
+# temporarily added below file to ignore list to avoid someone pushing this file in a pr by accident.
+/images/federation-v2/controller-manager


### PR DESCRIPTION
Recent changes to rename binary name in image to hyperfed caused https://github.com/kubernetes-sigs/federation-v2/pull/326/files to push a binary image accidentally. To avoid such things happening to other authors, the binary name is added to git ignore list temporarily.

/cc @marun 