### PR TITLE
Enable configurable replicas retention by the sync controller

### DIFF
--- a/charts/federation-v2/templates/deployments.apps.yaml
+++ b/charts/federation-v2/templates/deployments.apps.yaml
@@ -91,6 +91,8 @@ spec:
                       type: object
                   type: object
               type: object
+            retainReplicas:
+              type: bool
             template:
               properties:
                 apiVersion:

--- a/charts/federation-v2/templates/replicasets.apps.yaml
+++ b/charts/federation-v2/templates/replicasets.apps.yaml
@@ -91,6 +91,8 @@ spec:
                       type: object
                   type: object
               type: object
+            retainReplicas:
+              type: bool
             template:
               properties:
                 apiVersion:

--- a/docs/userguide.md
+++ b/docs/userguide.md
@@ -33,6 +33,8 @@
     - [Automated Deployment](#automated-deployment-1)
     - [Joining Clusters](#joining-clusters)
     - [Deployment Cleanup](#deployment-cleanup-1)
+  - [Local Value Retention](#local-value-retention)
+    - [Scalable Resources](#scalable-resources)
   - [Higher order behaviour](#higher-order-behaviour)
     - [Multi-Cluster Ingress DNS](#multi-cluster-ingress-dns)
     - [Multi-Cluster Service DNS](#multi-cluster-service-dns)
@@ -527,6 +529,44 @@ employed by deployment:
 ```bash
 NAMESPACED=y FEDERATION_NAMESPACE=<namespace> ./scripts/delete-federation.sh
 ```
+
+## Local Value Retention
+
+In most cases, the federation sync controller will overwrite any
+changes made to resources it manages in member clusters.  The
+exceptions appear in the following table.  Where retention is
+conditional, an explanation will be provided in a subsequent section.
+
+| Resource Type  | Fields                    | Retention   | Requirement                                                                  |
+|----------------|---------------------------|--------------------------------------------------------------------------------------------|
+| All            | metadata.resourceVersion  | Always      | Updates require the most recent resourceVersion for concurrency control.     |
+| Scalable       | spec.replicas             | Conditional | The HPA controller may be managing the replica count of a scalable resource. |
+| Service        | spec.clusterIP,spec.ports | Always      | A controller may be managing these fields.                                   |
+| ServiceAccount | secrets                   | Conditional | A controller may be managing this field.                                     |
+
+### Scalable
+
+For scalable resources (those that have a scale subtype
+e.g. `ReplicaSet` and `Deployment`), retention of the `spec.replicas`
+field is controlled by the `retainReplicas` boolean field of the
+federated resource.  `retainReplicas` defaults to `false`, and should
+be set to `true` only if the resource will be managed by HPA in member
+clusters.
+
+Retention of the replicas field is possible for all
+clusters or no clusters.  If a resource will be managed by HPA in some
+clusters but not others, it will be necessary to create a separate
+federated resource for each retention strategy (i.e. one with
+`retainReplicas: true` and one with `retainReplicas: false`).
+
+### ServiceAccount
+
+A populated `secrets` field of a `ServiceAccount` resource managed by
+federation will be retained if the managing federated resource does
+not specify a value for the field.  This avoids the possibility of the
+sync controller attempting to repeatedly clear the field while a local
+serviceaccounts controller attempts to repeatedly set it to a
+generated value.
 
 ## Higher order behaviour
 

--- a/pkg/controller/sync/controller_test.go
+++ b/pkg/controller/sync/controller_test.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sync
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/kubernetes-sigs/federation-v2/pkg/controller/util"
+)
+
+func TestObjectForUpdateOp(t *testing.T) {
+	testCases := map[string]struct {
+		retainReplicas   bool
+		desiredReplicas  int64
+		clusterReplicas  int64
+		expectedReplicas int64
+	}{
+		"replicas not retained when retainReplicas=false or is not present": {
+			retainReplicas:   false,
+			desiredReplicas:  1,
+			clusterReplicas:  2,
+			expectedReplicas: 1,
+		},
+		"replicas retained when retainReplicas=true": {
+			retainReplicas:   true,
+			desiredReplicas:  1,
+			clusterReplicas:  2,
+			expectedReplicas: 2,
+		},
+	}
+
+	for testName, testCase := range testCases {
+		t.Run(testName, func(t *testing.T) {
+			desiredObj := &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"spec": map[string]interface{}{
+						"replicas": testCase.desiredReplicas,
+					},
+				},
+			}
+			clusterObj := &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"spec": map[string]interface{}{
+						"replicas": testCase.clusterReplicas,
+					},
+				},
+			}
+			fedObj := &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"spec": map[string]interface{}{
+						"retainReplicas": testCase.retainReplicas,
+					},
+				},
+			}
+			objectForUpdateOp("", desiredObj, clusterObj, fedObj)
+			replicas, ok, err := unstructured.NestedInt64(desiredObj.Object, util.SpecField, util.ReplicasField)
+			if !ok {
+				t.Fatalf("Field 'spec.replicas' not found")
+			}
+			if err != nil {
+				t.Fatalf("An unexpected error occurred")
+			}
+			if replicas != testCase.expectedReplicas {
+				t.Fatalf("Expected %d replicas when retainReplicas=%v, got %d", testCase.expectedReplicas, testCase.retainReplicas, replicas)
+			}
+		})
+	}
+}

--- a/pkg/controller/util/constants.go
+++ b/pkg/controller/util/constants.go
@@ -41,6 +41,10 @@ const (
 	// ServiceAccount fields
 	SecretsField = "secrets"
 
+	// Scale types
+	ReplicasField       = "replicas"
+	RetainReplicasField = "retainReplicas"
+
 	// Template fields
 	TemplateField = "template"
 


### PR DESCRIPTION
`kubefed2 enable` is updated to add a `retainReplicas` field for target types that expose a `spec.replicas` field.  If set on a federated resource, the sync controller will attempt to retain a replicas field from the target resource when performing updates to the target.  This is intended to avoid thrashing the scheduler when in-cluster HPA is targeting a scalable resource.

The granularity of this retention is all clusters or no-clusters, with the expectation that where HPA is intended to be applied selectively, a user will define 2 resources (one with `retainReplicas: true` and one with `retainReplicas: false`) along with partitioning placement.

Fixes #570 

TODO

- [x] Add testing
- [x] Add documentation