### PR TITLE
Properly pluralizes type configs for resources ending in y

### DIFF
--- a/pkg/apis/core/v1alpha1/federatedtypeconfig_types.go
+++ b/pkg/apis/core/v1alpha1/federatedtypeconfig_types.go
@@ -190,6 +190,10 @@ func PluralName(kind string) string {
 		strings.HasSuffix(lowerKind, "z") || strings.HasSuffix(lowerKind, "o") {
 		return fmt.Sprintf("%ses", lowerKind)
 	}
+	if strings.HasSuffix(lowerKind, "y") {
+		strings.TrimSuffix(lowerKind, "y")
+		return fmt.Sprintf("%sies", lowerKind)
+	}
 	return fmt.Sprintf("%ss", lowerKind)
 }
 

--- a/pkg/apis/core/v1alpha1/federatedtypeconfig_types_test.go
+++ b/pkg/apis/core/v1alpha1/federatedtypeconfig_types_test.go
@@ -159,6 +159,16 @@ func TestPluralName(t *testing.T) {
 			plural: "waltzs",
 			expect: false,
 		},
+		{
+			name:   "serviceentry",
+			plural: "serviceentrys",
+			expect: false,
+		},
+		{
+			name:   "serviceentry",
+			plural: "serviceentries",
+			expect: true,
+		},
 	}
 
 	for _, rt := range tests {


### PR DESCRIPTION
Fixes https://github.com/kubernetes-sigs/federation-v2/issues/457