### PR TITLE
Update federatednamespace-template.yaml

### DIFF
--- a/example/sample1/federatednamespace-template.yaml
+++ b/example/sample1/federatednamespace-template.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
-kind: Namespace
+apiVersion: primitives.federation.k8s.io/v1alpha1
+kind: FederatedNamespace
 metadata:
   name: test-namespace


### PR DESCRIPTION
The sample namespace used for the user guide wasn't federated yet.