### PR TITLE
automate consistent update of primitive crds

### DIFF
--- a/charts/federation-v2/charts/controllermanager/templates/crds.yaml
+++ b/charts/federation-v2/charts/controllermanager/templates/crds.yaml
@@ -270,6 +270,7 @@ spec:
           - propagationEnabled
           - template
           - placement
+          - override
           type: object
         status:
           properties:

--- a/charts/federation-v2/templates/deployments.apps.yaml
+++ b/charts/federation-v2/templates/deployments.apps.yaml
@@ -1007,8 +1007,6 @@ spec:
                                         type: object
                                       privileged:
                                         type: boolean
-                                      procMount:
-                                        type: string
                                       readOnlyRootFilesystem:
                                         type: boolean
                                       runAsGroup:
@@ -1499,8 +1497,6 @@ spec:
                                         type: object
                                       privileged:
                                         type: boolean
-                                      procMount:
-                                        type: string
                                       readOnlyRootFilesystem:
                                         type: boolean
                                       runAsGroup:
@@ -1590,8 +1586,6 @@ spec:
                                 type: object
                               type: array
                             restartPolicy:
-                              type: string
-                            runtimeClassName:
                               type: string
                             schedulerName:
                               type: string

--- a/charts/federation-v2/templates/jobs.batch.yaml
+++ b/charts/federation-v2/templates/jobs.batch.yaml
@@ -989,8 +989,6 @@ spec:
                                         type: object
                                       privileged:
                                         type: boolean
-                                      procMount:
-                                        type: string
                                       readOnlyRootFilesystem:
                                         type: boolean
                                       runAsGroup:
@@ -1481,8 +1479,6 @@ spec:
                                         type: object
                                       privileged:
                                         type: boolean
-                                      procMount:
-                                        type: string
                                       readOnlyRootFilesystem:
                                         type: boolean
                                       runAsGroup:
@@ -1572,8 +1568,6 @@ spec:
                                 type: object
                               type: array
                             restartPolicy:
-                              type: string
-                            runtimeClassName:
                               type: string
                             schedulerName:
                               type: string
@@ -2209,9 +2203,6 @@ spec:
                           - containers
                           type: object
                       type: object
-                    ttlSecondsAfterFinished:
-                      format: int32
-                      type: integer
                   required:
                   - template
                   type: object

--- a/charts/federation-v2/templates/namespaces.yaml
+++ b/charts/federation-v2/templates/namespaces.yaml
@@ -86,7 +86,7 @@ spec:
   names:
     kind: FederatedNamespaceOverride
     plural: federatednamespaceoverrides
-  scope: Cluster
+  scope: Namespaced
   validation:
     openAPIV3Schema:
       properties:

--- a/charts/federation-v2/templates/replicasets.apps.yaml
+++ b/charts/federation-v2/templates/replicasets.apps.yaml
@@ -981,8 +981,6 @@ spec:
                                         type: object
                                       privileged:
                                         type: boolean
-                                      procMount:
-                                        type: string
                                       readOnlyRootFilesystem:
                                         type: boolean
                                       runAsGroup:
@@ -1473,8 +1471,6 @@ spec:
                                         type: object
                                       privileged:
                                         type: boolean
-                                      procMount:
-                                        type: string
                                       readOnlyRootFilesystem:
                                         type: boolean
                                       runAsGroup:
@@ -1564,8 +1560,6 @@ spec:
                                 type: object
                               type: array
                             restartPolicy:
-                              type: string
-                            runtimeClassName:
                               type: string
                             schedulerName:
                               type: string

