### PR TITLE
Determine the comparison field at runtime rather than configuring

### DIFF
--- a/charts/federation-v2/charts/controllermanager/templates/crds.yaml
+++ b/charts/federation-v2/charts/controllermanager/templates/crds.yaml
@@ -190,8 +190,6 @@ spec:
           type: object
         spec:
           properties:
-            comparisonField:
-              type: string
             enableStatus:
               type: boolean
             federatedType:
@@ -240,7 +238,6 @@ spec:
           required:
           - target
           - namespaced
-          - comparisonField
           - propagationEnabled
           - federatedType
           type: object

--- a/charts/federation-v2/templates/clusterroles.rbac.authorization.k8s.io.yaml
+++ b/charts/federation-v2/templates/clusterroles.rbac.authorization.k8s.io.yaml
@@ -4,7 +4,6 @@ kind: FederatedTypeConfig
 metadata:
   name: clusterroles.rbac.authorization.k8s.io
 spec:
-  comparisonField: ResourceVersion
   federatedType:
     group: primitives.federation.k8s.io
     kind: FederatedClusterRole

--- a/charts/federation-v2/templates/configmaps.yaml
+++ b/charts/federation-v2/templates/configmaps.yaml
@@ -4,7 +4,6 @@ kind: FederatedTypeConfig
 metadata:
   name: configmaps
 spec:
-  comparisonField: ResourceVersion
   federatedType:
     group: primitives.federation.k8s.io
     kind: FederatedConfigMap

--- a/charts/federation-v2/templates/deployments.apps.yaml
+++ b/charts/federation-v2/templates/deployments.apps.yaml
@@ -4,7 +4,6 @@ kind: FederatedTypeConfig
 metadata:
   name: deployments.apps
 spec:
-  comparisonField: Generation
   federatedType:
     group: primitives.federation.k8s.io
     kind: FederatedDeployment

--- a/charts/federation-v2/templates/ingresses.extensions.yaml
+++ b/charts/federation-v2/templates/ingresses.extensions.yaml
@@ -4,7 +4,6 @@ kind: FederatedTypeConfig
 metadata:
   name: ingresses.extensions
 spec:
-  comparisonField: Generation
   federatedType:
     group: primitives.federation.k8s.io
     kind: FederatedIngress

--- a/charts/federation-v2/templates/jobs.batch.yaml
+++ b/charts/federation-v2/templates/jobs.batch.yaml
@@ -4,7 +4,6 @@ kind: FederatedTypeConfig
 metadata:
   name: jobs.batch
 spec:
-  comparisonField: Generation
   federatedType:
     group: primitives.federation.k8s.io
     kind: FederatedJob

--- a/charts/federation-v2/templates/namespaces.yaml
+++ b/charts/federation-v2/templates/namespaces.yaml
@@ -4,7 +4,6 @@ kind: FederatedTypeConfig
 metadata:
   name: namespaces
 spec:
-  comparisonField: ResourceVersion
   federatedType:
     group: primitives.federation.k8s.io
     kind: FederatedNamespace

--- a/charts/federation-v2/templates/replicasets.apps.yaml
+++ b/charts/federation-v2/templates/replicasets.apps.yaml
@@ -4,7 +4,6 @@ kind: FederatedTypeConfig
 metadata:
   name: replicasets.apps
 spec:
-  comparisonField: Generation
   federatedType:
     group: primitives.federation.k8s.io
     kind: FederatedReplicaSet

--- a/charts/federation-v2/templates/secrets.yaml
+++ b/charts/federation-v2/templates/secrets.yaml
@@ -4,7 +4,6 @@ kind: FederatedTypeConfig
 metadata:
   name: secrets
 spec:
-  comparisonField: ResourceVersion
   federatedType:
     group: primitives.federation.k8s.io
     kind: FederatedSecret

--- a/charts/federation-v2/templates/serviceaccounts.yaml
+++ b/charts/federation-v2/templates/serviceaccounts.yaml
@@ -4,7 +4,6 @@ kind: FederatedTypeConfig
 metadata:
   name: serviceaccounts
 spec:
