### PR TITLE
s/FederateDirective/EnableTypeDirective

### DIFF
--- a/config/enabletypedirectives/clusterroles.rbac.authorization.k8s.io.yaml
+++ b/config/enabletypedirectives/clusterroles.rbac.authorization.k8s.io.yaml
@@ -1,4 +1,4 @@
 apiVersion: core.federation.k8s.io/v1alpha1
-kind: FederateDirective
+kind: EnableTypeDirective
 metadata:
   name: clusterroles.rbac.authorization.k8s.io

--- a/config/enabletypedirectives/configmaps.yaml
+++ b/config/enabletypedirectives/configmaps.yaml
@@ -1,4 +1,4 @@
 apiVersion: core.federation.k8s.io/v1alpha1
-kind: FederateDirective
+kind: EnableTypeDirective
 metadata:
   name: configmaps

--- a/config/enabletypedirectives/deployments.apps.yaml
+++ b/config/enabletypedirectives/deployments.apps.yaml
@@ -1,6 +1,6 @@
 apiVersion: core.federation.k8s.io/v1alpha1
-kind: FederateDirective
+kind: EnableTypeDirective
 metadata:
-  name: serviceaccounts
+  name: deployments.apps
 spec:
   comparisonField: Generation

--- a/config/enabletypedirectives/ingresses.extensions.yaml
+++ b/config/enabletypedirectives/ingresses.extensions.yaml
@@ -1,5 +1,5 @@
 apiVersion: core.federation.k8s.io/v1alpha1
-kind: FederateDirective
+kind: EnableTypeDirective
 metadata:
   name: ingresses.extensions
 spec:

--- a/config/enabletypedirectives/jobs.batch.yaml
+++ b/config/enabletypedirectives/jobs.batch.yaml
@@ -1,6 +1,6 @@
 apiVersion: core.federation.k8s.io/v1alpha1
-kind: FederateDirective
+kind: EnableTypeDirective
 metadata:
-  name: replicasets.apps
+  name: jobs.batch
 spec:
   comparisonField: Generation

--- a/config/enabletypedirectives/namespaces.yaml
+++ b/config/enabletypedirectives/namespaces.yaml
@@ -1,4 +1,4 @@
 apiVersion: core.federation.k8s.io/v1alpha1
-kind: FederateDirective
+kind: EnableTypeDirective
 metadata:
   name: namespaces

--- a/config/enabletypedirectives/replicasets.apps.yaml
+++ b/config/enabletypedirectives/replicasets.apps.yaml
@@ -1,6 +1,6 @@
 apiVersion: core.federation.k8s.io/v1alpha1
-kind: FederateDirective
+kind: EnableTypeDirective
 metadata:
-  name: deployments.apps
+  name: replicasets.apps
 spec:
   comparisonField: Generation

--- a/config/enabletypedirectives/secrets.yaml
+++ b/config/enabletypedirectives/secrets.yaml
@@ -1,4 +1,4 @@
 apiVersion: core.federation.k8s.io/v1alpha1
-kind: FederateDirective
+kind: EnableTypeDirective
 metadata:
   name: secrets

--- a/config/enabletypedirectives/serviceaccounts.yaml
+++ b/config/enabletypedirectives/serviceaccounts.yaml
@@ -1,6 +1,6 @@
 apiVersion: core.federation.k8s.io/v1alpha1
-kind: FederateDirective
+kind: EnableTypeDirective
 metadata:
-  name: jobs.batch
+  name: serviceaccounts
 spec:
   comparisonField: Generation

--- a/config/enabletypedirectives/services.yaml
+++ b/config/enabletypedirectives/services.yaml
@@ -1,5 +1,5 @@
 apiVersion: core.federation.k8s.io/v1alpha1
-kind: FederateDirective
+kind: EnableTypeDirective
 metadata:
   name: services
 ## TODO(marun) enable status generation

--- a/pkg/kubefed2/federate/directive.go
+++ b/pkg/kubefed2/federate/directive.go
@@ -22,8 +22,8 @@ import (
 	"github.com/kubernetes-sigs/federation-v2/pkg/apis/core/common"
 )
 
