### PR TITLE
Added additionalprintercolumn "Ready"  for the federatedcluster

### DIFF
--- a/charts/federation-v2/charts/controllermanager/templates/crds.yaml
+++ b/charts/federation-v2/charts/controllermanager/templates/crds.yaml
@@ -74,6 +74,10 @@ metadata:
     controller-tools.k8s.io: "1.0"
   name: federatedclusters.core.federation.k8s.io
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.conditions[?(@.type=='Ready')].status
+    name: ready
+    type: string
   group: core.federation.k8s.io
   names:
     kind: FederatedCluster

--- a/pkg/apis/core/v1alpha1/federatedcluster_types.go
+++ b/pkg/apis/core/v1alpha1/federatedcluster_types.go
@@ -70,6 +70,7 @@ type FederatedClusterStatus struct {
 // +k8s:openapi-gen=true
 // +kubebuilder:resource:path=federatedclusters
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name=ready,type=string,JSONPath=.status.conditions[?(@.type=='Ready')].status
 type FederatedCluster struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`


### PR DESCRIPTION
I'm adding an additional column called `READY` in the federatedcluster type to print the readiness status for a cluster when you run `kubectl get federatedclusters -n federation-system` 
```
$ kubectl get federatedclusters -n federation-system
NAME         AGE           READY
cluster1     20m           true
cluster2     20m           true
```
We need to bump up the version for `kubebuilder` (probably v1.0.6/1.0.7) in order to support the`kubebuilder:printcolumn` annotation.