### PR TITLE
Add the missing test-namespace

### DIFF
--- a/docs/ingress-service-dns-with-coredns.md
+++ b/docs/ingress-service-dns-with-coredns.md
@@ -34,6 +34,7 @@ Install Federation-v2 with minikube in [User Guide](https://github.com/kubernete
 Install ExternalDNS with CoreDNS as backend in your host cluster. You can follow the [tutorial](https://github.com/kubernetes-incubator/external-dns/blob/master/docs/tutorials/coredns.md).
 
 To make it work for federation resources, you need to use below ExternalDNS deployment instead of the one in the tutorial.
+**Note**: You should replace parameter of `parameters: example.org` with `parameters: example.com` when [Installing CoreDNS](https://github.com/kubernetes-incubator/external-dns/blob/master/docs/tutorials/coredns.md#installing-coredns)
 **Note**: You should replace value of `ETCD_URLS` with your own etcd client service IP address.
 
 ```bash

--- a/docs/ingressdns-with-externaldns.md
+++ b/docs/ingressdns-with-externaldns.md
@@ -88,7 +88,7 @@ After creating the `IngressDNSRecord`, the DNS Endpoint controller uses the IP a
 populate the `targets` field of the `DNSEndpoint` resource. For example:
 
 ```bash
-$ kubectl get dnsendpoints -o yaml
+$ kubectl -n test-namespace get dnsendpoints -o yaml
 apiVersion: v1
 items:
 - apiVersion: multiclusterdns.federation.k8s.io/v1alpha1


### PR DESCRIPTION
This PR fixes the issue, when user executes command: $ kubectl get dnsendpoints -o yaml.