-  comparisonField: ResourceVersion
   federatedType:
     group: primitives.federation.k8s.io
     kind: FederatedServiceAccount

--- a/charts/federation-v2/templates/services.yaml
+++ b/charts/federation-v2/templates/services.yaml
@@ -4,7 +4,6 @@ kind: FederatedTypeConfig
 metadata:
   name: services
 spec:
-  comparisonField: ResourceVersion
   federatedType:
     group: primitives.federation.k8s.io
     kind: FederatedService

--- a/config/enabletypedirectives/deployments.apps.yaml
+++ b/config/enabletypedirectives/deployments.apps.yaml
@@ -2,5 +2,3 @@ apiVersion: core.federation.k8s.io/v1alpha1
 kind: EnableTypeDirective
 metadata:
   name: deployments.apps
-spec:
-  comparisonField: Generation

--- a/config/enabletypedirectives/ingresses.extensions.yaml
+++ b/config/enabletypedirectives/ingresses.extensions.yaml
@@ -2,5 +2,3 @@ apiVersion: core.federation.k8s.io/v1alpha1
 kind: EnableTypeDirective
 metadata:
   name: ingresses.extensions
-spec:
-  comparisonField: Generation

--- a/config/enabletypedirectives/jobs.batch.yaml
+++ b/config/enabletypedirectives/jobs.batch.yaml
@@ -2,5 +2,3 @@ apiVersion: core.federation.k8s.io/v1alpha1
 kind: EnableTypeDirective
 metadata:
   name: jobs.batch
-spec:
-  comparisonField: Generation

--- a/config/enabletypedirectives/replicasets.apps.yaml
+++ b/config/enabletypedirectives/replicasets.apps.yaml
@@ -2,5 +2,3 @@ apiVersion: core.federation.k8s.io/v1alpha1
 kind: EnableTypeDirective
 metadata:
   name: replicasets.apps
-spec:
-  comparisonField: Generation

--- a/hack/install-latest.yaml
+++ b/hack/install-latest.yaml
@@ -228,8 +228,6 @@ spec:
           type: object
         spec:
           properties:
-            comparisonField:
-              type: string
             enableStatus:
               type: boolean
             federatedType:
@@ -278,7 +276,6 @@ spec:
           required:
           - target
           - namespaced
-          - comparisonField
           - propagationEnabled
           - federatedType
           type: object

