### PR TITLE
Use a hash of the template field as the template version

### DIFF
--- a/pkg/controller/sync/version/manager_test.go
+++ b/pkg/controller/sync/version/manager_test.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package version
+
+import (
+	"strings"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/kubernetes-sigs/federation-v2/pkg/kubefed2/federate"
+)
+
+func TestGetTemplateHash(t *testing.T) {
+	template := &unstructured.Unstructured{}
+	yaml := `
+kind: foo
+spec:
+  template:
+    spec:
+      foo:
+`
+	err := federate.DecodeYAML(strings.NewReader(yaml), template)
+	if err != nil {
+		t.Fatalf("An unexpected error occurred: %v", err)
+	}
+	hash, err := GetTemplateHash(template)
+	if err != nil {
+		t.Fatalf("An unexpected error occurred: %v", err)
+	}
+	expectedHash := "a5b8d4352d5aed51c51b93900258ccf3"
+	if hash != expectedHash {
+		t.Fatalf("Expected %s, got %s", expectedHash, hash)
+	}
+}


### PR DESCRIPTION
Previously the resourceVersion of the template resource was used, but resourceVersion changes when status changes.  Switching to a hash paves the way to store propagated version in the status of a template resource.

Part 1 of #479 