### PR TITLE
Add scripts for creating and deleting kind clusters

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ install:
   -
 
 script:
-  - CONFIGURE_INSECURE_REGISTRY=y DOWNLOAD_BINARIES=y bash -x ./scripts/pre-commit.sh
+  - DOWNLOAD_BINARIES=y bash -x ./scripts/pre-commit.sh
   - vendor/github.com/kubernetes/repo-infra/verify/verify-boilerplate.sh -- rootdir="$GOPATH/src/github.com/kubernetes-sigs/federation-v2" -v
 
 after_success:

--- a/scripts/create-clusters.sh
+++ b/scripts/create-clusters.sh
@@ -118,7 +118,7 @@ function fixup-cluster() {
   export KUBECONFIG="${KUBECONFIG:-}:${kubeconfig_path}"
 
   # Simplify context name
-  kubectl config rename-context kubernetes-admin@kind-${i} kind-${i}
+  kubectl config rename-context kubernetes-admin@kind-${i} cluster${i}
 
   # TODO(font): Need to set container IP address in order for clusters to reach
   # kube API servers in other clusters until
@@ -134,7 +134,7 @@ function fixup-cluster() {
 
 function check-clusters-ready() {
   for i in $(seq ${1}); do
-    util::wait-for-condition 'ok' "kubectl --context kind-${i} get --raw=/healthz &> /dev/null" 120
+    util::wait-for-condition 'ok' "kubectl --context cluster${i} get --raw=/healthz &> /dev/null" 120
   done
 }
 

--- a/scripts/create-clusters.sh
+++ b/scripts/create-clusters.sh
@@ -37,12 +37,24 @@ function create-and-configure-insecure-registry() {
     return
   fi
 
+  local err=
   if sudo test -f "${docker_daemon_config}"; then
     echo <<EOF "Error: ${docker_daemon_config} exists and \
 CONFIGURE_INSECURE_REGISTRY=${CONFIGURE_INSECURE_REGISTRY}. This script needs \
 to add an 'insecure-registries' entry with host '${CONTAINER_REGISTRY_HOST}' to \
 ${docker_daemon_config}. Please make the necessary changes or backup and try again."
 EOF
+    err=true
+  elif pgrep -a dockerd | grep -q 'insecure-registry'; then
+    echo <<EOF "Error: CONFIGURE_INSECURE_REGISTRY=${CONFIGURE_INSECURE_REGISTRY} \
+and about to write ${docker_daemon_config}, but dockerd is already configured with \
+an 'insecure-registry' command line option. Please make the necessary changes or disable \
+the command line option and try again."
+EOF
+    err=true
+  fi
+
+  if [[ "${err}" ]]; then
     docker kill registry &> /dev/null
     docker rm registry &> /dev/null
     return 1

--- a/scripts/create-clusters.sh
+++ b/scripts/create-clusters.sh
@@ -122,7 +122,7 @@ function fixup-cluster() {
 
 function check-clusters-ready() {
   for i in $(seq ${1}); do
-    util::wait-for-condition 'ok' "kubectl --context kind-${i} get --raw=/healthz" 120
+    util::wait-for-condition 'ok' "kubectl --context kind-${i} get --raw=/healthz &> /dev/null" 120
   done
 }
 

--- a/scripts/create-clusters.sh
+++ b/scripts/create-clusters.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+
+# Copyright 2018 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script handles the creation of multiple clusters using kind and the
+# ability to create and configure an insecure container registry.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+source "$(dirname "${BASH_SOURCE}")/util.sh"
+CONFIGURE_INSECURE_REGISTRY="${CONFIGURE_INSECURE_REGISTRY:-}"
+CONTAINER_REGISTRY_HOST="${CONTAINER_REGISTRY_HOST:-172.17.0.1:5000}"
+NUM_CLUSTERS="${NUM_CLUSTERS:-2}"
+docker_daemon_config="/etc/docker/daemon.json"
+
+function create-and-configure-insecure-registry() {
+  # Run insecure registry as container
+  docker run -d -p 5000:5000 --restart=always --name registry registry:2
+
+  if [[ -z "${CONFIGURE_INSECURE_REGISTRY}" ]]; then
+    return
+  fi
+
+  if sudo test -f "${docker_daemon_config}"; then
+    echo <<EOF "Error: ${docker_daemon_config} exists and \
+CONFIGURE_INSECURE_REGISTRY=${CONFIGURE_INSECURE_REGISTRY}. This script needs \
+to add an 'insecure-registries' entry with host '${CONTAINER_REGISTRY_HOST}' to \
+${docker_daemon_config}. Please make the necessary changes or backup and try again."
+EOF
+    return 1
+  fi
+
+  configure-insecure-registry-and-reload "sudo bash -c" $(pgrep dockerd)
+}
+
+function configure-insecure-registry-and-reload() {
+  local cmd_context="${1}" # context to run command e.g. sudo, docker exec
+  local docker_pid="${2}"
+  ${cmd_context} "$(insecure-registry-config-cmd)"
+  ${cmd_context} "$(reload-docker-daemon-cmd "${docker_pid}")"
+}
+
+function insecure-registry-config-cmd() {
+  echo "cat <<EOF > ${docker_daemon_config}
+{
+    \"insecure-registries\": [\"${CONTAINER_REGISTRY_HOST}\"]
+}
+EOF
+"
+}
+
+function reload-docker-daemon-cmd() {
+  echo "kill -s SIGHUP ${1}"
+}
+
+function create-clusters() {
+  local num_clusters=${1}
+
+  for i in $(seq ${num_clusters}); do
+    # kind will create cluster with name: kind-${i}
+    kind create cluster --name ${i}
+    # TODO(font): remove once all workarounds are addressed.
+    fixup-cluster ${i}
+  done
+
+  # TODO(font): kind will create separate kubeconfig files for each cluster.
+  # Remove once https://github.com/kubernetes-sigs/kind/issues/113 is resolved.
+  kubectl config view --flatten > ~/.kube/config
+  unset KUBECONFIG
+
+  echo "Waiting for clusters to be ready"
+  check-clusters-ready ${num_clusters}
+
+  # TODO(font): Configure insecure registry on kind host cluster. Remove once
+  # https://github.com/kubernetes-sigs/kind/issues/110 is resolved.
+  configure-insecure-registry-on-cluster 1
+
+}
+
+function fixup-cluster() {
+  local i=${1} # cluster num
+
+  local kubeconfig_path="$(kind get kubeconfig-path --name ${i})"
+  export KUBECONFIG="${KUBECONFIG:-}:${kubeconfig_path}"
+
+  # Simplify context name
+  kubectl config rename-context kubernetes-admin@kind-${i} kind-${i}
+
+  # TODO(font): Need to set container IP address in order for clusters to reach
+  # kube API servers in other clusters until
+  # https://github.com/kubernetes-sigs/kind/issues/111 is resolved.
+  local container_ip_addr=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' kind-${i}-control-plane)
+  sed -i "s/localhost/${container_ip_addr}/" ${kubeconfig_path}
+
+  # TODO(font): Need to rename auth user name to avoid conflicts when using
+  # multiple cluster kubeconfigs. Remove once
+  # https://github.com/kubernetes-sigs/kind/issues/112 is resolved.
+  sed -i "s/kubernetes-admin/kubernetes-kind-${i}-admin/" ${kubeconfig_path}
+}
+
+function check-clusters-ready() {
+  for i in $(seq ${1}); do
+    util::wait-for-condition 'ok' "kubectl --context kind-${i} get --raw=/healthz" 120
+  done
+}
+
+function configure-insecure-registry-on-cluster() {
+  configure-insecure-registry-and-reload "docker exec kind-${1}-control-plane bash -c" '$(pgrep dockerd)'
+}
+
+echo "Creating container registry on host"
+create-and-configure-insecure-registry
+
+echo "Creating ${NUM_CLUSTERS} clusters"
+create-clusters ${NUM_CLUSTERS}

--- a/scripts/delete-clusters.sh
+++ b/scripts/delete-clusters.sh
@@ -33,7 +33,7 @@ function delete-clusters() {
 
   for i in $(seq ${num_clusters}); do
     # kind will delete cluster with name: kind-${i}
-    echo "Deleting cluster 'kind-${i}' ..."
+    echo "Deleting cluster ${i} ..."
     kind delete cluster --name ${i}
   done
 }

--- a/scripts/delete-clusters.sh
+++ b/scripts/delete-clusters.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+# Copyright 2018 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script handles the deletion of multiple clusters using kind as well as
+# the deletion of the container registry.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+NUM_CLUSTERS="${NUM_CLUSTERS:-2}"
+
+function delete-insecure-registry() {
+  docker kill registry &> /dev/null || return 0
+  docker rm registry &> /dev/null || true
+}
+
+function delete-clusters() {
+  local num_clusters=${1}
+
+  for i in $(seq ${num_clusters}); do
+    # kind will delete cluster with name: kind-${i}
+    echo "Deleting cluster 'kind-${i}' ..."
+    kind delete cluster --name ${i}
+  done
+}
+
+echo "Deleting container registry on host"
+delete-insecure-registry
+
+echo "Deleting ${NUM_CLUSTERS} clusters"
+delete-clusters ${NUM_CLUSTERS}
+
+echo "Complete"

--- a/scripts/download-e2e-binaries.sh
+++ b/scripts/download-e2e-binaries.sh
@@ -30,7 +30,8 @@ trap 'logEnd $?' EXIT
 
 echo "About to download some binaries. This might take a while..."
 
-GOBIN="$(go env GOPATH)/bin"
+GOPATH=$(go env GOPATH)
+GOBIN="${GOPATH}/bin"
 
 # kind
 # TODO(font): kind does not have versioning yet.

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -56,7 +56,7 @@ function run-e2e-tests-with-managed-fixture() {
 function join-cluster-list() {
   if [[ -z "${JOIN_CLUSTERS}" ]]; then
     for i in $(seq 2 ${NUM_CLUSTERS}); do
-      JOIN_CLUSTERS+="kind-${i} "
+      JOIN_CLUSTERS+="cluster${i} "
     done
     export JOIN_CLUSTERS=$(echo ${JOIN_CLUSTERS} | sed 's/ $//')
   fi

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -136,7 +136,7 @@ echo "Downloading e2e test dependencies"
 
 export PATH=${TEST_ASSET_PATH}:${PATH}
 
-CONFIGURE_INSECURE_REGISTRY=y ./scripts/create-clusters.sh
+CONFIGURE_INSECURE_REGISTRY=y OVERWRITE_KUBECONFIG=y ./scripts/create-clusters.sh
 
 # Initialize list of clusters to join
 join-cluster-list > /dev/null

--- a/scripts/util.sh
+++ b/scripts/util.sh
@@ -37,7 +37,7 @@ function util::wait-for-condition() {
   local error_msg="[ERROR] Timeout waiting for ${msg}"
 
   local counter=0
-  while ! ${condition}; do
+  while ! eval ${condition}; do
     if [[ "${counter}" = "0" ]]; then
       echo -n "${start_msg}"
     fi


### PR DESCRIPTION
The following changes are implemented here to enable users to create and delete kind clusters for dev testing.

- This moves the functions that create kind clusters out of the CI script and into its own script to allow running locally for a dev workflow. Additional checks were added to prevent the script from clobbering user's existing kube config and warn about multiple `insecure-registry` configurations.
- Modify contexts to use `cluster[0-9]` to be consistent with the docs.
- Add delete clusters script.