--- a/pkg/apis/core/typeconfig/interface.go
+++ b/pkg/apis/core/typeconfig/interface.go
@@ -17,7 +17,6 @@ limitations under the License.
 package typeconfig
 
 import (
-	"github.com/kubernetes-sigs/federation-v2/pkg/apis/core/common"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -26,7 +25,6 @@ type Interface interface {
 	GetObjectMeta() metav1.ObjectMeta
 	GetTarget() metav1.APIResource
 	GetNamespaced() bool
-	GetComparisonField() common.VersionComparisonField
 	GetPropagationEnabled() bool
 	GetFederatedType() metav1.APIResource
 	GetStatus() *metav1.APIResource

--- a/pkg/apis/core/v1alpha1/federatedtypeconfig_types.go
+++ b/pkg/apis/core/v1alpha1/federatedtypeconfig_types.go
@@ -21,8 +21,6 @@ import (
 	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"github.com/kubernetes-sigs/federation-v2/pkg/apis/core/common"
 )
 
 // FederatedTypeConfigSpec defines the desired state of FederatedTypeConfig.
@@ -38,11 +36,6 @@ type FederatedTypeConfigSpec struct {
 	// TODO(marun) Remove in favor of using the value from Target and
 	// FederatedType (depending on context).
 	Namespaced bool `json:"namespaced"`
-	// Which field of the target type determines whether federation
-	// considers two resources to be equal.
-	//
-	// TODO(marun) Remove and discover the field to use at runtime.
-	ComparisonField common.VersionComparisonField `json:"comparisonField"`
 	// Whether or not propagation to member clusters should be enabled.
 	PropagationEnabled bool `json:"propagationEnabled"`
 	// Configuration for the federated type that defines (via
@@ -176,10 +169,6 @@ func (f *FederatedTypeConfig) GetTarget() metav1.APIResource {
 
 func (f *FederatedTypeConfig) GetNamespaced() bool {
 	return f.Spec.Namespaced
-}
-
-func (f *FederatedTypeConfig) GetComparisonField() common.VersionComparisonField {
-	return f.Spec.ComparisonField
 }
 
 func (f *FederatedTypeConfig) GetPropagationEnabled() bool {

--- a/pkg/apis/core/v1alpha1/zz_generated.kubebuilder.go
+++ b/pkg/apis/core/v1alpha1/zz_generated.kubebuilder.go
@@ -337,9 +337,6 @@ var (
 						"spec": v1beta1.JSONSchemaProps{
 							Type: "object",
 							Properties: map[string]v1beta1.JSONSchemaProps{
-								"comparisonField": v1beta1.JSONSchemaProps{
-									Type: "string",
-								},
 								"enableStatus": v1beta1.JSONSchemaProps{
 									Type: "boolean",
 								},
@@ -410,7 +407,6 @@ var (
 							Required: []string{
 								"target",
 								"namespaced",
-								"comparisonField",
 								"propagationEnabled",
 								"federatedType",
 							}},

--- a/pkg/kubefed2/federate/directive.go
+++ b/pkg/kubefed2/federate/directive.go
@@ -52,7 +52,6 @@ type EnableTypeDirective struct {
 }
 
 func (ft *EnableTypeDirective) SetDefaults() {
-	ft.Spec.ComparisonField = defaultComparisonField
 	ft.Spec.PrimitiveGroup = defaultPrimitiveGroup
 	ft.Spec.PrimitiveVersion = defaultPrimitiveVersion
 }

--- a/test/common/crudtester.go
+++ b/test/common/crudtester.go
@@ -46,7 +46,6 @@ type FederatedTypeCrudTester struct {
 	tl                TestLogger
 	typeConfig        typeconfig.Interface
 	targetIsNamespace bool
-	comparisonHelper  util.ComparisonHelper
 	fedClient         clientset.Interface
 	kubeConfig        *rest.Config
 	testClusters      map[string]TestCluster
@@ -68,16 +67,10 @@ type TestCluster struct {
 }
 
 func NewFederatedTypeCrudTester(testLogger TestLogger, typeConfig typeconfig.Interface, kubeConfig *rest.Config, testClusters map[string]TestCluster, waitInterval, clusterWaitTimeout time.Duration) (*FederatedTypeCrudTester, error) {
-	compare, err := util.NewComparisonHelper(typeConfig.GetComparisonField())
-	if err != nil {
-		return nil, err
-	}
-
 	return &FederatedTypeCrudTester{
 		tl:                 testLogger,
 		typeConfig:         typeConfig,
 		targetIsNamespace:  typeConfig.GetTarget().Kind == util.NamespaceKind,
-		comparisonHelper:   compare,
 		fedClient:          clientset.NewForConfigOrDie(kubeConfig),
 		kubeConfig:         kubeConfig,
 		testClusters:       testClusters,
@@ -408,7 +401,7 @@ func (c *FederatedTypeCrudTester) waitForResource(client util.ResourceClient, qu
 		}
 
 		clusterObj, err := client.Resources(qualifiedName.Namespace).Get(qualifiedName.Name, metav1.GetOptions{})
-		if err == nil && c.comparisonHelper.GetVersion(clusterObj) == expectedVersion {
+		if err == nil && util.ObjectVersion(clusterObj) == expectedVersion {
 			// Validate that the expected override was applied
 			if len(expectedOverrides) > 0 {
 				for path, expectedValue := range expectedOverrides {


### PR DESCRIPTION
As per a suggestion from @irfanurrehman, the field used in deriving the version of a cluster object is now determined at runtime rather than having to be configured at the type level.  This allows use of the `generation` field where an object is expected to be modified regularly by a controller, and fallback to the `resourceVersion` field if the generation field is not being set.  Removing the requirement to configure `comparisonField` when enabling federation of a type will remove the possibility of a user inadvertently choosing the wrong field and the potential for variance in type configuration across deployments of federation. 

Fixes #480