### PR TITLE
forcely delete a member cluster information in the host cluster 

### DIFF
--- a/pkg/kubefed2/util/util.go
+++ b/pkg/kubefed2/util/util.go
@@ -86,7 +86,7 @@ func (a *fedConfig) getClientConfig(context, kubeconfigPath string) clientcmd.Cl
 // HostClientset provides a kubernetes API compliant clientset to
 // communicate with the host cluster's kubernetes API server.
 func HostClientset(config *rest.Config) (*client.Clientset, error) {
-	return client.NewForConfigOrDie(config), nil
+	return client.NewForConfig(config)
 }
 
 // ClusterClientset provides a kubernetes API compliant clientset to
@@ -98,13 +98,13 @@ func ClusterClientset(config *rest.Config) (*client.Clientset, error) {
 // ClusterRegistryClientset provides a cluster registry API compliant
 // clientset to communicate with the cluster registry.
 func ClusterRegistryClientset(config *rest.Config) (*crclient.Clientset, error) {
-	return crclient.NewForConfigOrDie(config), nil
+	return crclient.NewForConfig(config)
 }
 
 // FedClientset provides a federation API compliant clientset
 // to communicate with the federation API server.
 func FedClientset(config *rest.Config) (*fedclient.Clientset, error) {
-	return fedclient.NewForConfigOrDie(config), nil
+	return fedclient.NewForConfig(config)
 }
 
 // ClusterServiceAccountName returns the name of a service account whose

--- a/pkg/kubefed2/util/util.go
+++ b/pkg/kubefed2/util/util.go
@@ -92,7 +92,7 @@ func HostClientset(config *rest.Config) (*client.Clientset, error) {
 // ClusterClientset provides a kubernetes API compliant clientset to
 // communicate with the joining cluster's kubernetes API server.
 func ClusterClientset(config *rest.Config) (*client.Clientset, error) {
-	return client.NewForConfigOrDie(config), nil
+	return client.NewForConfig(config)
 }
 
 // ClusterRegistryClientset provides a cluster registry API compliant


### PR DESCRIPTION
Fix#592

forcely delete federation information in the host cluster if a member cluster
is not available