### PR TITLE
Replace references to 'federation primitives' with 'federated type'

### DIFF
--- a/charts/federation-v2/templates/clusterroles.rbac.authorization.k8s.io.yaml
+++ b/charts/federation-v2/templates/clusterroles.rbac.authorization.k8s.io.yaml
@@ -5,7 +5,7 @@ metadata:
   name: clusterroles.rbac.authorization.k8s.io
 spec:
   federatedType:
-    group: primitives.federation.k8s.io
+    group: types.federation.k8s.io
     kind: FederatedClusterRole
     pluralName: federatedclusterroles
     version: v1alpha1
@@ -20,9 +20,9 @@ spec:
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: federatedclusterroles.primitives.federation.k8s.io
+  name: federatedclusterroles.types.federation.k8s.io
 spec:
-  group: primitives.federation.k8s.io
+  group: types.federation.k8s.io
   names:
     kind: FederatedClusterRole
     plural: federatedclusterroles

--- a/charts/federation-v2/templates/configmaps.yaml
+++ b/charts/federation-v2/templates/configmaps.yaml
@@ -5,7 +5,7 @@ metadata:
   name: configmaps
 spec:
   federatedType:
-    group: primitives.federation.k8s.io
+    group: types.federation.k8s.io
     kind: FederatedConfigMap
     pluralName: federatedconfigmaps
     version: v1alpha1
@@ -19,9 +19,9 @@ spec:
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: federatedconfigmaps.primitives.federation.k8s.io
+  name: federatedconfigmaps.types.federation.k8s.io
 spec:
-  group: primitives.federation.k8s.io
+  group: types.federation.k8s.io
   names:
     kind: FederatedConfigMap
     plural: federatedconfigmaps

--- a/charts/federation-v2/templates/deployments.apps.yaml
+++ b/charts/federation-v2/templates/deployments.apps.yaml
@@ -5,7 +5,7 @@ metadata:
   name: deployments.apps
 spec:
   federatedType:
-    group: primitives.federation.k8s.io
+    group: types.federation.k8s.io
     kind: FederatedDeployment
     pluralName: federateddeployments
     version: v1alpha1
@@ -20,9 +20,9 @@ spec:
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: federateddeployments.primitives.federation.k8s.io
+  name: federateddeployments.types.federation.k8s.io
 spec:
-  group: primitives.federation.k8s.io
+  group: types.federation.k8s.io
   names:
     kind: FederatedDeployment
     plural: federateddeployments

--- a/charts/federation-v2/templates/ingresses.extensions.yaml
+++ b/charts/federation-v2/templates/ingresses.extensions.yaml
@@ -5,7 +5,7 @@ metadata:
   name: ingresses.extensions
 spec:
   federatedType:
-    group: primitives.federation.k8s.io
+    group: types.federation.k8s.io
     kind: FederatedIngress
     pluralName: federatedingresses
     version: v1alpha1
@@ -20,9 +20,9 @@ spec:
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: federatedingresses.primitives.federation.k8s.io
+  name: federatedingresses.types.federation.k8s.io
 spec:
-  group: primitives.federation.k8s.io
+  group: types.federation.k8s.io
   names:
     kind: FederatedIngress
     plural: federatedingresses

--- a/charts/federation-v2/templates/jobs.batch.yaml
+++ b/charts/federation-v2/templates/jobs.batch.yaml
@@ -5,7 +5,7 @@ metadata:
   name: jobs.batch
 spec:
   federatedType:
-    group: primitives.federation.k8s.io
+    group: types.federation.k8s.io
     kind: FederatedJob
     pluralName: federatedjobs
     version: v1alpha1
@@ -20,9 +20,9 @@ spec:
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: federatedjobs.primitives.federation.k8s.io
+  name: federatedjobs.types.federation.k8s.io
 spec:
-  group: primitives.federation.k8s.io
+  group: types.federation.k8s.io
   names:
     kind: FederatedJob
     plural: federatedjobs

--- a/charts/federation-v2/templates/namespaces.yaml
+++ b/charts/federation-v2/templates/namespaces.yaml
@@ -5,7 +5,7 @@ metadata:
   name: namespaces
 spec:
   federatedType:
