### PR TITLE
download-binaries.sh: Remove a problematic pipefail

### DIFF
--- a/scripts/download-binaries.sh
+++ b/scripts/download-binaries.sh
@@ -58,7 +58,7 @@ curl "${curl_args}O" "${helm_url}" \
 echo    "# destination:"
 echo    "#   ${dest_dir}"
 echo    "# versions:"
-echo -n "#   etcd:           "; "${dest_dir}/etcd" --version | head -n 1
+echo -n "#   etcd:           "; ("${dest_dir}/etcd" --version || :) | grep "etcd Version:"
 echo -n "#   kube-apiserver: "; "${dest_dir}/kube-apiserver" --version
 echo -n "#   kubectl:        "; "${dest_dir}/kubectl" version --client --short
 echo -n "#   kubebuilder:    "; "${dest_dir}/kubebuilder" version


### PR DESCRIPTION
If you are unlucky enough, "etcd --version | head -n 1" can
fail due to pipefail. (Depending on process scheduling and
other factors.)

As it's the only use of a pipe in this script, this commit
simply disables the pipefail option.