### PR TITLE
Ensure namespace placement changes trigger useful reconcile events

### DIFF
--- a/pkg/controller/sync/placement/namespaced.go
+++ b/pkg/controller/sync/placement/namespaced.go
@@ -47,11 +47,11 @@ type namespacedPlacementPlugin struct {
 	namespacePlugin *ResourcePlacementPlugin
 }
 
-func NewNamespacedPlacementPlugin(resourceClient, namespaceClient util.ResourceClient, targetNamespace string, triggerFunc func(pkgruntime.Object)) PlacementPlugin {
+func NewNamespacedPlacementPlugin(resourceClient, namespaceClient util.ResourceClient, targetNamespace string, resourceTriggerFunc, namespaceTriggerFunc func(pkgruntime.Object)) PlacementPlugin {
 	return &namespacedPlacementPlugin{
 		targetNamespace: targetNamespace,
-		resourcePlugin:  NewResourcePlacementPlugin(resourceClient, targetNamespace, triggerFunc),
-		namespacePlugin: newResourcePlacementPluginWithOk(namespaceClient, targetNamespace, triggerFunc),
+		resourcePlugin:  NewResourcePlacementPlugin(resourceClient, targetNamespace, resourceTriggerFunc),
+		namespacePlugin: newResourcePlacementPluginWithOk(namespaceClient, targetNamespace, namespaceTriggerFunc),
 	}
 }
 

--- a/test/e2e/placement.go
+++ b/test/e2e/placement.go
@@ -18,6 +18,7 @@ package e2e
 
 import (
 	"context"
+	"time"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -90,6 +91,16 @@ var _ = Describe("Placement", func() {
 			orphanDependents := false
 			crudTester.CheckDelete(template, &orphanDependents)
 		}()
+
+		// Wait until pending events for the templates have cleared
+		// from the controller queue to ensure that event handling for
+		// namespace placement is tested.  If a reconcile event
+		// remains in the queue a resource may be reconciled even in
+		// the absence of reconcile events being queued by a namespace
+		// placement event.
+		//
+		// TODO(marun) This is non-deterministic, revisit if it ends up being flakey.
+		time.Sleep(5 * time.Second)
 
 		namespace := f.TestNamespaceName()
 


### PR DESCRIPTION
Previously namespace placement changes for namespaced resources did not properly trigger reconcile events for contained resources.