### PR TITLE
build kubefed2 on demands with parameter control

### DIFF
--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -163,7 +163,7 @@ echo "Deploying federation-v2"
 ./scripts/deploy-federation.sh ${CONTAINER_REGISTRY_HOST}/federation-v2:e2e $(join-cluster-list)
 
 echo "Checking sync up status of helm chart"
-PATH="${PATH}:${base_dir}/bin" ./scripts/sync-up-helm-chart.sh
+BUILD_KUBEFED="false" PATH="${PATH}:${base_dir}/bin" ./scripts/sync-up-helm-chart.sh
 
 echo "Checking helm chart state of working tree"
 check-git-state

--- a/scripts/sync-up-helm-chart.sh
+++ b/scripts/sync-up-helm-chart.sh
@@ -20,6 +20,7 @@ set -o pipefail
 
 source "$(dirname "${BASH_SOURCE}")/util.sh"
 
+ROOT_DIR="$(cd "$(dirname "$0")/.." ; pwd)"
 WORKDIR=$(mktemp -d)
 NS="${FEDERATION_NAMESPACE:-federation-system}"
 CHART_FEDERATED_CRD_DIR="${CHART_FEDERATED_CRD_DIR:-charts/federation-v2/charts/controllermanager/templates}"
@@ -27,6 +28,11 @@ CHART_FEDERATED_PROPAGATION_DIR="${CHART_FEDERATED_PROPAGATION_DIR:-charts/feder
 INSTALL_CRDS_YAML="${INSTALL_CRDS_YAML:-hack/install-crds-latest.yaml}"
 
 INSTALL_CRDS_YAML="${INSTALL_CRDS_YAML}" scripts/generate-install-crds-yaml.sh
+
+BUILD_KUBEFED="${BUILD_KUBEFED:-true}"
+if [[ "${BUILD_KUBEFED}" == true ]]; then
+  make -C "${ROOT_DIR}" kubefed2
+fi
 
 # "diff -U 4" will take 1 as return code which will cause the script failed to execute, here
 # I was force returning true to get a return code as 0.


### PR DESCRIPTION
Fix#589

build kubefed2 on demands with parameter control: when the script is used independently, kubefed2 should be build. If it is used in pre-commit.sh, the build process should be ignored.

@gyliu513 @marun 