### PR TITLE
Require the override field in FederatedTypeConfig

### DIFF
--- a/hack/install-latest.yaml
+++ b/hack/install-latest.yaml
@@ -308,6 +308,7 @@ spec:
           - propagationEnabled
           - template
           - placement
+          - override
           type: object
         status:
           properties:

--- a/pkg/apis/core/typeconfig/interface.go
+++ b/pkg/apis/core/typeconfig/interface.go
@@ -30,7 +30,7 @@ type Interface interface {
 	GetPropagationEnabled() bool
 	GetTemplate() metav1.APIResource
 	GetPlacement() metav1.APIResource
-	GetOverride() *metav1.APIResource
+	GetOverride() metav1.APIResource
 	GetStatus() *metav1.APIResource
 	GetEnableStatus() bool
 }

--- a/pkg/apis/core/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/core/v1alpha1/zz_generated.deepcopy.go
@@ -412,15 +412,7 @@ func (in *FederatedTypeConfigSpec) DeepCopyInto(out *FederatedTypeConfigSpec) {
 	out.Target = in.Target
 	out.Template = in.Template
 	out.Placement = in.Placement
-	if in.Override != nil {
-		in, out := &in.Override, &out.Override
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(APIResource)
-			**out = **in
-		}
-	}
+	out.Override = in.Override
 	if in.Status != nil {
 		in, out := &in.Status, &out.Status
 		if *in == nil {

--- a/pkg/apis/core/v1alpha1/zz_generated.kubebuilder.go
+++ b/pkg/apis/core/v1alpha1/zz_generated.kubebuilder.go
@@ -452,6 +452,7 @@ var (
 								"propagationEnabled",
 								"template",
 								"placement",
+								"override",
 							}},
 						"status": v1beta1.JSONSchemaProps{
 							Type: "object",

--- a/pkg/controller/sync/controller.go
+++ b/pkg/controller/sync/controller.go
@@ -157,13 +157,12 @@ func newFederationSyncController(controllerConfig *util.ControllerConfig, typeCo
 
 	s.templateStore, s.templateController = util.NewResourceInformer(templateClient, targetNamespace, enqueueObj)
 
-	if overrideAPIResource := typeConfig.GetOverride(); overrideAPIResource != nil {
-		client, err := util.NewResourceClient(pool, overrideAPIResource)
-		if err != nil {
-			return nil, err
-		}
-		s.overrideStore, s.overrideController = util.NewResourceInformer(client, targetNamespace, enqueueObj)
+	overrideAPIResource := typeConfig.GetOverride()
+	overrideClient, err := util.NewResourceClient(pool, &overrideAPIResource)
+	if err != nil {
+		return nil, err
 	}
+	s.overrideStore, s.overrideController = util.NewResourceInformer(overrideClient, targetNamespace, enqueueObj)
 
 	placementAPIResource := typeConfig.GetPlacement()
 	placementClient, err := util.NewResourceClient(pool, &placementAPIResource)

--- a/pkg/kubefed2/federate/disable.go
+++ b/pkg/kubefed2/federate/disable.go
@@ -199,13 +199,9 @@ func deletePrimitives(config *rest.Config, typeConfig typeconfig.Interface, writ
 }
 
 func primitiveCRDNames(typeConfig typeconfig.Interface) []string {
-	names := []string{
+	return []string{
 		typeconfig.GroupQualifiedName(typeConfig.GetTemplate()),
 		typeconfig.GroupQualifiedName(typeConfig.GetPlacement()),
+		typeconfig.GroupQualifiedName(typeConfig.GetOverride()),
 	}
-	overrideAPIResource := typeConfig.GetOverride()
-	if overrideAPIResource != nil {
-		names = append(names, typeconfig.GroupQualifiedName(*overrideAPIResource))
-	}
-	return names
 }

--- a/pkg/kubefed2/federate/enable.go
+++ b/pkg/kubefed2/federate/enable.go
@@ -299,7 +299,7 @@ func typeConfigForTarget(apiResource metav1.APIResource, federateDirective *Fede
 			Placement: fedv1a1.APIResource{
 				Kind: fmt.Sprintf("Federated%sPlacement", kind),
 			},
-			Override: &fedv1a1.APIResource{
+			Override: fedv1a1.APIResource{
 				Kind: fmt.Sprintf("Federated%sOverride", kind),
 			},
 		},
@@ -339,7 +339,7 @@ func primitiveCRDs(typeConfig typeconfig.Interface, accessor schemaAccessor) ([]
 	crds = append(crds, CrdForAPIResource(typeConfig.GetPlacement(), placementSchema))
 
 	overrideSchema := overrideValidationSchema()
-	crds = append(crds, CrdForAPIResource(*typeConfig.GetOverride(), overrideSchema))
+	crds = append(crds, CrdForAPIResource(typeConfig.GetOverride(), overrideSchema))
 
 	return crds, nil
 }

--- a/pkg/schedulingtypes/plugin.go
+++ b/pkg/schedulingtypes/plugin.go
@@ -97,7 +97,8 @@ func NewPlugin(controllerConfig *util.ControllerConfig, eventHandlers SchedulerE
 	}
 	p.placementStore, p.placementController = util.NewResourceInformer(p.placementClient, targetNamespace, federationEventHandler)
 
-	p.overrideClient, err = util.NewResourceClient(pool, typeConfig.GetOverride())
+	overrideAPIResource := typeConfig.GetOverride()
+	p.overrideClient, err = util.NewResourceClient(pool, &overrideAPIResource)
 	if err != nil {
 		return nil, err
 	}
@@ -190,8 +191,7 @@ func (p *Plugin) ReconcileOverride(qualifiedName util.QualifiedName, result map[
 		if !errors.IsNotFound(err) {
 			return err
 		}
-		apiResource := p.typeConfig.GetOverride()
-		newOverride := newUnstructured(*apiResource, qualifiedName)
+		newOverride := newUnstructured(p.typeConfig.GetOverride(), qualifiedName)
 		err := setOverrides(newOverride, nil, result)
 		if err != nil {
 			return err

--- a/test/common/crudtester.go
+++ b/test/common/crudtester.go
@@ -116,8 +116,7 @@ func (c *FederatedTypeCrudTester) Create(desiredTemplate, desiredPlacement, desi
 	var override *unstructured.Unstructured
 	if desiredOverride != nil {
 		desiredOverride.SetName(name)
-		overrideAPIResource := c.typeConfig.GetOverride()
-		override = c.createFedResource(*overrideAPIResource, desiredOverride)
+		override = c.createFedResource(c.typeConfig.GetOverride(), desiredOverride)
 	}
 
 	desiredTemplate.SetName(name)

--- a/test/common/testobjects.go
+++ b/test/common/testobjects.go
@@ -39,12 +39,9 @@ func NewTestObjects(typeConfig typeconfig.Interface, namespace string, clusterNa
 		return nil, nil, nil, err
 	}
 
-	overrideAPIResource := typeConfig.GetOverride()
-	if overrideAPIResource != nil {
-		override, err = newTestOverride(*overrideAPIResource, namespace, clusterNames, fixture)
-		if err != nil {
-			return nil, nil, nil, err
-		}
+	override, err = newTestOverride(typeConfig.GetOverride(), namespace, clusterNames, fixture)
+	if err != nil {
+		return nil, nil, nil, err
 	}
 
 	return template, placement, override, nil

--- a/test/e2e/scheduling.go
+++ b/test/e2e/scheduling.go
@@ -277,7 +277,7 @@ func waitForMatchingPlacement(tl common.TestLogger, typeConfig typeconfig.Interf
 func waitForMatchingOverride(tl common.TestLogger, typeConfig typeconfig.Interface, kubeConfig *restclient.Config, name, namespace string, expected32 map[string]int32) error {
 	overrideAPIResource := typeConfig.GetOverride()
 	overrideKind := overrideAPIResource.Kind
-	client, err := util.NewResourceClientFromConfig(kubeConfig, overrideAPIResource)
+	client, err := util.NewResourceClientFromConfig(kubeConfig, &overrideAPIResource)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Now that overrides are generic and federation primitives are generated, there's no reason to avoid defining an override resource for a federated type.  This also ensures that all federation deployments support generic overrides regardless of whether they decide to use it initially, which is likely a win for supportability.