-    group: primitives.federation.k8s.io
+    group: types.federation.k8s.io
     kind: FederatedNamespace
     pluralName: federatednamespaces
     version: v1alpha1
@@ -19,9 +19,9 @@ spec:
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: federatednamespaces.primitives.federation.k8s.io
+  name: federatednamespaces.types.federation.k8s.io
 spec:
-  group: primitives.federation.k8s.io
+  group: types.federation.k8s.io
   names:
     kind: FederatedNamespace
     plural: federatednamespaces

--- a/charts/federation-v2/templates/replicasets.apps.yaml
+++ b/charts/federation-v2/templates/replicasets.apps.yaml
@@ -5,7 +5,7 @@ metadata:
   name: replicasets.apps
 spec:
   federatedType:
-    group: primitives.federation.k8s.io
+    group: types.federation.k8s.io
     kind: FederatedReplicaSet
     pluralName: federatedreplicasets
     version: v1alpha1
@@ -20,9 +20,9 @@ spec:
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: federatedreplicasets.primitives.federation.k8s.io
+  name: federatedreplicasets.types.federation.k8s.io
 spec:
-  group: primitives.federation.k8s.io
+  group: types.federation.k8s.io
   names:
     kind: FederatedReplicaSet
     plural: federatedreplicasets

--- a/charts/federation-v2/templates/secrets.yaml
+++ b/charts/federation-v2/templates/secrets.yaml
@@ -5,7 +5,7 @@ metadata:
   name: secrets
 spec:
   federatedType:
-    group: primitives.federation.k8s.io
+    group: types.federation.k8s.io
     kind: FederatedSecret
     pluralName: federatedsecrets
     version: v1alpha1
@@ -19,9 +19,9 @@ spec:
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: federatedsecrets.primitives.federation.k8s.io
+  name: federatedsecrets.types.federation.k8s.io
 spec:
-  group: primitives.federation.k8s.io
+  group: types.federation.k8s.io
   names:
     kind: FederatedSecret
     plural: federatedsecrets

--- a/charts/federation-v2/templates/serviceaccounts.yaml
+++ b/charts/federation-v2/templates/serviceaccounts.yaml
@@ -5,7 +5,7 @@ metadata:
   name: serviceaccounts
 spec:
   federatedType:
-    group: primitives.federation.k8s.io
+    group: types.federation.k8s.io
     kind: FederatedServiceAccount
     pluralName: federatedserviceaccounts
     version: v1alpha1
@@ -19,9 +19,9 @@ spec:
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: federatedserviceaccounts.primitives.federation.k8s.io
+  name: federatedserviceaccounts.types.federation.k8s.io
 spec:
-  group: primitives.federation.k8s.io
+  group: types.federation.k8s.io
   names:
     kind: FederatedServiceAccount
     plural: federatedserviceaccounts

--- a/charts/federation-v2/templates/services.yaml
+++ b/charts/federation-v2/templates/services.yaml
@@ -5,7 +5,7 @@ metadata:
   name: services
 spec:
   federatedType:
-    group: primitives.federation.k8s.io
+    group: types.federation.k8s.io
     kind: FederatedService
     pluralName: federatedservices
     version: v1alpha1
@@ -19,9 +19,9 @@ spec:
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: federatedservices.primitives.federation.k8s.io
+  name: federatedservices.types.federation.k8s.io
 spec:
-  group: primitives.federation.k8s.io
+  group: types.federation.k8s.io
   names:
     kind: FederatedService
     plural: federatedservices

--- a/docs/userguide.md
+++ b/docs/userguide.md
@@ -223,7 +223,7 @@ If the goal is to permanently disable federation of the target API type, passing
 kubefed2 disable <FederatedTypeConfig Name> --delete-from-api
 ```
 
-**WARNING: All primitive custom resources for the type will be removed by this command.**
+**WARNING: All custom resources for the type will be removed by this command.**
 
 ## Example
 
@@ -253,7 +253,7 @@ kubectl apply -R -f example/sample1
 **NOTE:** If you get the following error while creating a test resource i.e.
 
 ```
