### PR TITLE
Fix service account sync

### DIFF
--- a/charts/federation-v2/templates/serviceaccounts.yaml
+++ b/charts/federation-v2/templates/serviceaccounts.yaml
@@ -4,7 +4,7 @@ kind: FederatedTypeConfig
 metadata:
   name: serviceaccounts
 spec:
-  comparisonField: Generation
+  comparisonField: ResourceVersion
   federatedType:
     group: primitives.federation.k8s.io
     kind: FederatedServiceAccount

--- a/config/enabletypedirectives/serviceaccounts.yaml
+++ b/config/enabletypedirectives/serviceaccounts.yaml
@@ -2,5 +2,3 @@ apiVersion: core.federation.k8s.io/v1alpha1
 kind: EnableTypeDirective
 metadata:
   name: serviceaccounts
-spec:
-  comparisonField: Generation

--- a/pkg/controller/util/constants.go
+++ b/pkg/controller/util/constants.go
@@ -29,11 +29,16 @@ const (
 
 	ServiceKind = "Service"
 
+	ServiceAccountKind = "ServiceAccount"
+
 	// The following fields are used to interact with unstructured
 	// resources.
 
 	// Common fields
 	SpecField = "spec"
+
+	// ServiceAccount fields
+	SecretsField = "secrets"
 
 	// Template fields
 	TemplateField = "template"


### PR DESCRIPTION
Previously service account propagation had been configured to use the generation field for versioning, which was masking the need to retain the secrets field when it was populated by the in-cluster service
account controller.  Switching to the resource version field for versioning resulted in thrashing between the sync and service account controllers.  The sync controller would continually clear the 'secrets' field, and the service account controller would continually generate a new token secret and set it in the 'secrets' field.  This change ensures that the sync controller retains the 'secrets' field of service accounts to avoid this problem.