### PR TITLE
stop scheduler and plugins if resource is deleted

### DIFF
--- a/pkg/controller/federatedtypeconfig/controller.go
+++ b/pkg/controller/federatedtypeconfig/controller.go
@@ -129,7 +129,7 @@ func (c *Controller) Run(stopChan <-chan struct{}) {
 func (c *Controller) reconcile(qualifiedName util.QualifiedName) util.ReconciliationStatus {
 	key := qualifiedName.String()
 
-	glog.Infof("Running reconcile FederatedTypeConfig for %q", key)
+	glog.V(3).Infof("Running reconcile FederatedTypeConfig for %q", key)
 
 	cachedObj, exist, err := c.store.GetByKey(key)
 	if err != nil {

--- a/pkg/controller/schedulingmanager/controller.go
+++ b/pkg/controller/schedulingmanager/controller.go
@@ -45,12 +45,13 @@ type SchedulerController struct {
 
 	worker util.ReconcileWorker
 
-	scheduler map[string]schedulingtypes.Scheduler
+	scheduler    map[string]schedulingtypes.Scheduler
+	stopChannels map[string]chan struct{}
 
-	config   *util.ControllerConfig
-	stopChan <-chan struct{}
+	config *util.ControllerConfig
 
 	runningPlugins sets.String
+	templateKinds  map[string]string
 }
 
 func StartSchedulerController(config *util.ControllerConfig, stopChan <-chan struct{}) {
@@ -60,18 +61,19 @@ func StartSchedulerController(config *util.ControllerConfig, stopChan <-chan str
 	restclient.AddUserAgent(kubeConfig, userAgent)
 	client := fedclientset.NewForConfigOrDie(kubeConfig).CoreV1alpha1()
 
-	controller := newController(config, client, stopChan)
+	controller := newController(config, client)
 
 	glog.Infof("Starting scheduler controller")
 	controller.Run(stopChan)
 }
 
-func newController(config *util.ControllerConfig, client corev1alpha1client.CoreV1alpha1Interface, stopChan <-chan struct{}) *SchedulerController {
+func newController(config *util.ControllerConfig, client corev1alpha1client.CoreV1alpha1Interface) *SchedulerController {
 	c := &SchedulerController{
-		scheduler:      make(map[string]schedulingtypes.Scheduler),
 		config:         config,
-		stopChan:       stopChan,
+		scheduler:      make(map[string]schedulingtypes.Scheduler),
+		stopChannels:   make(map[string]chan struct{}),
 		runningPlugins: sets.String{},
+		templateKinds:  make(map[string]string),
 	}
 
 	fedNamespace := config.FederationNamespace
@@ -108,20 +110,25 @@ func (c *SchedulerController) Run(stopChan <-chan struct{}) {
 	}
 
 	c.worker.Run(stopChan)
+
+	// Ensure all goroutines are cleaned up when the stop channel closes
+	go func() {
+		<-stopChan
+
+		for _, stopChannel := range c.stopChannels {
+			close(stopChannel)
+		}
+	}()
 }
 
 func (c *SchedulerController) reconcile(qualifiedName util.QualifiedName) util.ReconciliationStatus {
 	key := qualifiedName.String()
 
-	glog.Infof("Running reconcile FederatedTypeConfig for %q", key)
+	glog.V(3).Infof("Running reconcile FederatedTypeConfig for %q", key)
 
 	schedulingType := schedulingtypes.GetSchedulingType(qualifiedName.Name)
 	if schedulingType == nil {
 		// No scheduler supported for this resource
-		return util.StatusAllOK
-	}
-	if c.runningPlugins.Has(qualifiedName.Name) {
-		// Scheduler and plugin are already running
 		return util.StatusAllOK
 	}
 
@@ -130,14 +137,20 @@ func (c *SchedulerController) reconcile(qualifiedName util.QualifiedName) util.R
 		runtime.HandleError(fmt.Errorf("Failed to query FederatedTypeConfig store for %q: %v", key, err))
 		return util.StatusError
 	}
+
 	if !exist {
+		c.stopScheduler(schedulingType.Kind, qualifiedName)
 		return util.StatusAllOK
 	}
-	typeConfig := cachedObj.(*corev1a1.FederatedTypeConfig)
 
-	deleted := typeConfig.DeletionTimestamp != nil
-	if deleted {
-		// Do not support deletion yet
+	typeConfig := cachedObj.(*corev1a1.FederatedTypeConfig)
+	if typeConfig.Spec.PropagationEnabled == false || typeConfig.DeletionTimestamp != nil {
+		c.stopScheduler(schedulingType.Kind, qualifiedName)
+		return util.StatusAllOK
+	}
+
+	if c.runningPlugins.Has(qualifiedName.Name) {
+		// Scheduler and plugin are already running
 		return util.StatusAllOK
 	}
 
@@ -156,22 +169,57 @@ func (c *SchedulerController) reconcile(qualifiedName util.QualifiedName) util.R
 	scheduler, ok := c.scheduler[schedulingKind]
 	if !ok {
 		var err error
-		scheduler, err = schedulingpreference.StartSchedulingPreferenceController(c.config, *schedulingType, c.stopChan)
+
+		stopChan := make(chan struct{})
+		scheduler, err = schedulingpreference.StartSchedulingPreferenceController(c.config, *schedulingType, stopChan)
 		if err != nil {
 			runtime.HandleError(fmt.Errorf("Error starting schedulingpreference controller for %q : %v", schedulingKind, err))
 			return util.StatusError
 		}
 		c.scheduler[schedulingKind] = scheduler
+		c.stopChannels[schedulingKind] = stopChan
 	}
 
 	templateKind := typeConfig.GetTemplate().Kind
-	glog.Infof("Start plugin with kind %s for scheduling type %s", templateKind, schedulingKind)
-	err = scheduler.StartPlugin(typeConfig, c.stopChan)
+	glog.Infof("Start plugin kind %s for scheduling type %s", templateKind, schedulingKind)
+
+	stopChan := make(chan struct{})
+	err = scheduler.StartPlugin(typeConfig, stopChan)
 	if err != nil {
 		runtime.HandleError(fmt.Errorf("Error starting plugin for %q : %v", templateKind, err))
 		return util.StatusError
 	}
 	c.runningPlugins.Insert(qualifiedName.Name)
+	c.templateKinds[qualifiedName.Name] = templateKind
 
 	return util.StatusAllOK
+}
+
+func (c *SchedulerController) stopScheduler(schedulingKind string, qualifiedName util.QualifiedName) {
+	scheduler, ok := c.scheduler[schedulingKind]
+	if !ok {
+		return
+	}
+
+	if !c.runningPlugins.Has(qualifiedName.Name) {
+		return
+	}
+
+	glog.Infof("Stop plugin for %q with kind %q", qualifiedName.Name, c.templateKinds[qualifiedName.Name])
+
+	scheduler.StopPlugin(c.templateKinds[qualifiedName.Name])
+	c.runningPlugins.Delete(qualifiedName.Name)
+	delete(c.templateKinds, qualifiedName.Name)
+
+	// if all resources registered to same scheduler are deleted, the scheduler should be stopped
+	resources := schedulingtypes.GetSameSchedulingKindResources(qualifiedName.Name)
+	result := c.runningPlugins.Intersection(resources)
+	if result.Len() == 0 {
+		glog.Infof("Stop scheduler schedulingpreference controller for %q", schedulingKind)
+
+		close(c.stopChannels[schedulingKind])
+
+		delete(c.scheduler, schedulingKind)
+		delete(c.stopChannels, schedulingKind)
+	}
 }

--- a/pkg/controller/schedulingpreference/controller.go
+++ b/pkg/controller/schedulingpreference/controller.go
@@ -176,7 +176,7 @@ func (s *SchedulingPreferenceController) Run(stopChan <-chan struct{}) {
 	}()
 }
 
-func (s *SchedulingPreferenceController) Stop(stopChan <-chan struct{}) {
+func (s *SchedulingPreferenceController) Stop() {
 	close(s.stopChannel)
 }
 

--- a/pkg/schedulingtypes/interface.go
+++ b/pkg/schedulingtypes/interface.go
@@ -35,7 +35,8 @@ type Scheduler interface {
 	Stop()
 	Reconcile(obj pkgruntime.Object, qualifiedName QualifiedName) ReconciliationStatus
 
-	StartPlugin(typeConfig typeconfig.Interface, stopChan <-chan struct{}) error
+	StartPlugin(typeConfig typeconfig.Interface, stopChan chan struct{}) error
+	StopPlugin(kind string)
 }
 
 type SchedulerEventHandlers struct {

--- a/pkg/schedulingtypes/interface.go
+++ b/pkg/schedulingtypes/interface.go
@@ -30,12 +30,12 @@ type Scheduler interface {
 	FedList(namespace string, options metav1.ListOptions) (pkgruntime.Object, error)
 	FedWatch(namespace string, options metav1.ListOptions) (watch.Interface, error)
 
-	Start(stopChan <-chan struct{})
+	Start()
 	HasSynced() bool
 	Stop()
 	Reconcile(obj pkgruntime.Object, qualifiedName QualifiedName) ReconciliationStatus
 
-	StartPlugin(typeConfig typeconfig.Interface, stopChan chan struct{}) error
+	StartPlugin(typeConfig typeconfig.Interface) error
 	StopPlugin(kind string)
 }
 

--- a/pkg/schedulingtypes/typeregistry.go
+++ b/pkg/schedulingtypes/typeregistry.go
@@ -18,6 +18,8 @@ package schedulingtypes
 
 import (
 	"fmt"
+
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 type SchedulingType struct {
@@ -51,4 +53,21 @@ func GetSchedulingType(kind string) *SchedulingType {
 		return &schedulingType
 	}
 	return nil
+}
+
+func GetSameSchedulingKindResources(kind string) sets.String {
+	result := sets.String{}
+
+	schedulingType, ok := typeRegistry[kind]
+	if !ok {
+		return result
+	}
+
+	for key, value := range typeRegistry {
+		if value.Kind == schedulingType.Kind {
+			result.Insert(key)
+		}
+	}
+
+	return result
 }

--- a/pkg/schedulingtypes/typeregistry.go
+++ b/pkg/schedulingtypes/typeregistry.go
@@ -55,7 +55,7 @@ func GetSchedulingType(kind string) *SchedulingType {
 	return nil
 }
 
-func GetSameSchedulingKindResources(kind string) sets.String {
+func GetSchedulingKinds(kind string) sets.String {
 	result := sets.String{}
 
 	schedulingType, ok := typeRegistry[kind]


### PR DESCRIPTION
Fix  #386

stop scheduling controller if federatedtypeconfig resource is deleted
from system

I also make reconcile federatedtypeconfig log V(3) to avoid messing up
default messages.

@marun 