### PR TITLE
Updates clusterrole rules to include all NonResourceURLs

### DIFF
--- a/pkg/kubefed2/unjoin.go
+++ b/pkg/kubefed2/unjoin.go
@@ -345,12 +345,12 @@ func deleteClusterRoleAndBinding(clusterClientset client.Interface, saName, name
 	}
 
 	roleName := util.RoleName(saName)
-	commonClusterRoleName := util.CommonClusterRoleName(saName)
+	healthCheckRoleName := util.HealthCheckRoleName(saName)
 
 	// Attempt to delete all role and role bindings created by join
 	// and ignore if there is any error
 
-	for _, name := range []string{roleName, commonClusterRoleName} {
+	for _, name := range []string{roleName, healthCheckRoleName} {
 		err := clusterClientset.RbacV1().ClusterRoleBindings().Delete(name, &metav1.DeleteOptions{})
 		if err != nil && !errors.IsNotFound(err) {
 			deletionSucceeded = false

--- a/pkg/kubefed2/util/util.go
+++ b/pkg/kubefed2/util/util.go
@@ -120,9 +120,9 @@ func RoleName(serviceAccountName string) string {
 	return fmt.Sprintf("federation-controller-manager:%s", serviceAccountName)
 }
 
-// CommonClusterRoleName returns the name of a ClusterRole and its
+// HealthCheckRoleName returns the name of a ClusterRole and its
 // associated ClusterRoleBinding that is used to allow the service
 // account to check the health of the cluster and list nodes.
-func CommonClusterRoleName(serviceAccountName string) string {
-	return fmt.Sprintf("federation-controller-manager:common-%s", serviceAccountName)
+func HealthCheckRoleName(serviceAccountName string) string {
+	return fmt.Sprintf("federation-controller-manager:healthcheck-%s", serviceAccountName)
 }


### PR DESCRIPTION
Rules update is specific to cluster roles and binding and not namespace roles and binding.

Fixes issue #354 