### PR TITLE
Adds region/zone level custom naming support for ServiceDNSRecords

### DIFF
--- a/charts/federation-v2/charts/controllermanager/templates/crds.yaml
+++ b/charts/federation-v2/charts/controllermanager/templates/crds.yaml
@@ -1447,6 +1447,8 @@ spec:
               type: string
             domainRef:
               type: string
+            externalName:
+              type: string
             recordTTL:
               format: int64
               type: integer

--- a/hack/install-latest.yaml
+++ b/hack/install-latest.yaml
@@ -567,6 +567,8 @@ spec:
               type: string
             domainRef:
               type: string
+            externalName:
+              type: string
             recordTTL:
               format: int64
               type: integer

--- a/pkg/apis/multiclusterdns/v1alpha1/servicednsrecord_types.go
+++ b/pkg/apis/multiclusterdns/v1alpha1/servicednsrecord_types.go
@@ -29,6 +29,9 @@ type ServiceDNSRecordSpec struct {
 	RecordTTL TTL `json:"recordTTL,omitempty"`
 	// DNSPrefix when specified, an additional DNS record would be created with <DNSPrefix>.<FederationDomain>
 	DNSPrefix string `json:"dnsPrefix,omitempty"`
+	// ExternalName when specified, replaces the service name portion of a resource record
+	// with the value of ExternalName.
+	ExternalName string `json:"externalName,omitempty"`
 	// AllowServiceWithoutEndpoints allows DNS records to be written for Service shards without endpoints
 	AllowServiceWithoutEndpoints bool `json:"allowServiceWithoutEndpoints,omitempty"`
 }

--- a/pkg/apis/multiclusterdns/v1alpha1/zz_generated.kubebuilder.go
+++ b/pkg/apis/multiclusterdns/v1alpha1/zz_generated.kubebuilder.go
@@ -320,6 +320,9 @@ var (
 								"domainRef": v1beta1.JSONSchemaProps{
 									Type: "string",
 								},
+								"externalName": v1beta1.JSONSchemaProps{
+									Type: "string",
+								},
 								"recordTTL": v1beta1.JSONSchemaProps{
 									Type:   "integer",
 									Format: "int64",


### PR DESCRIPTION
Setting `dnsPrefix` for a `ServiceDNSRecord` causes zone/region level records to use the service name instead of `dnsPrefix`. This is by design. However, use cases exist for DNS name customization at global, region, and zone scopes. This PR introduces the `ExternalName` field to the `ServiceDNSRecordSpec` type to provide this functionality while keeping `dnsPrefix` as-is.

Fixes https://github.com/kubernetes-sigs/federation-v2/issues/329

/cc @shashidharatd 