### PR TITLE
Fix validation generation for crd targets that lack validation

### DIFF
--- a/pkg/kubefed2/federate/schema.go
+++ b/pkg/kubefed2/federate/schema.go
@@ -74,7 +74,7 @@ func newCRDSchemaAccessor(config *rest.Config, apiResource metav1.APIResource) (
 }
 
 func (a *crdSchemaAccessor) templateSchema() map[string]apiextv1b1.JSONSchemaProps {
-	if a.validation.OpenAPIV3Schema != nil {
+	if a.validation != nil && a.validation.OpenAPIV3Schema != nil {
 		return a.validation.OpenAPIV3Schema.Properties
 	}
 	return nil


### PR DESCRIPTION
It was not a reasonable assumption that all crd targets would have a validation schema.