-unable to recognize "example/sample1/federated<type>.yaml": no matches for kind "Federated<type>" in version "primitives.federation.k8s.io/v1alpha1",
+unable to recognize "example/sample1/federated<type>.yaml": no matches for kind "Federated<type>" in version "types.federation.k8s.io/v1alpha1",
 
 ```
 

--- a/example/sample1/federatedclusterrole.yaml
+++ b/example/sample1/federatedclusterrole.yaml
@@ -1,4 +1,4 @@
-apiVersion: primitives.federation.k8s.io/v1alpha1
+apiVersion: types.federation.k8s.io/v1alpha1
 kind: FederatedClusterRole
 metadata:
   name: test-clusterrole

--- a/example/sample1/federatedclusterrolebinding.yaml
+++ b/example/sample1/federatedclusterrolebinding.yaml
@@ -1,4 +1,4 @@
-apiVersion: primitives.federation.k8s.io/v1alpha1
+apiVersion: types.federation.k8s.io/v1alpha1
 kind: FederatedClusterRoleBinding
 metadata:
   name: test-clusterrolebinding

--- a/example/sample1/federatedconfigmap.yaml
+++ b/example/sample1/federatedconfigmap.yaml
@@ -1,4 +1,4 @@
-apiVersion: primitives.federation.k8s.io/v1alpha1
+apiVersion: types.federation.k8s.io/v1alpha1
 kind: FederatedConfigMap
 metadata:
   name: test-configmap

--- a/example/sample1/federateddeployment.yaml
+++ b/example/sample1/federateddeployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: primitives.federation.k8s.io/v1alpha1
+apiVersion: types.federation.k8s.io/v1alpha1
 kind: FederatedDeployment
 metadata:
   name: test-deployment

--- a/example/sample1/federatedingress.yaml
+++ b/example/sample1/federatedingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: primitives.federation.k8s.io/v1alpha1
+apiVersion: types.federation.k8s.io/v1alpha1
 kind: FederatedIngress
 metadata:
   name: test-ingress

--- a/example/sample1/federatedjob.yaml
+++ b/example/sample1/federatedjob.yaml
@@ -1,4 +1,4 @@
-apiVersion: primitives.federation.k8s.io/v1alpha1
+apiVersion: types.federation.k8s.io/v1alpha1
 kind: FederatedJob
 metadata:
   name: test-job

--- a/example/sample1/federatednamespace.yaml
+++ b/example/sample1/federatednamespace.yaml
@@ -1,4 +1,4 @@
-apiVersion: primitives.federation.k8s.io/v1alpha1
+apiVersion: types.federation.k8s.io/v1alpha1
 kind: FederatedNamespace
 metadata:
   name: test-namespace

--- a/example/sample1/federatedsecret.yaml
+++ b/example/sample1/federatedsecret.yaml
@@ -1,4 +1,4 @@
-apiVersion: primitives.federation.k8s.io/v1alpha1
+apiVersion: types.federation.k8s.io/v1alpha1
 kind: FederatedSecret
 metadata:
   name: test-secret

--- a/example/sample1/federatedservice.yaml
+++ b/example/sample1/federatedservice.yaml
@@ -1,4 +1,4 @@
-apiVersion: primitives.federation.k8s.io/v1alpha1
+apiVersion: types.federation.k8s.io/v1alpha1
 kind: FederatedService
 metadata:
   name: test-service

--- a/example/sample1/federatedserviceaccount.yaml
+++ b/example/sample1/federatedserviceaccount.yaml
@@ -1,4 +1,4 @@
-apiVersion: primitives.federation.k8s.io/v1alpha1
+apiVersion: types.federation.k8s.io/v1alpha1
 kind: FederatedServiceAccount
 metadata:
   name: test-serviceaccount

--- a/pkg/apis/core/v1alpha1/federatedtypeconfig_types.go
+++ b/pkg/apis/core/v1alpha1/federatedtypeconfig_types.go
@@ -194,9 +194,9 @@ func (f *FederatedTypeConfig) GetEnableStatus() bool {
 // TODO(marun) Remove in favor of using 'true' for namespaces and the
 // value from target otherwise.
 func (f *FederatedTypeConfig) GetFederatedNamespaced() bool {
-	// Special-case the scope of namespace primitives since it will
-	// hopefully be the only instance of the scope of a federation
-	// primitive differing from the scope of its target.
+	// Special-case the scope of federated namespace since it will
+	// hopefully be the only instance of the scope of a federated
+	// type differing from the scope of its target.
 
 	// TODO(marun) Use the constant in pkg/controller/util
 	if f.Name == "namespaces" {

--- a/pkg/controller/sync/accessor.go
+++ b/pkg/controller/sync/accessor.go
@@ -206,7 +206,7 @@ func (a *resourceAccessor) FederatedResource(eventSource util.QualifiedName) (Fe
 		Name:      eventSource.Name,
 	}
 
-	// A federated primitive for namespace "foo" is namespaced
+	// A federated type for namespace "foo" is namespaced
 	// (e.g. "foo/foo"). An event sourced from a namespace in the host
 	// or member clusters will have the name "foo", and an event
 	// sourced from a federated resource will have the name "foo/foo".

--- a/pkg/controller/sync/resource.go
+++ b/pkg/controller/sync/resource.go
@@ -135,8 +135,8 @@ func (r *federatedResource) ObjectForCluster(clusterName string) (*unstructured.
 	//
 	// Namespace is the only type that can contain other resources,
 	// and adding a federation-specific container type would be
-	// difficult or impossible. This implies that federation
-	// primitives need to exist in regular namespaces.
+	// difficult or impossible. This implies that federated types need
+	// to exist in regular namespaces.
 	//
 	// TODO(marun) Ensure this is reflected in documentation
 	obj := &unstructured.Unstructured{}

--- a/pkg/kubefed2/federate/directive.go
+++ b/pkg/kubefed2/federate/directive.go
@@ -32,13 +32,13 @@ type EnableTypeDirectiveSpec struct {
 	// considers two resources to be equal.
 	ComparisonField common.VersionComparisonField `json:"comparisonField"`
 
-	// The name of the API group to use for generated federation primitives.
+	// The name of the API group to use for generated federation types.
 	// +optional
-	PrimitiveGroup string `json:"primitiveGroup,omitempty"`
+	FederationGroup string `json:"federationGroup,omitempty"`
 
-	// The API version to use for generated federation primitives.
+	// The API version to use for generated federation types.
 	// +optional
-	PrimitiveVersion string `json:"primitiveVersion,omitempty"`
+	FederationVersion string `json:"federationVersion,omitempty"`
 }
 
 // TODO(marun) This should become a proper API type and drive enabling
@@ -52,8 +52,8 @@ type EnableTypeDirective struct {
 }
 
 func (ft *EnableTypeDirective) SetDefaults() {
-	ft.Spec.PrimitiveGroup = defaultPrimitiveGroup
-	ft.Spec.PrimitiveVersion = defaultPrimitiveVersion
+	ft.Spec.FederationGroup = defaultFederationGroup
+	ft.Spec.FederationVersion = defaultFederationVersion
 }
 
 func NewEnableTypeDirective() *EnableTypeDirective {

--- a/pkg/kubefed2/federate/enable.go
+++ b/pkg/kubefed2/federate/enable.go
@@ -42,16 +42,16 @@ import (
 )
 
 const (
-	defaultPrimitiveGroup   = "primitives.federation.k8s.io"
-	defaultPrimitiveVersion = "v1alpha1"
+	defaultFederationGroup   = "types.federation.k8s.io"
+	defaultFederationVersion = "v1alpha1"
 )
 
 var (
 	enable_long = `
 		Enables a Kubernetes API type (including a CRD) to be propagated