-// FederateDirectiveSpec defines the desired state of FederateDirective.
-type FederateDirectiveSpec struct {
+// EnableTypeDirectiveSpec defines the desired state of EnableTypeDirective.
+type EnableTypeDirectiveSpec struct {
 	// The API version of the target type.
 	// +optional
 	TargetVersion string `json:"targetVersion,omitempty"`
@@ -44,21 +44,21 @@ type FederateDirectiveSpec struct {
 // TODO(marun) This should become a proper API type and drive enabling
 // type federation via a controller.  For now its only purpose is to
 // enable loading of configuration from disk.
-type FederateDirective struct {
+type EnableTypeDirective struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec FederateDirectiveSpec `json:"spec,omitempty"`
+	Spec EnableTypeDirectiveSpec `json:"spec,omitempty"`
 }
 
-func (ft *FederateDirective) SetDefaults() {
+func (ft *EnableTypeDirective) SetDefaults() {
 	ft.Spec.ComparisonField = defaultComparisonField
 	ft.Spec.PrimitiveGroup = defaultPrimitiveGroup
 	ft.Spec.PrimitiveVersion = defaultPrimitiveVersion
 }
 
-func NewFederateDirective() *FederateDirective {
-	ft := &FederateDirective{}
+func NewEnableTypeDirective() *EnableTypeDirective {
+	ft := &EnableTypeDirective{}
 	ft.SetDefaults()
 	return ft
 }

--- a/pkg/kubefed2/federate/enable.go
+++ b/pkg/kubefed2/federate/enable.go
@@ -70,15 +70,15 @@ type enableType struct {
 }
 
 type enableTypeOptions struct {
-	targetName         string
-	targetVersion      string
-	rawComparisonField string
-	primitiveVersion   string
-	primitiveGroup     string
-	output             string
-	outputYAML         bool
-	filename           string
-	federateDirective  *FederateDirective
+	targetName          string
+	targetVersion       string
+	rawComparisonField  string
+	primitiveVersion    string
+	primitiveGroup      string
+	output              string
+	outputYAML          bool
+	filename            string
+	enableTypeDirective *EnableTypeDirective
 }
 
 // Bind adds the join specific arguments to the flagset passed in as an
@@ -128,8 +128,8 @@ func NewCmdTypeEnable(cmdOut io.Writer, config util.FedConfig) *cobra.Command {
 
 // Complete ensures that options are valid and marshals them if necessary.
 func (j *enableType) Complete(args []string) error {
-	j.federateDirective = NewFederateDirective()
-	fd := j.federateDirective
+	j.enableTypeDirective = NewEnableTypeDirective()
+	fd := j.enableTypeDirective
 
 	if j.output == "yaml" {
 		j.outputYAML = true
@@ -179,7 +179,7 @@ func (j *enableType) Run(cmdOut io.Writer, config util.FedConfig) error {
 		return errors.Wrap(err, "Failed to get host cluster config")
 	}
 
-	resources, err := GetResources(hostConfig, j.federateDirective)
+	resources, err := GetResources(hostConfig, j.enableTypeDirective)
 	if err != nil {
 		return err
 	}
@@ -211,14 +211,14 @@ type typeResources struct {
 	CRDs       []*apiextv1b1.CustomResourceDefinition
 }
 
-func GetResources(config *rest.Config, federateDirective *FederateDirective) (*typeResources, error) {
-	apiResource, err := LookupAPIResource(config, federateDirective.Name, federateDirective.Spec.TargetVersion)
+func GetResources(config *rest.Config, enableTypeDirective *EnableTypeDirective) (*typeResources, error) {
+	apiResource, err := LookupAPIResource(config, enableTypeDirective.Name, enableTypeDirective.Spec.TargetVersion)
 	if err != nil {
 		return nil, err
 	}
 	glog.V(2).Infof("Found resource %q", resourceKey(*apiResource))
 
-	typeConfig := typeConfigForTarget(*apiResource, federateDirective)
+	typeConfig := typeConfigForTarget(*apiResource, enableTypeDirective)
 
 	accessor, err := newSchemaAccessor(config, *apiResource)
 	if err != nil {
@@ -271,8 +271,8 @@ func CreateResources(cmdOut io.Writer, config *rest.Config, resources *typeResou
 	return nil
 }
 
-func typeConfigForTarget(apiResource metav1.APIResource, federateDirective *FederateDirective) typeconfig.Interface {
-	spec := federateDirective.Spec
+func typeConfigForTarget(apiResource metav1.APIResource, enableTypeDirective *EnableTypeDirective) typeconfig.Interface {
+	spec := enableTypeDirective.Spec
 	kind := apiResource.Kind
 	pluralName := apiResource.Name
 	typeConfig := &fedv1a1.FederatedTypeConfig{

--- a/scripts/check-directive-fixtures.sh
+++ b/scripts/check-directive-fixtures.sh
@@ -25,7 +25,7 @@ set -o pipefail
 ROOT_DIR="$(cd "$(dirname "$0")/.." ; pwd)"
 
 function check-directive-fixtures() {
-  local directives=( "${ROOT_DIR}/config/federatedirectives/"*.yaml )
+  local directives=( "${ROOT_DIR}/config/enabletypedirectives/"*.yaml )
   for file in "${directives[@]}"; do
     local filename="$(basename "${file}")"
     local expected_file="${ROOT_DIR}/test/common/fixtures/${filename}"

--- a/scripts/deploy-federation.sh
+++ b/scripts/deploy-federation.sh
@@ -68,7 +68,7 @@ function deploy-with-script() {
   # TODO(marun) Ensure crds are created for a given federated type before starting sync controller for that type
 
   # Enable available types
-  for filename in ./config/federatedirectives/*.yaml; do
+  for filename in ./config/enabletypedirectives/*.yaml; do
     ./bin/kubefed2 enable -f "${filename}" --federation-namespace="${NS}"
   done
 }

--- a/scripts/sync-up-helm-chart.sh
+++ b/scripts/sync-up-helm-chart.sh
@@ -60,7 +60,7 @@ util::wait-for-condition 'ok' "curl http://127.0.0.1:2379/version &> /dev/null" 
 util::wait-for-condition 'ok' "kubectl --kubeconfig ${WORKDIR}/kubeconfig --context federation get --raw=/healthz &> /dev/null" 60
 
 # Generate YAML templates to enable resource propagation for helm chart.
-for filename in ./config/federatedirectives/*.yaml; do
+for filename in ./config/enabletypedirectives/*.yaml; do
   ./bin/kubefed2 --kubeconfig ${WORKDIR}/kubeconfig enable -f "${filename}" --federation-namespace="${NS}" --host-cluster-context federation -o yaml > ${CHART_FEDERATED_PROPAGATION_DIR}/$(basename $filename)
 done
 

--- a/test/e2e/crd.go
+++ b/test/e2e/crd.go
@@ -129,11 +129,11 @@ func validateCrdCrud(f framework.FederationFramework, targetCrdKind string, name
 		tl.Fatalf("Timed out waiting for target type %q to be published as an available resource", targetName)
 	}
 
-	federateDirective := &federate.FederateDirective{
+	enableTypeDirective := &federate.EnableTypeDirective{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: targetAPIResource.Name,
 		},
-		Spec: federate.FederateDirectiveSpec{
+		Spec: federate.EnableTypeDirectiveSpec{
 			TargetVersion:    targetAPIResource.Version,
 			PrimitiveGroup:   targetAPIResource.Group,
 			PrimitiveVersion: targetAPIResource.Version,
@@ -141,7 +141,7 @@ func validateCrdCrud(f framework.FederationFramework, targetCrdKind string, name
 		},
 	}
 
-	resources, err := federate.GetResources(hostConfig, federateDirective)
+	resources, err := federate.GetResources(hostConfig, enableTypeDirective)
 	if err != nil {
 		tl.Fatalf("Error retrieving resources to enable federation of target type %q: %v", targetAPIResource.Kind, err)
 	}

--- a/test/e2e/framework/managed/federation.go
+++ b/test/e2e/framework/managed/federation.go
@@ -370,47 +370,47 @@ func waitForCrd(tl common.TestLogger, config *rest.Config, crd *apiextv1b1.Custo
 
 func federateCoreTypes(tl common.TestLogger, config *rest.Config, namespace string) []*apiextv1b1.CustomResourceDefinition {
 	crds := []*apiextv1b1.CustomResourceDefinition{}
-	for _, federateDirective := range loadFederateDirectives(tl) {
-		resources, err := federate.GetResources(config, federateDirective)
+	for _, enableTypeDirective := range loadEnableTypeDirectives(tl) {
+		resources, err := federate.GetResources(config, enableTypeDirective)
 		if err != nil {
-			tl.Fatalf("Error retrieving resource definitions for FederateDirective %q: %v", federateDirective.Name, err)
+			tl.Fatalf("Error retrieving resource definitions for EnableTypeDirective %q: %v", enableTypeDirective.Name, err)
 		}
 		err = federate.CreateResources(nil, config, resources, namespace)
 		if err != nil {
-			tl.Fatalf("Error creating resources for FederateDirective %q: %v", federateDirective.Name, err)
+			tl.Fatalf("Error creating resources for EnableTypeDirective %q: %v", enableTypeDirective.Name, err)
 		}
 		crds = append(crds, resources.CRDs...)
 	}
 	return crds
 }
-func loadFederateDirectives(tl common.TestLogger) []*federate.FederateDirective {
-	path := federateDirectivesPath(tl)
+func loadEnableTypeDirectives(tl common.TestLogger) []*federate.EnableTypeDirective {
+	path := enableTypeDirectivesPath(tl)
 	files, err := ioutil.ReadDir(path)
 	if err != nil {
-		tl.Fatalf("Error reading FederateDirective resources from path %q: %v", path, err)
+		tl.Fatalf("Error reading EnableTypeDirective resources from path %q: %v", path, err)
 	}
-	federateDirectives := []*federate.FederateDirective{}
+	enableTypeDirectives := []*federate.EnableTypeDirective{}
 	suffix := ".yaml"
 	for _, file := range files {
 		if !strings.HasSuffix(file.Name(), suffix) {
 			continue
 		}
 		filename := filepath.Join(path, file.Name())
-		obj := federate.NewFederateDirective()
+		obj := federate.NewEnableTypeDirective()
 		err := federate.DecodeYAMLFromFile(filename, obj)
 		if err != nil {
-			tl.Fatalf("Error loading FederateDirective from file %q: %v", filename, err)
+			tl.Fatalf("Error loading EnableTypeDirective from file %q: %v", filename, err)
 		}
-		federateDirectives = append(federateDirectives, obj)
+		enableTypeDirectives = append(enableTypeDirectives, obj)
 	}
-	return federateDirectives
+	return enableTypeDirectives
 }
 
-func federateDirectivesPath(tl common.TestLogger) string {
+func enableTypeDirectivesPath(tl common.TestLogger) string {
 	// Get the directory of the current executable
 	_, filename, _, _ := runtime.Caller(0)
 	managedPath := filepath.Dir(filename)
-	path, err := filepath.Abs(fmt.Sprintf("%s/../../../../config/federatedirectives", managedPath))
+	path, err := filepath.Abs(fmt.Sprintf("%s/../../../../config/enabletypedirectives", managedPath))
 	if err != nil {
 		tl.Fatalf("Error discovering the path to FederatedType resources: %v", err)
 	}


### PR DESCRIPTION
As a precursor to use keyword `federate` for resources and namespaces only.
Also `TypeDirective` sounds more suitable in use for `types`.

Based on #571. Only the last commit is reviewable.

cc @marun @gyliu513 @xunpan 