--- a/docs/development.md
+++ b/docs/development.md
@@ -217,6 +217,13 @@ Follow the [cleanup instructions in the user guide](userguide.md#cleanup).
 In order to test your changes on your kubernetes cluster, you'll need
 to build an image and a deployment config.
 
+**NOTE:** When federation CRDs are changed, you need to run:
+```bash
+./scripts/sync-up-helm-chart.sh
+```
+This script ensures that the CRD resources in helm chart can be synced.
+Ensure binaries from kubebuilder for `etcd` and `kube-apiserver` are in the path (see [prerequisites](#prerequisites)).
+
 ### Automated Deployment
 
 If you just want to have this automated, then run the following command

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -159,18 +159,11 @@ join-cluster-list > /dev/null
 echo "Deploying federation-v2"
 ./scripts/deploy-federation.sh ${CONTAINER_REGISTRY_HOST}/federation-v2:e2e $(join-cluster-list)
 
-# TODO(marun) Ensure that contributors can consistently update the
-# helm chart crds.  Requiring that a specific version of kubernetes be
-# deployed seems onerous, and a preferable solution would be a script
-# that launched the version of kubernetes-apiserver that is downloaded
-# for testing (currently as part of kubebuilder) and runs kubefed
-# federate against it.
+echo "Checking sync up status of helm chart"
+PATH="${PATH}:${base_dir}/bin" ./scripts/sync-up-helm-chart.sh
 
-# echo "Checking sync up status of helm chart"
-# PATH="${PATH}:${base_dir}/bin" ./scripts/sync-up-helm-chart.sh
-
-# echo "Checking helm chart state of working tree"
-# check-git-state
+echo "Checking helm chart state of working tree"
+check-git-state
 
 echo "Running go e2e tests with unmanaged fixture"
 run-e2e-tests-with-unmanaged-fixture

--- a/scripts/sync-up-helm-chart.sh
+++ b/scripts/sync-up-helm-chart.sh
@@ -18,6 +18,9 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+source "$(dirname "${BASH_SOURCE}")/util.sh"
+
+WORKDIR=$(mktemp -d)
 NS="${FEDERATION_NAMESPACE:-federation-system}"
 CHART_FEDERATED_CRD_DIR="${CHART_FEDERATED_CRD_DIR:-charts/federation-v2/charts/controllermanager/templates}"
 CHART_FEDERATED_PROPAGATION_DIR="${CHART_FEDERATED_PROPAGATION_DIR:-charts/federation-v2/templates}"
@@ -32,7 +35,36 @@ if [ -n "${crd_diff}" ]; then
   cp -f $INSTALL_CRDS_YAML $CHART_FEDERATED_CRD_DIR/crds.yaml
 fi
 
+# Generate kubeconfig to access kube-apiserver. It is cleaned when script is done.
+cat <<EOF > ${WORKDIR}/kubeconfig
+apiVersion: v1
+clusters:
+- cluster:
+    server: 127.0.0.1:8080
+  name: development
+contexts:
+- context:
+    cluster: development
+    user: ""
+  name: federation
+current-context: ""
+kind: Config
+preferences: {}
+users: []
+EOF
+
+# Start kube-apiserver to generate CRDs
+./bin/etcd --data-dir ${WORKDIR} &
+util::wait-for-condition 'ok' "curl http://127.0.0.1:2379/version &> /dev/null" 30
+./bin/kube-apiserver --etcd-servers=http://127.0.0.1:2379 --service-cluster-ip-range=10.0.0.0/16 --cert-dir ${WORKDIR} &
+util::wait-for-condition 'ok' "kubectl --kubeconfig ${WORKDIR}/kubeconfig --context federation get --raw=/healthz &> /dev/null" 60
+
 # Generate YAML templates to enable resource propagation for helm chart.
 for filename in ./config/federatedirectives/*.yaml; do
-  ./bin/kubefed2 federate enable -f "${filename}" --federation-namespace="${NS}" --dry-run -oyaml > ${CHART_FEDERATED_PROPAGATION_DIR}/$(basename $filename)
+  ./bin/kubefed2 --kubeconfig ${WORKDIR}/kubeconfig federate enable -f "${filename}" --federation-namespace="${NS}" --host-cluster-context federation -o yaml > ${CHART_FEDERATED_PROPAGATION_DIR}/$(basename $filename)
 done
+
+# Clean kube-apiserver daemons and temporary files
+kill %1 # etcd
+kill %2 # kube-apiserver
+rm -fr ${WORKDIR}


### PR DESCRIPTION
Fix #505 

A predownloaded kube-apiserver is started for generation federation crds
based on primitive.

@gyliu513 