### PR TITLE
Fix help text for kubefed2 enable

### DIFF
--- a/pkg/kubefed2/federate/enable.go
+++ b/pkg/kubefed2/federate/enable.go
@@ -61,7 +61,7 @@ var (
 
 	enable_example = `
 		# Enable federation of Services with service type overrideable
-		kubefed2 federate enable Service --override-paths=spec.type --host-cluster-context=cluster1`
+		kubefed2 enable Service --override-paths=spec.type --host-cluster-context=cluster1`
 )
 
 type enableType struct {


### PR DESCRIPTION
Mistakenly still said "federate enable" in the help text rather than "enable"