### PR TITLE
add test case for scheduler manager

### DIFF
--- a/cmd/controller-manager/app/controller-manager.go
+++ b/cmd/controller-manager/app/controller-manager.go
@@ -109,7 +109,7 @@ func Run(opts *options.Options) error {
 	}
 
 	if utilfeature.DefaultFeatureGate.Enabled(features.SchedulerPreferences) {
-		if err := schedulingmanager.StartSchedulerController(opts.Config, stopChan); err != nil {
+		if _, err := schedulingmanager.StartSchedulerController(opts.Config, stopChan); err != nil {
 			glog.Fatalf("Error starting scheduler controller: %v", err)
 		}
 	}

--- a/pkg/controller/schedulingmanager/controller.go
+++ b/pkg/controller/schedulingmanager/controller.go
@@ -49,7 +49,7 @@ type SchedulerController struct {
 	federatedKindMap map[string]string
 }
 
-func StartSchedulerController(config *util.ControllerConfig, stopChan <-chan struct{}) error {
+func StartSchedulerController(config *util.ControllerConfig, stopChan <-chan struct{}) (*SchedulerController, error) {
 
 	userAgent := "SchedulerController"
 	kubeConfig := config.KubeConfig
@@ -57,12 +57,12 @@ func StartSchedulerController(config *util.ControllerConfig, stopChan <-chan str
 
 	controller, err := newController(config)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	glog.Infof("Starting scheduler controller")
 	controller.Run(stopChan)
-	return nil
+	return controller, nil
 }
 
 func newController(config *util.ControllerConfig) (*SchedulerController, error) {
@@ -199,4 +199,16 @@ func (c *SchedulerController) stopScheduler(schedulingKind string, qualifiedName
 
 		delete(c.scheduler, schedulingKind)
 	}
+}
+
+func (c *SchedulerController) HasSchedulerPlugin(name string) bool {
+	return c.runningPlugins.Has(name)
+}
+
+func (c *SchedulerController) HasScheduler(name string) bool {
+	_, ok := c.scheduler[name]
+	if !ok {
+		return false
+	}
+	return true
 }

--- a/test/e2e/framework/managed/controller.go
+++ b/test/e2e/framework/managed/controller.go
@@ -98,12 +98,16 @@ func NewClusterControllerFixture(config *util.ControllerConfig) *ControllerFixtu
 	return f
 }
 
-func NewSchedulerControllerFixture(tl common.TestLogger, config *util.ControllerConfig) *ControllerFixture {
+func NewSchedulerControllerFixture(tl common.TestLogger, config *util.ControllerConfig) (*ControllerFixture, *schedulingmanager.SchedulerController) {
 	f := &ControllerFixture{
 		stopChan: make(chan struct{}),
 	}
-	schedulingmanager.StartSchedulerController(config, f.stopChan)
-	return f
+
+	controller, err := schedulingmanager.StartSchedulerController(config, f.stopChan)
+	if err != nil {
+		tl.Fatalf("Error starting scheduler controller: %v", err)
+	}
+	return f, controller
 }
 
 func (f *ControllerFixture) TearDown(tl common.TestLogger) {

--- a/test/e2e/framework/managed/federation.go
+++ b/test/e2e/framework/managed/federation.go
@@ -371,7 +371,7 @@ func waitForCrd(tl common.TestLogger, config *rest.Config, crd *apiextv1b1.Custo
 
 func federateCoreTypes(tl common.TestLogger, config *rest.Config, namespace string) []*apiextv1b1.CustomResourceDefinition {
 	crds := []*apiextv1b1.CustomResourceDefinition{}
-	for _, enableTypeDirective := range loadEnableTypeDirectives(tl) {
+	for _, enableTypeDirective := range LoadEnableTypeDirectives(tl) {
 		resources, err := federate.GetResources(config, enableTypeDirective)
 		if err != nil {
 			tl.Fatalf("Error retrieving resource definitions for EnableTypeDirective %q: %v", enableTypeDirective.Name, err)
@@ -384,7 +384,7 @@ func federateCoreTypes(tl common.TestLogger, config *rest.Config, namespace stri
 	}
 	return crds
 }
-func loadEnableTypeDirectives(tl common.TestLogger) []*federate.EnableTypeDirective {
+func LoadEnableTypeDirectives(tl common.TestLogger) []*federate.EnableTypeDirective {
 	path := enableTypeDirectivesPath(tl)
 	files, err := ioutil.ReadDir(path)
 	if err != nil {


### PR DESCRIPTION
When related federatedtypeconfig resources is created, scheduler and
related plugin controllers are started. If they are deleted, stop
related scheduler and plugin controllers.

@marun any comments for related test cases?

Fixes #543 