### PR TITLE
Simple overrides unmarshalling

### DIFF
--- a/pkg/schedulingtypes/plugin.go
+++ b/pkg/schedulingtypes/plugin.go
@@ -279,10 +279,13 @@ func OverrideUpdateNeeded(overridesMap util.OverridesMap, result map[string]int6
 			if path != replicasPath {
 				continue
 			}
-			value, ok := rawValue.(int64)
+			// The type of the value will be float64 due to how json
+			// marshalling works for interfaces.
+			floatValue, ok := rawValue.(float64)
 			if !ok {
 				return true
 			}
+			value := int64(floatValue)
 			replicas, ok := result[clusterName]
 			if !ok || value != int64(replicas) {
 				return true

--- a/test/common/crudtester.go
+++ b/test/common/crudtester.go
@@ -18,7 +18,6 @@ package common
 
 import (
 	"fmt"
-	"reflect"
 	"strings"
 	"time"
 
@@ -434,7 +433,10 @@ func (c *FederatedTypeCrudTester) waitForResource(client util.ResourceClient, qu
 					if !ok {
 						c.tl.Fatalf("Missing overridden path %s", path)
 					}
-					if !reflect.DeepEqual(expectedValue, value) {
+					// Lacking type information for the override
+					// field, use string conversion as a cheap way to
+					// determine equality.
+					if fmt.Sprintf("%v", expectedValue) != fmt.Sprintf("%v", value) {
 						c.tl.Errorf("Expected field %s to be %q, got %q", path, expectedValue, value)
 						return false, nil
 					}


### PR DESCRIPTION
Defining a struct for generic overrides and unmarshalling via json is much simplier than using unstructured helpers.