-		to members of a federation.  Federation primitives will be
-		generated as CRDs and a FederatedTypeConfig will be created to
-		configure a sync controller.
+		to members of a federation.  A CRD for the federated type will be
+		generated and a FederatedTypeConfig will be created to configure
+		a sync controller.
 
 		Current context is assumed to be a Kubernetes cluster hosting
 		the federation control plane. Please use the
@@ -70,8 +70,8 @@ type enableType struct {
 type enableTypeOptions struct {
 	targetName          string
 	targetVersion       string
-	primitiveVersion    string
-	primitiveGroup      string
+	federationVersion   string
+	federationGroup     string
 	output              string
 	outputYAML          bool
 	filename            string
@@ -82,8 +82,8 @@ type enableTypeOptions struct {
 // argument.
 func (o *enableTypeOptions) Bind(flags *pflag.FlagSet) {
 	flags.StringVar(&o.targetVersion, "version", "", "Optional, the API version of the target type.")
-	flags.StringVar(&o.primitiveGroup, "primitive-group", defaultPrimitiveGroup, "The name of the API group to use for generated federation primitives.")
-	flags.StringVar(&o.primitiveVersion, "primitive-version", defaultPrimitiveVersion, "The API version to use for generated federation primitives.")
+	flags.StringVar(&o.federationGroup, "federation-group", defaultFederationGroup, "The name of the API group to use for the generated federation type.")
+	flags.StringVar(&o.federationVersion, "federation-version", defaultFederationVersion, "The API version to use for the generated federation type.")
 	flags.StringVarP(&o.output, "output", "o", "", "If provided, the resources that would be created in the API by the command are instead output to stdout in the provided format.  Valid values are ['yaml'].")
 	flags.StringVarP(&o.filename, "filename", "f", "", "If provided, the command will be configured from the provided yaml file.  Only --output wll be accepted from the command line")
 }
@@ -145,11 +145,11 @@ func (j *enableType) Complete(args []string) error {
 	if len(j.targetVersion) > 0 {
 		fd.Spec.TargetVersion = j.targetVersion
 	}
-	if len(j.primitiveGroup) > 0 {
-		fd.Spec.PrimitiveGroup = j.primitiveGroup
+	if len(j.federationGroup) > 0 {
+		fd.Spec.FederationGroup = j.federationGroup
 	}
-	if len(j.primitiveVersion) > 0 {
-		fd.Spec.PrimitiveVersion = j.primitiveVersion
+	if len(j.federationVersion) > 0 {
+		fd.Spec.FederationVersion = j.federationVersion
 	}
 
 	return nil
@@ -268,8 +268,8 @@ func typeConfigForTarget(apiResource metav1.APIResource, enableTypeDirective *En
 			Namespaced:         apiResource.Namespaced,
 			PropagationEnabled: true,
 			FederatedType: fedv1a1.APIResource{
-				Group:      spec.PrimitiveGroup,
-				Version:    spec.PrimitiveVersion,
+				Group:      spec.FederationGroup,
+				Version:    spec.FederationVersion,
 				Kind:       fmt.Sprintf("Federated%s", kind),
 				PluralName: fmt.Sprintf("federated%s", pluralName),
 			},

--- a/test/e2e/crd.go
+++ b/test/e2e/crd.go
@@ -134,10 +134,10 @@ func validateCrdCrud(f framework.FederationFramework, targetCrdKind string, name
 			Name: targetAPIResource.Name,
 		},
 		Spec: federate.EnableTypeDirectiveSpec{
-			TargetVersion:    targetAPIResource.Version,
-			PrimitiveGroup:   targetAPIResource.Group,
-			PrimitiveVersion: targetAPIResource.Version,
-			ComparisonField:  apicommon.ResourceVersionField,
+			TargetVersion:     targetAPIResource.Version,
+			FederationGroup:   targetAPIResource.Group,
+			FederationVersion: targetAPIResource.Version,
+			ComparisonField:   apicommon.ResourceVersionField,
 		},
 	}
 


### PR DESCRIPTION
This change is in response to the unification of federation primitives into federated types.  The term 'primitives' is no longer relevant, and continuing to include it in documentation or code is likely to cause confusion.  As part of this change, the api group that federated types are generated into has been changed from `primitives.federation.k8s.io` to `types.federation.k8s.io`.  I'm not fixed on the name, but there does need to be differentiation from the `core` group, as everything in the core group is essential to propagation but the contents of the generated group are likely to depend on the propagation requirements of a federation deployment.