### PR TITLE
Add apiGroup to the FederatedClusterRoleBinding example

### DIFF
--- a/example/sample1/federatedclusterrolebinding-template.yaml
+++ b/example/sample1/federatedclusterrolebinding-template.yaml
@@ -7,6 +7,8 @@ spec:
     subjects:
     - kind: Group
       name: test-user
+      apiGroup: rbac.authorization.k8s.io
     roleRef:
       kind: ClusterRole
       name: cluster-admin
+      apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
The `apiGroup` property must be defined, otherwise the creation fails with:

```
The FederatedClusterRoleBinding "test-clusterrolebinding" is invalid: []: Invalid value: map[string]interface {}{"metadata":map[string]interface {}{"clusterName":"", "name":"test-clusterrolebinding", "creationTimestamp":"2018-12-12T11:23:34Z", "namespace":"", "generation":1, "uid":"5d06fd0d-fe00-11e8-bc84-525400b4b564", "selfLink":""}, "spec":map[string]interface {}{"template":map[string]interface {}{"roleRef":map[string]interface {}{"kind":"ClusterRole", "name":"cluster-admin"}, "subjects":[]interface {}{map[string]interface {}{"kind":"Group", "name":"test-user"}}}}, "apiVersion":"primitives.federation.k8s.io/v1alpha1", "kind":"FederatedClusterRoleBinding"}: validation failure list:
spec.template.roleRef.apiGroup in body is required
```