### PR TITLE
Fix enabling federation for CustomResourceDefinition

### DIFF
--- a/pkg/kubefed2/federate/schema.go
+++ b/pkg/kubefed2/federate/schema.go
@@ -220,6 +220,14 @@ func (v *jsonSchemaVistor) VisitKind(k *proto.Kind) {
 }
 
 func (v *jsonSchemaVistor) VisitReference(r proto.Reference) {
+	// Short-circuit the recursive definition of JSONSchemaProps (used for CRD validation)
+	//
+	// TODO(marun) Implement proper support for recursive schema
+	if r.Reference() == "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.JSONSchemaProps" {
+		v.collect(apiextv1b1.JSONSchemaProps{Type: "object"})
+		return
+	}
+
 	r.SubSchema().Accept(v)
 }
 


### PR DESCRIPTION
`federate enable` schema generation doesn't properly handle recursive schema (it fails with a stack overflow) when attempting to enable federation for CustomResourceDefinition.  This change adds a
CRD-specific workaround to short-circuit the recursion.

Fixes #466 