### PR TITLE
Factor host cluster interaction out of the sync controller

### DIFF
--- a/pkg/apis/core/typeconfig/interface.go
+++ b/pkg/apis/core/typeconfig/interface.go
@@ -33,4 +33,6 @@ type Interface interface {
 	GetOverride() metav1.APIResource
 	GetStatus() *metav1.APIResource
 	GetEnableStatus() bool
+	GetFederatedNamespaced() bool
+	GetFederatedKind() string
 }

--- a/pkg/apis/core/v1alpha1/federatedtypeconfig_types.go
+++ b/pkg/apis/core/v1alpha1/federatedtypeconfig_types.go
@@ -201,12 +201,12 @@ func (f *FederatedTypeConfig) GetTemplate() metav1.APIResource {
 }
 
 func (f *FederatedTypeConfig) GetPlacement() metav1.APIResource {
-	namespaced := f.isPrimitiveNamespaced()
+	namespaced := f.GetFederatedNamespaced()
 	return apiResourceToMeta(f.Spec.Placement, namespaced)
 }
 
 func (f *FederatedTypeConfig) GetOverride() metav1.APIResource {
-	namespaced := f.isPrimitiveNamespaced()
+	namespaced := f.GetFederatedNamespaced()
 	return apiResourceToMeta(f.Spec.Override, namespaced)
 }
 
@@ -222,7 +222,7 @@ func (f *FederatedTypeConfig) GetEnableStatus() bool {
 	return f.Spec.EnableStatus
 }
 
