### PR TITLE
Require explicit namespace placement

### DIFF
--- a/pkg/controller/federatedtypeconfig/controller.go
+++ b/pkg/controller/federatedtypeconfig/controller.go
@@ -327,11 +327,6 @@ func (c *Controller) removeFinalizer(tc *corev1a1.FederatedTypeConfig) error {
 }
 
 func (c *Controller) getNamespacePlacement() (*metav1.APIResource, error) {
-	// Namespace placement is only required if running namespaced.
-	if c.controllerConfig.TargetNamespace == metav1.NamespaceAll {
-		return nil, nil
-	}
-
 	// TODO(marun) Document the requirement to restart the controller
 	// manager if the namespace placement resource changes.
 
@@ -343,7 +338,7 @@ func (c *Controller) getNamespacePlacement() (*metav1.APIResource, error) {
 	}
 
 	qualifiedName := util.QualifiedName{
-		Namespace: c.controllerConfig.TargetNamespace,
+		Namespace: c.controllerConfig.FederationNamespace,
 		Name:      util.NamespaceName,
 	}
 	key := qualifiedName.String()

--- a/pkg/controller/sync/placement/namespaced.go
+++ b/pkg/controller/sync/placement/namespaced.go
@@ -17,9 +17,12 @@ limitations under the License.
 package placement
 
 import (
+	"fmt"
+
 	fedv1a1 "github.com/kubernetes-sigs/federation-v2/pkg/apis/core/v1alpha1"
 	"github.com/kubernetes-sigs/federation-v2/pkg/controller/util"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	pkgruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
@@ -87,4 +90,8 @@ func (p *namespacedPlacementPlugin) ComputePlacement(qualifiedName util.Qualifie
 	selectedSet := resourceClusterSet.Intersection(namespaceClusterSet)
 
 	return selectedSet.List(), clusterSet.Difference(selectedSet).List(), nil
+}
+
+func (p *namespacedPlacementPlugin) GetPlacement(key string) (*unstructured.Unstructured, error) {
+	return nil, fmt.Errorf("Not implemented")
 }

--- a/pkg/controller/sync/placement/plugin.go
+++ b/pkg/controller/sync/placement/plugin.go
@@ -19,10 +19,12 @@ package placement
 import (
 	fedv1a1 "github.com/kubernetes-sigs/federation-v2/pkg/apis/core/v1alpha1"
 	"github.com/kubernetes-sigs/federation-v2/pkg/controller/util"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 type PlacementPlugin interface {
 	Run(stopCh <-chan struct{})
 	HasSynced() bool
 	ComputePlacement(qualifiedName util.QualifiedName, clusters []*fedv1a1.FederatedCluster) (selectedClusters, unselectedClusters []string, err error)
+	GetPlacement(key string) (*unstructured.Unstructured, error)
 }

--- a/pkg/controller/sync/placement/resource.go
+++ b/pkg/controller/sync/placement/resource.go
@@ -31,22 +31,17 @@ type ResourcePlacementPlugin struct {
 	store cache.Store
 	// Informer controller for placement directives of the federated type
 	controller cache.Controller
-
-	// Whether to default to all clusters if a placement resource is
-	// not found for a given qualified name.
-	defaultAll bool
 }
 
-func NewResourcePlacementPlugin(client util.ResourceClient, targetNamespace string, triggerFunc func(pkgruntime.Object), defaultAll bool) PlacementPlugin {
-	return newResourcePlacementPluginWithOk(client, targetNamespace, triggerFunc, defaultAll)
+func NewResourcePlacementPlugin(client util.ResourceClient, targetNamespace string, triggerFunc func(pkgruntime.Object)) PlacementPlugin {
+	return newResourcePlacementPluginWithOk(client, targetNamespace, triggerFunc)
 }
 
-func newResourcePlacementPluginWithOk(client util.ResourceClient, targetNamespace string, triggerFunc func(pkgruntime.Object), defaultAll bool) *ResourcePlacementPlugin {
+func newResourcePlacementPluginWithOk(client util.ResourceClient, targetNamespace string, triggerFunc func(pkgruntime.Object)) *ResourcePlacementPlugin {
 	store, controller := util.NewResourceInformer(client, targetNamespace, triggerFunc)
 	return &ResourcePlacementPlugin{
 		store:      store,
 		controller: controller,
-		defaultAll: defaultAll,
 	}
 }
 
@@ -71,9 +66,6 @@ func (p *ResourcePlacementPlugin) computePlacementWithOk(qualifiedName util.Qual
 	}
 	clusterNames := getClusterNames(clusters)
 	if cachedObj == nil {
-		if p.defaultAll {
-			return clusterNames, []string{}, false, nil
-		}
 		return []string{}, clusterNames, false, nil
 	}
 	unstructuredObj := cachedObj.(*unstructured.Unstructured)

--- a/pkg/controller/sync/placement/resource_test.go
+++ b/pkg/controller/sync/placement/resource_test.go
@@ -80,10 +80,10 @@ func TestSelectedClusterNames(t *testing.T) {
 				},
 			}
 			if testCase.clusterNames != nil {
-				unstructured.SetNestedStringSlice(obj.Object, testCase.clusterNames, "spec", util.ClusterNamesField)
+				unstructured.SetNestedStringSlice(obj.Object, testCase.clusterNames, util.SpecField, util.ClusterNamesField)
 			}
 			if testCase.clusterSelector != nil {
-				unstructured.SetNestedStringMap(obj.Object, testCase.clusterSelector, "spec", "clusterSelector", "matchLabels")
+				unstructured.SetNestedStringMap(obj.Object, testCase.clusterSelector, util.SpecField, util.ClusterSelectorField, "matchLabels")
 			}
 
 			selectedNames, err := selectedClusterNames(obj, clusters)

--- a/pkg/controller/util/constants.go
+++ b/pkg/controller/util/constants.go
@@ -36,7 +36,8 @@ const (
 	SpecField = "spec"
 
 	// Placement fields
-	ClusterNamesField = "clusterNames"
+	ClusterNamesField    = "clusterNames"
+	ClusterSelectorField = "clusterSelector"
 
 	// Override fields
 	OverridesField        = "overrides"

--- a/pkg/controller/util/resourceclient.go
+++ b/pkg/controller/util/resourceclient.go
@@ -25,12 +25,14 @@ import (
 
 type ResourceClient interface {
 	Resources(namespace string) dynamic.ResourceInterface
+	Kind() string
 }
 
 type resourceClient struct {
 	client      dynamic.Interface
 	apiResource schema.GroupVersionResource
 	namespaced  bool
+	kind        string
 }
 
 func NewResourceClient(config *rest.Config, apiResource *metav1.APIResource) (ResourceClient, error) {
@@ -48,6 +50,7 @@ func NewResourceClient(config *rest.Config, apiResource *metav1.APIResource) (Re
 		client:      client,
 		apiResource: resource,
 		namespaced:  apiResource.Namespaced,
+		kind:        apiResource.Kind,
 	}, nil
 }
 
@@ -60,4 +63,8 @@ func (c *resourceClient) Resources(namespace string) dynamic.ResourceInterface {
 		return c.client.Resource(c.apiResource).Namespace(namespace)
 	}
 	return c.client.Resource(c.apiResource)
+}
+
+func (c *resourceClient) Kind() string {
+	return c.kind
 }

--- a/test/e2e/framework/unmanaged.go
+++ b/test/e2e/framework/unmanaged.go
@@ -26,6 +26,7 @@ import (
 	"github.com/kubernetes-sigs/federation-v2/test/common"
 	"github.com/kubernetes-sigs/federation-v2/test/e2e/framework/managed"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -291,7 +292,9 @@ func (f *UnmanagedFramework) setUpSyncControllerFixture(typeConfig typeconfig.In
 func deleteNamespace(client kubeclientset.Interface, namespaceName string) {
 	orphanDependents := false
 	if err := client.Core().Namespaces().Delete(namespaceName, &metav1.DeleteOptions{OrphanDependents: &orphanDependents}); err != nil {
-		Failf("Error while deleting namespace %s: %s", namespaceName, err)
+		if !errors.IsNotFound(err) {
+			Failf("Error while deleting namespace %s: %s", namespaceName, err)
+		}
 	}
 	// TODO(marun) Check namespace deletion at the end of the test run.
 	return

--- a/test/e2e/ingressdns.go
+++ b/test/e2e/ingressdns.go
@@ -57,8 +57,8 @@ var _ = Describe("IngressDNS", func() {
 		if framework.TestContext.RunControllers() {
 			fixture := managed.NewIngressDNSControllerFixture(tl, f.ControllerConfig())
 			f.RegisterFixture(fixture)
-			f.SetUpNamespaceSyncControllerFixture()
 		}
+		f.EnsureTestNamespacePropagation()
 		namespace = f.TestNamespaceName()
 		dnsClient = fedClient.MulticlusterdnsV1alpha1().IngressDNSRecords(namespace)
 	})

--- a/test/e2e/servicedns.go
+++ b/test/e2e/servicedns.go
@@ -75,8 +75,8 @@ var _ = Describe("ServiceDNS", func() {
 		if framework.TestContext.RunControllers() {
 			fixture := managed.NewServiceDNSControllerFixture(tl, f.ControllerConfig())
 			f.RegisterFixture(fixture)
-			f.SetUpNamespaceSyncControllerFixture()
 		}
+		f.EnsureTestNamespacePropagation()
 		domainObj := common.NewDomainObject(federation, Domain)
 		_, err = domainClient.Create(domainObj)
 		framework.ExpectNoError(err, "Error creating Domain object")


### PR DESCRIPTION
Up till now namespace propagation in a cluster-scoped deployment was implicit - a namespace would be propagated to member clusters by default if a namespace placement resource was absent.  This PR reverses that behavior so that a namespace is not propagated if placement is absent.  This also prevents a resource from being propagated to a member cluster unless its containing namespace is configured to be propagated to that cluster.

This change is intended to ensure that federation will play nicely when deployed to existing clusters in which only a subset of available namespaces are intended to be federated.  As part of the change, finalization for federated namespaces was moved to namespace placement to prevent the sync controller from attempting to remove namespaces from member clusters where placement was absent in those namespaces in the host cluster.  A future work item may be switching all resources to finalize placement instead of the template (assuming an ownerReference on the placement) for consistency.

The behavior of resource placement for namespaced federation remains unchanged.  Since the single namespace targeted for federation already exists in member clusters in such a deployment, namespace placement remains implicit.

Fixes #538 
Related: #396 #526 