-func (f *FederatedTypeConfig) isPrimitiveNamespaced() bool {
+func (f *FederatedTypeConfig) GetFederatedNamespaced() bool {
 	// Special-case the scope of namespace primitives since it will
 	// hopefully be the only instance of the scope of a federation
 	// primitive differing from the scope of its target.
@@ -234,6 +234,16 @@ func (f *FederatedTypeConfig) isPrimitiveNamespaced() bool {
 		return true
 	}
 	return f.Spec.Namespaced
+}
+
+func (f *FederatedTypeConfig) GetFederatedKind() string {
+	// TODO(marun) Use the constant in pkg/controller/util
+	if f.Name == "namespaces" {
+		// The template type is 'Namespace', so return
+		// 'FederatedNamespace' for consistency with other types.
+		return "FederatedNamespace"
+	}
+	return f.GetTemplate().Kind
 }
 
 func apiResourceToMeta(apiResource APIResource, namespaced bool) metav1.APIResource {

--- a/pkg/controller/federatedtypeconfig/controller.go
+++ b/pkg/controller/federatedtypeconfig/controller.go
@@ -256,6 +256,8 @@ func (c *Controller) getStopChannel(name string) (chan struct{}, bool) {
 }
 
 func (c *Controller) startSyncController(tc *corev1a1.FederatedTypeConfig) error {
+	// TODO(marun) Consider creating a placement plugin that can be
+	// shared between all controllers.
 	namespacePlacement, err := c.getNamespacePlacement()
 	if err != nil {
 		return err

--- a/pkg/controller/sync/accessor.go
+++ b/pkg/controller/sync/accessor.go
@@ -1,0 +1,288 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sync
+
+import (
+	"github.com/golang/glog"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	pkgruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/kubernetes-sigs/federation-v2/pkg/apis/core/typeconfig"
+	fedclientset "github.com/kubernetes-sigs/federation-v2/pkg/client/clientset/versioned"
+	"github.com/kubernetes-sigs/federation-v2/pkg/controller/sync/placement"
+	"github.com/kubernetes-sigs/federation-v2/pkg/controller/sync/version"
+	"github.com/kubernetes-sigs/federation-v2/pkg/controller/util"
+	"github.com/kubernetes-sigs/federation-v2/pkg/controller/util/deletionhelper"
+)
+
+// FederatedResourceAccessor provides a way to retrieve and visit
+// logical federated resources (e.g. FederatedConfigMap)
+type FederatedResourceAccessor interface {
+	Run(stopChan <-chan struct{})
+	HasSynced() bool
+	FederatedResource(qualifiedName util.QualifiedName) (FederatedResource, error)
+	VisitFederatedResources(visitFunc func(obj interface{}))
+}
+
+type resourceAccessor struct {
+	typeConfig        typeconfig.Interface
+	targetIsNamespace bool
+	fedNamespace      string
+
+	// Store for the templates of the federated type
+	templateStore cache.Store
+	// Informer for the templates of the federated type
+	templateController cache.Controller
+
+	// Store for the override directives of the federated type
+	overrideStore cache.Store
+	// Informer controller for override directives of the federated type
+	overrideController cache.Controller
+
+	placementPlugin placement.PlacementPlugin
+
+	// Manages propagated versions
+	versionManager *version.VersionManager
+
+	// Adds finalizers to resources and performs cleanup of target resources.
+	deletionHelper *deletionhelper.DeletionHelper
+}
+
+func NewFederatedResourceAccessor(
+	controllerConfig *util.ControllerConfig,
+	typeConfig typeconfig.Interface,
+	namespacePlacementAPIResource *metav1.APIResource,
+	fedClient fedclientset.Interface,
+	enqueueObj func(pkgruntime.Object),
+	informer util.FederatedInformer,
+	updater util.FederatedUpdater) (FederatedResourceAccessor, error) {
+
+	a := &resourceAccessor{
+		typeConfig:        typeConfig,
+		targetIsNamespace: typeConfig.GetTarget().Kind == util.NamespaceKind,
+		fedNamespace:      controllerConfig.FederationNamespace,
+	}
+
+	targetNamespace := controllerConfig.TargetNamespace
+
+	// Start informers on the resources for the federated type
+	templateAPIResource := typeConfig.GetTemplate()
+	templateClient, err := util.NewResourceClient(controllerConfig.KubeConfig, &templateAPIResource)
+	if err != nil {
+		return nil, err
+	}
+	a.templateStore, a.templateController = util.NewResourceInformer(templateClient, targetNamespace, enqueueObj)
+
+	overrideAPIResource := typeConfig.GetOverride()
+	overrideClient, err := util.NewResourceClient(controllerConfig.KubeConfig, &overrideAPIResource)
+	if err != nil {
+		return nil, err
+	}
+	a.overrideStore, a.overrideController = util.NewResourceInformer(overrideClient, targetNamespace, enqueueObj)
+
+	placementAPIResource := typeConfig.GetPlacement()
+	placementClient, err := util.NewResourceClient(controllerConfig.KubeConfig, &placementAPIResource)
+	if err != nil {
+		return nil, err
+	}
+	if typeConfig.GetNamespaced() {
+		namespacePlacementClient, err := util.NewResourceClient(controllerConfig.KubeConfig, namespacePlacementAPIResource)
+		if err != nil {
+			return nil, err
+		}
+		namespacePlacementEnqueue := func(placementObj pkgruntime.Object) {
+			// When namespace placement changes, every resource in the
+			// namespace needs to be reconciled.
+			placementNamespace := util.NewQualifiedName(placementObj).Namespace
+			for _, templateObj := range a.templateStore.List() {
+				template := templateObj.(pkgruntime.Object)
+				qualifiedName := util.NewQualifiedName(template)
+				if qualifiedName.Namespace == placementNamespace {
+					enqueueObj(template)
+				}
+			}
+		}
+
+		a.placementPlugin = placement.NewNamespacedPlacementPlugin(placementClient, namespacePlacementClient, targetNamespace, enqueueObj, namespacePlacementEnqueue)
+	} else {
+		a.placementPlugin = placement.NewResourcePlacementPlugin(placementClient, targetNamespace, enqueueObj)
+	}
+
+	a.versionManager = version.NewVersionManager(
+		fedClient,
+		typeConfig.GetFederatedNamespaced(),
+		typeConfig.GetFederatedKind(),
+		typeConfig.GetTarget().Kind,
+		targetNamespace,
+	)
+
+	// Most types apply the finalizer to the template.
+	finalizerClient := templateClient
+	if a.targetIsNamespace {
+		// For namespaces the finalizer is applied to the placement to
+		// ensure that deletion of namespaces in member clusters only
+		// occurs after a namespace has been configured to be propagated
+		// to those clusters.
+		finalizerClient = placementClient
+	}
+
+	a.deletionHelper = deletionhelper.NewDeletionHelper(
+		func(rawObj pkgruntime.Object) (pkgruntime.Object, error) {
+			obj := rawObj.(*unstructured.Unstructured)
+			return finalizerClient.Resources(obj.GetNamespace()).Update(obj, metav1.UpdateOptions{})
+		},
+		func(obj pkgruntime.Object) string {
+			return util.NewQualifiedName(obj).String()
+		},
+		informer,
+		updater,
+	)
+
+	return a, nil
+}
+
+func (a *resourceAccessor) Run(stopChan <-chan struct{}) {
+	go a.versionManager.Sync(stopChan)
+	go a.templateController.Run(stopChan)
+	go a.overrideController.Run(stopChan)
+	go a.placementPlugin.Run(stopChan)
+}
+
+func (a *resourceAccessor) HasSynced() bool {
+	if !a.versionManager.HasSynced() {
+		glog.V(2).Infof("Version manager not synced")
+		return false
+	}
+	if !a.templateController.HasSynced() {
+		glog.V(2).Infof("Templates not synced")
+		return false
+	}
+	if !a.overrideController.HasSynced() {
+		glog.V(2).Infof("Overrides not synced")
+		return false
+	}
+	if !a.placementPlugin.HasSynced() {
+		glog.V(2).Infof("Placements not synced")
+		return false
+	}
+	return true
+}
+
+func (a *resourceAccessor) FederatedResource(eventSource util.QualifiedName) (FederatedResource, error) {
+	if a.targetIsNamespace && a.isSystemNamespace(eventSource.Name) {
+		glog.V(7).Infof("Ignoring system namespace %q", eventSource.Name)
+		return nil, nil
+	}
+
+	// Most federated resources have the same name as their targets.
+	targetName := eventSource
+	federatedName := util.QualifiedName{
+		Namespace: eventSource.Namespace,
+		Name:      eventSource.Name,
+	}
+	templateKey := federatedName.String()
+
+	// If the target type is namespace, the placement resource must be
+	// present and will be used as the finalization target.
+	var placement *unstructured.Unstructured
+
+	// A federated primitive for namespace "foo" is namespaced
+	// (e.g. "foo/foo"). An event sourced from a namespace in the host
+	// or member clusters will have the name "foo", and an event
+	// sourced from a federated resource will have the name "foo/foo".
+	// In order to ensure object retrieval from the informers, it is
+	// necessary to derive the target name and federated name from the
+	// event source.
+	if a.targetIsNamespace {
+		eventSourceIsTarget := eventSource.Namespace == ""
+		if eventSourceIsTarget {
+			// Ensure the federated name is namespace qualified.
+			federatedName.Namespace = federatedName.Name
+		} else {
+			// Ensure the target name is not namespace qualified.
+			targetName.Namespace = ""
+		}
+
+		// A namespace is only federated if it has a corresponding
+		// placement resource.
+		var err error
+		placement, err = a.placementPlugin.GetPlacement(federatedName.String())
+		if err != nil {
+			return nil, err
+		}
+		if placement == nil {
+			// No propagation without placement, and finalization
+			// ensures that the absence of placement indicates removal
+			// of target resources from member clusters.
+			glog.V(7).Infof("%s %q was not found which indicates the namespace is not federated",
+				a.typeConfig.GetPlacement().Kind, federatedName)
+			return nil, nil
+		}
+
+		// The template for a federated namespace is the namespace.
+		templateKey = targetName.String()
+	}
+
+	templateKind := a.typeConfig.GetTemplate().Kind
+	template, err := util.ObjFromCache(a.templateStore, templateKind, templateKey)
+	if err != nil {
+		return nil, err
+	}
+	if template == nil {
+		// Without a template, a resource is not federated.  The event
+		// source may be an override or placement, but is more likely
+		// to be a non-federated resource in the target cluster.
+		glog.V(7).Infof("%s %q was not found which indicates that the %s is not federated",
+			templateKind, templateKey, a.typeConfig.GetTarget().Kind)
+		return nil, nil
+	}
+
+	return &federatedResource{
+		typeConfig:        a.typeConfig,
+		targetIsNamespace: a.targetIsNamespace,
+		targetName:        targetName,
+		federatedName:     federatedName,
+		template:          template,
+		placement:         placement,
+		placementPlugin:   a.placementPlugin,
+		versionManager:    a.versionManager,
+		deletionHelper:    a.deletionHelper,
+		// Overrides are loaded lazily to ensure that deletion can
+		// handled by the controller first.
+		overrideStore: a.overrideStore,
+	}, nil
+}
+
+func (a *resourceAccessor) VisitFederatedResources(visitFunc func(obj interface{})) {
+	for _, obj := range a.templateStore.List() {
+		visitFunc(obj)
+	}
+}
+
+func (a *resourceAccessor) isSystemNamespace(namespace string) bool {
+	// TODO(font): Need a configurable or discoverable list of namespaces
+	// to not propagate beyond just the default system namespaces e.g.
+	switch namespace {
+	case "kube-system", "kube-public", "default", a.fedNamespace:
+		return true
+	default:
+		return false
+	}
+}

--- a/pkg/controller/sync/resource.go
+++ b/pkg/controller/sync/resource.go
@@ -1,0 +1,312 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sync
+
+import (
+	"crypto/md5"
+	"encoding/hex"
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	pkgruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/kubernetes-sigs/federation-v2/pkg/apis/core/typeconfig"
+	fedv1a1 "github.com/kubernetes-sigs/federation-v2/pkg/apis/core/v1alpha1"
+	"github.com/kubernetes-sigs/federation-v2/pkg/controller/sync/placement"
+	"github.com/kubernetes-sigs/federation-v2/pkg/controller/sync/version"
+	"github.com/kubernetes-sigs/federation-v2/pkg/controller/util"
+	"github.com/kubernetes-sigs/federation-v2/pkg/controller/util/deletionhelper"
+)
+
+// FederatedResource encapsulates the behavior of a logical federated
+// resource which may be implemented by one or more kubernetes
+// resources in the cluster hosting the federation control plane.
+type FederatedResource interface {
+	FederatedName() util.QualifiedName
+	TargetName() util.QualifiedName
+	Object() *unstructured.Unstructured
+	GetVersions() (map[string]string, error)
+	UpdateVersions(selectedClusters []string, versionMap map[string]string) error
+	DeleteVersions()
+	ComputePlacement(clusters []*fedv1a1.FederatedCluster) (selectedClusters, unselectedClusters []string, err error)
+	SkipClusterChange(clusterObj pkgruntime.Object) bool
+	ObjectForCluster(clusterName string) (*unstructured.Unstructured, error)
+	FinalizationKind() string
+	MarkedForDeletion() bool
+	EnsureDeletion() error
+	EnsureFinalizers() error
+}
+
+type federatedResource struct {
+	typeConfig        typeconfig.Interface
+	targetIsNamespace bool
+	targetName        util.QualifiedName
+	federatedName     util.QualifiedName
+	template          *unstructured.Unstructured
+	placement         *unstructured.Unstructured
+	placementPlugin   placement.PlacementPlugin
+	versionManager    *version.VersionManager
+	deletionHelper    *deletionhelper.DeletionHelper
+	overrideStore     cache.Store
+	override          *unstructured.Unstructured
+	overridesMap      util.OverridesMap
+}
+
+func (r *federatedResource) FederatedName() util.QualifiedName {
+	return r.federatedName
+}
+
+func (r *federatedResource) TargetName() util.QualifiedName {
+	return r.targetName
+}
+
+func (r *federatedResource) Object() *unstructured.Unstructured {
+	if r.targetIsNamespace {
+		return r.placement
+	}
+	return r.template
+}
+
+func (r *federatedResource) TemplateVersion() (string, error) {
+	return GetTemplateHash(r.template)
+}
+
+func (r *federatedResource) OverrideVersion() (string, error) {
+	override, err := r.getOverride()
+	if err != nil {
+		return "", err
+	}
+	// Overrides are optional
+	if override == nil {
+		return "", nil
+	}
+	// TODO(marun) Hash the overrides
+	return override.GetResourceVersion(), nil
+}
+
+func (r *federatedResource) GetVersions() (map[string]string, error) {
+	return r.versionManager.Get(r)
+}
+
+func (r *federatedResource) UpdateVersions(selectedClusters []string, versionMap map[string]string) error {
+	return r.versionManager.Update(r, selectedClusters, versionMap)
+}
+
+func (r *federatedResource) DeleteVersions() {
+	r.versionManager.Delete(r.federatedName)
+}
+
+func (r *federatedResource) ComputePlacement(clusters []*fedv1a1.FederatedCluster) ([]string, []string, error) {
+	return r.placementPlugin.ComputePlacement(r.federatedName, clusters)
+}
+
+func (r *federatedResource) SkipClusterChange(clusterObj pkgruntime.Object) bool {
+	// Updates should not be performed on namespaces in the host
+	// cluster.  Such operations need to be performed via the Kube
+	// API.
+	//
+	// The Namespace type is a special case because it is the only
+	// container in the Kubernetes API.  Federation presumes a
+	// separation between the template and target resources, but a
+	// namespace in the host cluster is necessarily both template and
+	// target.
+	return r.targetIsNamespace && util.IsPrimaryCluster(r.template, clusterObj)
+}
+
+// TODO(marun) Marshall the template once per reconcile, not per-cluster
+func (r *federatedResource) ObjectForCluster(clusterName string) (*unstructured.Unstructured, error) {
+	// Federation of namespaces uses Namespace resources as the
+	// template for resource creation in member clusters. All other
+	// federated types rely on a template type distinct from the
+	// target type.
+	//
+	// Namespace is the only type that can contain other resources,
+	// and adding a federation-specific container type would be
+	// difficult or impossible. This implies that federation
+	// primitives need to exist in regular namespaces.
+	//
+	// TODO(marun) Ensure this is reflected in documentation
+	obj := &unstructured.Unstructured{}
+	if r.targetIsNamespace {
+		metadata, ok, err := unstructured.NestedMap(r.template.Object, "metadata")
+		if err != nil {
+			return nil, fmt.Errorf("Error retrieving namespace metadata: %s", err)
+		}
+		if !ok {
+			return nil, fmt.Errorf("Unable to retrieve namespace metadata")
+		}
+		// Retain only the target fields from the template
+		targetFields := sets.NewString("name", "namespace", "labels", "annotations")
+		for key := range metadata {
+			if !targetFields.Has(key) {
+				delete(metadata, key)
+			}
+		}
+		obj.Object = make(map[string]interface{})
+		obj.Object["metadata"] = metadata
+	} else {
+		var ok bool
+		var err error
+		obj.Object, ok, err = unstructured.NestedMap(r.template.Object, "spec", "template")
+		if err != nil {
+			return nil, fmt.Errorf("Error retrieving template body: %v", err)
+		}
+		if !ok {
+			return nil, fmt.Errorf("Unable to retrieve template body")
+		}
+		// Avoid having to duplicate these details in the template or have
+		// the name/namespace vary between the federation api and member
+		// clusters.
+		//
+		// TODO(marun) this should be documented
+		obj.SetName(r.template.GetName())
+		obj.SetNamespace(r.template.GetNamespace())
+		targetApiResource := r.typeConfig.GetTarget()
+		obj.SetKind(targetApiResource.Kind)
+		obj.SetAPIVersion(fmt.Sprintf("%s/%s", targetApiResource.Group, targetApiResource.Version))
+	}
+
+	overrides, err := r.overridesForCluster(clusterName)
+	if err != nil {
+		return nil, err
+	}
+	if overrides != nil {
+		for path, value := range overrides {
+			pathEntries := strings.Split(path, ".")
+			unstructured.SetNestedField(obj.Object, value, pathEntries...)
+		}
+	}
+
+	return obj, nil
+}
+
+func (r *federatedResource) FinalizationKind() string {
+	return r.finalizationTarget().GetKind()
+}
+
+func (r *federatedResource) MarkedForDeletion() bool {
+	return r.finalizationTarget().GetDeletionTimestamp() != nil
+}
+
+func (r *federatedResource) EnsureDeletion() error {
+	r.DeleteVersions()
+	_, err := r.deletionHelper.HandleObjectInUnderlyingClusters(
+		r.finalizationTarget(),
+		func(clusterObj pkgruntime.Object) bool {
+			// Skip deletion of a namespace in the host cluster as it will be
+			// removed by the garbage collector once its contents are removed.
+			return r.targetIsNamespace && util.IsPrimaryCluster(r.template, clusterObj)
+		},
+	)
+	return err
+}
+
+func (r *federatedResource) EnsureFinalizers() error {
+	updatedObj, err := r.deletionHelper.EnsureFinalizers(r.finalizationTarget())
+	if updatedObj != nil && !r.targetIsNamespace {
+		// Retain the updated template for use in future API calls.
+		// If the target is namespace, the placement resource is used
+		// for finalization and no updates are expected.
+		r.template = updatedObj.(*unstructured.Unstructured)
+	}
+	return err
+}
+
+func (r *federatedResource) finalizationTarget() *unstructured.Unstructured {
+	// A placement resource determines whether a resource should exist
+	// in member clusters. If a template exists but the associated
+	// placement does not, then the resource represented by the
+	// template should be removed from all member clusters.  That
+	// suggests that finalization could as well be performed on the
+	// placement as the template.
+	//
+	// Adding a finalizer to a namespace resource is problematic
+	// because it has the potential to try to delete namespaces in
+	// member clusters when a namespace in the host cluster is
+	// deleted.  This could occur even if a namespace was never
+	// intended to be federated.  Adding the finalizer to the
+	// namespace placement resource will still ensure cleanup of
+	// resources in member clusters (since deletion of the namespace
+	// will trigger deletion of its placement resource) but ensure
+	// that cleanup is only attempted for namespaces that have been
+	// explicitly targeted for propagation.
+	//
+	// TODO(marun) Consider performing finalization on the placement
+	// resource for other types.
+	//
+	if r.targetIsNamespace {
+		return r.placement
+	}
+	return r.template
+}
+
+func (r *federatedResource) overridesForCluster(clusterName string) (util.ClusterOverridesMap, error) {
+	if r.overridesMap == nil {
+		override, err := r.getOverride()
+		if err != nil {
+			return nil, err
+		}
+		r.overridesMap, err = util.GetOverrides(override)
+		if err != nil {
+			overrideKind := r.typeConfig.GetOverride().Kind
+			return nil, fmt.Errorf("Error reading cluster overrides for %s %q: %v", overrideKind, r.federatedName, err)
+		}
+	}
+	return r.overridesMap[clusterName], nil
+}
+
+func (r *federatedResource) getOverride() (*unstructured.Unstructured, error) {
+	if r.override == nil {
+		overrideKind := r.typeConfig.GetOverride().Kind
+		var err error
+		r.override, err = util.ObjFromCache(r.overrideStore, overrideKind, r.federatedName.String())
+		if err != nil {
+			return nil, err
+		}
+	}
+	return r.override, nil
+}
+
+func GetTemplateHash(template *unstructured.Unstructured) (string, error) {
+	// A namespace resource is the template and the lack of status
+	// updates to namespaces means the resource version is a good
+	// indicator of changes the sync controller needs to consider.
+	if template.GetKind() == util.NamespaceKind {
+		return template.GetResourceVersion(), nil
+	}
+
+	obj := &unstructured.Unstructured{}
+	templateMap, ok, err := unstructured.NestedMap(template.Object, "spec", "template")
+	if err != nil {
+		return "", fmt.Errorf("Error retrieving template body: %s", err)
+	}
+	if !ok {
+		return "", nil
+	}
+	obj.Object = templateMap
+
+	jsonBytes, err := obj.MarshalJSON()
+	if err != nil {
+		return "", fmt.Errorf("Failed to marshal template body to json: %v", err)
+	}
+	hash := md5.New()
+	hash.Write(jsonBytes)
+	return hex.EncodeToString(hash.Sum(nil)), nil
+}

--- a/pkg/controller/sync/resource_test.go
+++ b/pkg/controller/sync/resource_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package version
+package sync
 
 import (
 	"strings"

--- a/test/common/crudtester.go
+++ b/test/common/crudtester.go
@@ -26,6 +26,7 @@ import (
 	"github.com/kubernetes-sigs/federation-v2/pkg/apis/core/typeconfig"
 	fedv1a1 "github.com/kubernetes-sigs/federation-v2/pkg/apis/core/v1alpha1"
 	clientset "github.com/kubernetes-sigs/federation-v2/pkg/client/clientset/versioned"
+	"github.com/kubernetes-sigs/federation-v2/pkg/controller/sync"
 	versionmanager "github.com/kubernetes-sigs/federation-v2/pkg/controller/sync/version"
 	"github.com/kubernetes-sigs/federation-v2/pkg/controller/util"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -174,7 +175,7 @@ func (c *FederatedTypeCrudTester) fedResourceClient(apiResource metav1.APIResour
 func (c *FederatedTypeCrudTester) CheckCreate(desiredTemplate, desiredPlacement, desiredOverride *unstructured.Unstructured) (*unstructured.Unstructured, *unstructured.Unstructured, *unstructured.Unstructured) {
 	template, placement, override := c.Create(desiredTemplate, desiredPlacement, desiredOverride)
 
-	templateHash, err := versionmanager.GetTemplateHash(template)
+	templateHash, err := sync.GetTemplateHash(template)
 	if err != nil {
 		c.tl.Fatalf("Failed to compute template hash: %v", err)
 	}
@@ -504,7 +505,7 @@ func (c *FederatedTypeCrudTester) expectedVersion(qualifiedName util.QualifiedNa
 	}
 
 	loggedWaiting := false
-	adapter := versionmanager.NewVersionAdapter(c.fedClient, c.typeConfig.GetNamespaced())
+	adapter := versionmanager.NewVersionAdapter(c.fedClient, c.typeConfig.GetFederatedNamespaced())
 	var version *fedv1a1.PropagatedVersionStatus
 	err := wait.PollImmediate(c.waitInterval, wait.ForeverTestTimeout, func() (bool, error) {
 		versionObj, err := adapter.Get(versionName)
@@ -536,7 +537,7 @@ func (c *FederatedTypeCrudTester) expectedVersion(qualifiedName util.QualifiedNa
 		return "", false
 	}
 
-	templateHash, err := versionmanager.GetTemplateHash(template)
+	templateHash, err := sync.GetTemplateHash(template)
 	if err != nil {
 		c.tl.Fatalf("Failed to compute template hash: %v", err)
 	}


### PR DESCRIPTION
This change factors the logic of federated type composition out of the sync controller and into an accessor type that creates a logical federated resource to encapsulates one or more underlying kubernetes resources.  This separation is intended to simplify future maintenance.