### PR TITLE
 Avoid using generated client for federation types and use generic client instead

### DIFF
--- a/cmd/controller-manager/app/controller-manager.go
+++ b/cmd/controller-manager/app/controller-manager.go
@@ -104,10 +104,14 @@ func Run(opts *options.Options) error {
 		glog.Info("Federation will target all namespaces")
 	}
 
-	federatedcluster.StartClusterController(opts.Config, stopChan, opts.ClusterMonitorPeriod)
+	if err := federatedcluster.StartClusterController(opts.Config, stopChan, opts.ClusterMonitorPeriod); err != nil {
+		glog.Fatalf("Error starting cluster controller: %v", err)
+	}
 
 	if utilfeature.DefaultFeatureGate.Enabled(features.SchedulerPreferences) {
-		schedulingmanager.StartSchedulerController(opts.Config, stopChan)
+		if err := schedulingmanager.StartSchedulerController(opts.Config, stopChan); err != nil {
+			glog.Fatalf("Error starting scheduler controller: %v", err)
+		}
 	}
 
 	if utilfeature.DefaultFeatureGate.Enabled(features.CrossClusterServiceDiscovery) {

--- a/pkg/apis/register.go
+++ b/pkg/apis/register.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apis
+
+import (
+	corev1alpha1 "github.com/kubernetes-sigs/federation-v2/pkg/apis/core/v1alpha1"
+	multiclusterdnsv1alpha1 "github.com/kubernetes-sigs/federation-v2/pkg/apis/multiclusterdns/v1alpha1"
+	schedulingv1alpha1 "github.com/kubernetes-sigs/federation-v2/pkg/apis/scheduling/v1alpha1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	runtime "k8s.io/apimachinery/pkg/runtime"
+	schema "k8s.io/apimachinery/pkg/runtime/schema"
+	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
+)
+
+var Scheme = runtime.NewScheme()
+var Codecs = serializer.NewCodecFactory(Scheme)
+var ParameterCodec = runtime.NewParameterCodec(Scheme)
+
+func init() {
+	v1.AddToGroupVersion(Scheme, schema.GroupVersion{Version: "v1"})
+	AddToScheme(Scheme)
+}
+
+// AddToScheme adds all types of this clientset into the given scheme. This allows composition
+// of clientsets, like in:
+//
+//   import (
+//     "k8s.io/client-go/kubernetes"
+//     clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+//     aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
+//   )
+//
+//   kclientset, _ := kubernetes.NewForConfig(c)
+//   aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//
+// After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
+// correctly.
+func AddToScheme(scheme *runtime.Scheme) {
+	corev1alpha1.AddToScheme(scheme)
+	multiclusterdnsv1alpha1.AddToScheme(scheme)
+	schedulingv1alpha1.AddToScheme(scheme)
+}

--- a/pkg/client/generic/genericclient.go
+++ b/pkg/client/generic/genericclient.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package generic
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/kubernetes-sigs/federation-v2/pkg/apis"
+)
+
+type Client interface {
+	Create(ctx context.Context, obj runtime.Object) error
+	Get(ctx context.Context, obj runtime.Object, namespace, name string) error
+	Update(ctx context.Context, obj runtime.Object) error
+	Delete(ctx context.Context, obj runtime.Object, namespace, name string) error
+	List(ctx context.Context, obj runtime.Object, namespace string) error
+	UpdateStatus(ctx context.Context, obj runtime.Object) error
+}
+
+type genericClient struct {
+	client client.Client
+}
+
+func New(config *rest.Config) (Client, error) {
+	client, err := client.New(config, client.Options{Scheme: apis.Scheme})
+	return &genericClient{client}, err
+}
+
+func NewForConfigOrDie(config *rest.Config) Client {
+	client, err := New(config)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
+func (c *genericClient) Create(ctx context.Context, obj runtime.Object) error {
+	return c.client.Create(ctx, obj)
+}
+
+func (c *genericClient) Get(ctx context.Context, obj runtime.Object, namespace, name string) error {
+	return c.client.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, obj)
+}
+
+func (c *genericClient) Update(ctx context.Context, obj runtime.Object) error {
+	return c.client.Update(ctx, obj)
+}
+
+func (c *genericClient) Delete(ctx context.Context, obj runtime.Object, namespace, name string) error {
+	accessor, err := meta.Accessor(obj)
+	if err != nil {
+		return err
+	}
+	accessor.SetNamespace(namespace)
+	accessor.SetName(name)
+	return c.client.Delete(ctx, obj)
+}
+
+func (c *genericClient) List(ctx context.Context, obj runtime.Object, namespace string) error {
+	return c.client.List(ctx, &client.ListOptions{Namespace: namespace}, obj)
+}
+
+func (c *genericClient) UpdateStatus(ctx context.Context, obj runtime.Object) error {
+	return c.client.Status().Update(ctx, obj)
+}

--- a/pkg/controller/dnsendpoint/ingress.go
+++ b/pkg/controller/dnsendpoint/ingress.go
@@ -19,29 +19,16 @@ package dnsendpoint
 import (
 	"github.com/pkg/errors"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	pkgruntime "k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/watch"
 	restclient "k8s.io/client-go/rest"
 
 	feddnsv1a1 "github.com/kubernetes-sigs/federation-v2/pkg/apis/multiclusterdns/v1alpha1"
-	fedclientset "github.com/kubernetes-sigs/federation-v2/pkg/client/clientset/versioned"
 	"github.com/kubernetes-sigs/federation-v2/pkg/controller/util"
 )
 
 func StartIngressDNSEndpointController(config *util.ControllerConfig, stopChan <-chan struct{}) error {
 	restclient.AddUserAgent(config.KubeConfig, "Ingress DNSEndpoint")
-	client := fedclientset.NewForConfigOrDie(config.KubeConfig)
-
-	listFunc := func(options metav1.ListOptions) (pkgruntime.Object, error) {
-		return client.MulticlusterdnsV1alpha1().IngressDNSRecords(config.TargetNamespace).List(options)
-	}
-	watchFunc := func(options metav1.ListOptions) (watch.Interface, error) {
-		return client.MulticlusterdnsV1alpha1().IngressDNSRecords(config.TargetNamespace).Watch(options)
-	}
-
-	controller, err := newDNSEndpointController(client, &feddnsv1a1.IngressDNSRecord{}, "ingress",
-		listFunc, watchFunc, getIngressDNSEndpoints, config.MinimizeLatency)
+	controller, err := newDNSEndpointController(config, &feddnsv1a1.IngressDNSRecord{}, "ingress",
+		getIngressDNSEndpoints, config.MinimizeLatency)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/dnsendpoint/service.go
+++ b/pkg/controller/dnsendpoint/service.go
@@ -21,29 +21,16 @@ import (
 
 	"github.com/pkg/errors"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	pkgruntime "k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/watch"
 	restclient "k8s.io/client-go/rest"
 
 	feddnsv1a1 "github.com/kubernetes-sigs/federation-v2/pkg/apis/multiclusterdns/v1alpha1"
-	fedclientset "github.com/kubernetes-sigs/federation-v2/pkg/client/clientset/versioned"
 	"github.com/kubernetes-sigs/federation-v2/pkg/controller/util"
 )
 
 func StartServiceDNSEndpointController(config *util.ControllerConfig, stopChan <-chan struct{}) error {
 	restclient.AddUserAgent(config.KubeConfig, "Service DNSEndpoint")
-	client := fedclientset.NewForConfigOrDie(config.KubeConfig)
-
-	listFunc := func(options metav1.ListOptions) (pkgruntime.Object, error) {
-		return client.MulticlusterdnsV1alpha1().ServiceDNSRecords(config.TargetNamespace).List(options)
-	}
-	watchFunc := func(options metav1.ListOptions) (watch.Interface, error) {
-		return client.MulticlusterdnsV1alpha1().ServiceDNSRecords(config.TargetNamespace).Watch(options)
-	}
-
-	controller, err := newDNSEndpointController(client, &feddnsv1a1.ServiceDNSRecord{}, "service",
-		listFunc, watchFunc, getServiceDNSEndpoints, config.MinimizeLatency)
+	controller, err := newDNSEndpointController(config, &feddnsv1a1.ServiceDNSRecord{}, "service",
+		getServiceDNSEndpoints, config.MinimizeLatency)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/sync/accessor.go
+++ b/pkg/controller/sync/accessor.go
@@ -25,7 +25,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	"github.com/kubernetes-sigs/federation-v2/pkg/apis/core/typeconfig"
-	fedclientset "github.com/kubernetes-sigs/federation-v2/pkg/client/clientset/versioned"
+	genericclient "github.com/kubernetes-sigs/federation-v2/pkg/client/generic"
 	"github.com/kubernetes-sigs/federation-v2/pkg/controller/sync/version"
 	"github.com/kubernetes-sigs/federation-v2/pkg/controller/util"
 	"github.com/kubernetes-sigs/federation-v2/pkg/controller/util/deletionhelper"
@@ -75,7 +75,7 @@ func NewFederatedResourceAccessor(
 	controllerConfig *util.ControllerConfig,
 	typeConfig typeconfig.Interface,
 	fedNamespaceAPIResource *metav1.APIResource,
-	fedClient fedclientset.Interface,
+	client genericclient.Client,
 	enqueueObj func(pkgruntime.Object),
 	informer util.FederatedInformer,
 	updater util.FederatedUpdater) (FederatedResourceAccessor, error) {
@@ -137,7 +137,7 @@ func NewFederatedResourceAccessor(
 	}
 
 	a.versionManager = version.NewVersionManager(
-		fedClient,
+		client,
 		typeConfig.GetFederatedNamespaced(),
 		typeConfig.GetFederatedType().Kind,
 		typeConfig.GetTarget().Kind,

--- a/pkg/controller/sync/version/adapter.go
+++ b/pkg/controller/sync/version/adapter.go
@@ -21,7 +21,7 @@ import (
 	pkgruntime "k8s.io/apimachinery/pkg/runtime"
 
 	fedv1a1 "github.com/kubernetes-sigs/federation-v2/pkg/apis/core/v1alpha1"
-	fedclientset "github.com/kubernetes-sigs/federation-v2/pkg/client/clientset/versioned"
+	"github.com/kubernetes-sigs/federation-v2/pkg/client/generic"
 	"github.com/kubernetes-sigs/federation-v2/pkg/controller/util"
 )
 
@@ -42,7 +42,7 @@ type VersionAdapter interface {
 	UpdateStatus(obj pkgruntime.Object) (pkgruntime.Object, error)
 }
 
-func NewVersionAdapter(client fedclientset.Interface, namespaced bool) VersionAdapter {
+func NewVersionAdapter(client generic.Client, namespaced bool) VersionAdapter {
 	if namespaced {
 		return newNamespacedVersionAdapter(client)
 	}

--- a/pkg/controller/sync/version/manager.go
+++ b/pkg/controller/sync/version/manager.go
@@ -35,7 +35,7 @@ import (
 
 	"github.com/kubernetes-sigs/federation-v2/pkg/apis/core/common"
 	fedv1a1 "github.com/kubernetes-sigs/federation-v2/pkg/apis/core/v1alpha1"
-	fedclientset "github.com/kubernetes-sigs/federation-v2/pkg/client/clientset/versioned"
+	"github.com/kubernetes-sigs/federation-v2/pkg/client/generic"
 	"github.com/kubernetes-sigs/federation-v2/pkg/controller/util"
 )
 
@@ -67,7 +67,7 @@ type VersionManager struct {
 	versions map[string]pkgruntime.Object
 }
 
-func NewVersionManager(client fedclientset.Interface, namespaced bool, federatedKind, targetKind, namespace string) *VersionManager {
+func NewVersionManager(client generic.Client, namespaced bool, federatedKind, targetKind, namespace string) *VersionManager {
 	v := &VersionManager{
 		targetKind:    targetKind,
 		federatedKind: federatedKind,

--- a/pkg/controller/sync/version/namespaced.go
+++ b/pkg/controller/sync/version/namespaced.go
@@ -17,21 +17,22 @@ limitations under the License.
 package version
 
 import (
+	"context"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	pkgruntime "k8s.io/apimachinery/pkg/runtime"
 
 	fedv1a1 "github.com/kubernetes-sigs/federation-v2/pkg/apis/core/v1alpha1"
-	fedclientset "github.com/kubernetes-sigs/federation-v2/pkg/client/clientset/versioned"
-	corev1alpha1 "github.com/kubernetes-sigs/federation-v2/pkg/client/clientset/versioned/typed/core/v1alpha1"
+	genericclient "github.com/kubernetes-sigs/federation-v2/pkg/client/generic"
 	"github.com/kubernetes-sigs/federation-v2/pkg/controller/util"
 )
 
 type namespacedVersionAdapter struct {
-	client corev1alpha1.CoreV1alpha1Interface
+	client genericclient.Client
 }
 
-func newNamespacedVersionAdapter(client fedclientset.Interface) VersionAdapter {
-	return &namespacedVersionAdapter{client.CoreV1alpha1()}
+func newNamespacedVersionAdapter(client genericclient.Client) VersionAdapter {
+	return &namespacedVersionAdapter{client}
 }
 
 func (a *namespacedVersionAdapter) TypeName() string {
@@ -39,7 +40,9 @@ func (a *namespacedVersionAdapter) TypeName() string {
 }
 
 func (a *namespacedVersionAdapter) List(namespace string) (pkgruntime.Object, error) {
-	return a.client.PropagatedVersions(namespace).List(metav1.ListOptions{})
+	propagatedVersionList := &fedv1a1.PropagatedVersionList{}
+	err := a.client.List(context.TODO(), propagatedVersionList, namespace)
+	return propagatedVersionList, err
 }
 
 func (a *namespacedVersionAdapter) NewVersion(qualifiedName util.QualifiedName, ownerReference metav1.OwnerReference, status *fedv1a1.PropagatedVersionStatus) pkgruntime.Object {
@@ -66,14 +69,18 @@ func (a *namespacedVersionAdapter) SetStatus(obj pkgruntime.Object, status *fedv
 
 func (a *namespacedVersionAdapter) Create(obj pkgruntime.Object) (pkgruntime.Object, error) {
 	version := obj.(*fedv1a1.PropagatedVersion)
-	return a.client.PropagatedVersions(version.Namespace).Create(version)
+	err := a.client.Create(context.TODO(), version)
+	return version, err
 }
 
 func (a *namespacedVersionAdapter) Get(qualifiedName util.QualifiedName) (pkgruntime.Object, error) {
-	return a.client.PropagatedVersions(qualifiedName.Namespace).Get(qualifiedName.Name, metav1.GetOptions{})
+	propogatedVersion := &fedv1a1.PropagatedVersion{}
+	err := a.client.Get(context.TODO(), propogatedVersion, qualifiedName.Namespace, qualifiedName.Name)
+	return propogatedVersion, err
 }
 
 func (a *namespacedVersionAdapter) UpdateStatus(obj pkgruntime.Object) (pkgruntime.Object, error) {
 	version := obj.(*fedv1a1.PropagatedVersion)
-	return a.client.PropagatedVersions(version.Namespace).UpdateStatus(version)
+	err := a.client.UpdateStatus(context.TODO(), version)
+	return version, err
 }

--- a/pkg/controller/util/controllerconfig.go
+++ b/pkg/controller/util/controllerconfig.go
@@ -24,7 +24,7 @@ import (
 	restclient "k8s.io/client-go/rest"
 	crclientset "k8s.io/cluster-registry/pkg/client/clientset/versioned"
 
-	fedclientset "github.com/kubernetes-sigs/federation-v2/pkg/client/clientset/versioned"
+	genericclient "github.com/kubernetes-sigs/federation-v2/pkg/client/generic"
 )
 
 // FederationNamespaces defines the namespace configuration shared by
@@ -45,12 +45,12 @@ type ControllerConfig struct {
 	MinimizeLatency         bool
 }
 
-func (c *ControllerConfig) AllClients(userAgent string) (fedclientset.Interface, kubeclientset.Interface, crclientset.Interface) {
+func (c *ControllerConfig) AllClients(userAgent string) (genericclient.Client, kubeclientset.Interface, crclientset.Interface) {
 	restclient.AddUserAgent(c.KubeConfig, userAgent)
-	fedClient := fedclientset.NewForConfigOrDie(c.KubeConfig)
+	client := genericclient.NewForConfigOrDie(c.KubeConfig)
 	kubeClient := kubeclientset.NewForConfigOrDie(c.KubeConfig)
 	crClient := crclientset.NewForConfigOrDie(c.KubeConfig)
-	return fedClient, kubeClient, crClient
+	return client, kubeClient, crClient
 }
 
 func (c *ControllerConfig) LimitedScope() bool {

--- a/pkg/kubefed2/util/util.go
+++ b/pkg/kubefed2/util/util.go
@@ -19,8 +19,7 @@ package util
 import (
 	"fmt"
 
-	fedclient "github.com/kubernetes-sigs/federation-v2/pkg/client/clientset/versioned"
-	client "k8s.io/client-go/kubernetes"
+	kubeclient "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	crclient "k8s.io/cluster-registry/pkg/client/clientset/versioned"
@@ -85,26 +84,20 @@ func (a *fedConfig) getClientConfig(context, kubeconfigPath string) clientcmd.Cl
 
 // HostClientset provides a kubernetes API compliant clientset to
 // communicate with the host cluster's kubernetes API server.
-func HostClientset(config *rest.Config) (*client.Clientset, error) {
-	return client.NewForConfig(config)
+func HostClientset(config *rest.Config) (*kubeclient.Clientset, error) {
+	return kubeclient.NewForConfig(config)
 }
 
 // ClusterClientset provides a kubernetes API compliant clientset to
 // communicate with the joining cluster's kubernetes API server.
-func ClusterClientset(config *rest.Config) (*client.Clientset, error) {
-	return client.NewForConfig(config)
+func ClusterClientset(config *rest.Config) (*kubeclient.Clientset, error) {
+	return kubeclient.NewForConfig(config)
 }
 
 // ClusterRegistryClientset provides a cluster registry API compliant
 // clientset to communicate with the cluster registry.
 func ClusterRegistryClientset(config *rest.Config) (*crclient.Clientset, error) {
 	return crclient.NewForConfig(config)
-}
-
-// FedClientset provides a federation API compliant clientset
-// to communicate with the federation API server.
-func FedClientset(config *rest.Config) (*fedclient.Clientset, error) {
-	return fedclient.NewForConfig(config)
 }
 
 // ClusterServiceAccountName returns the name of a service account whose

--- a/pkg/schedulingtypes/interface.go
+++ b/pkg/schedulingtypes/interface.go
@@ -19,16 +19,12 @@ package schedulingtypes
 import (
 	"github.com/kubernetes-sigs/federation-v2/pkg/apis/core/typeconfig"
 	. "github.com/kubernetes-sigs/federation-v2/pkg/controller/util"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	pkgruntime "k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/watch"
 )
 
 type Scheduler interface {
 	Kind() string
 	ObjectType() pkgruntime.Object
-	FedList(namespace string, options metav1.ListOptions) (pkgruntime.Object, error)
-	FedWatch(namespace string, options metav1.ListOptions) (watch.Interface, error)
 
 	Start()
 	HasSynced() bool

--- a/test/common/crudtester.go
+++ b/test/common/crudtester.go
@@ -26,7 +26,7 @@ import (
 	"github.com/kubernetes-sigs/federation-v2/pkg/apis/core/common"
 	"github.com/kubernetes-sigs/federation-v2/pkg/apis/core/typeconfig"
 	fedv1a1 "github.com/kubernetes-sigs/federation-v2/pkg/apis/core/v1alpha1"
-	clientset "github.com/kubernetes-sigs/federation-v2/pkg/client/clientset/versioned"
+	genericclient "github.com/kubernetes-sigs/federation-v2/pkg/client/generic"
 	"github.com/kubernetes-sigs/federation-v2/pkg/controller/sync"
 	versionmanager "github.com/kubernetes-sigs/federation-v2/pkg/controller/sync/version"
 	"github.com/kubernetes-sigs/federation-v2/pkg/controller/util"
@@ -46,7 +46,7 @@ type FederatedTypeCrudTester struct {
 	tl                TestLogger
 	typeConfig        typeconfig.Interface
 	targetIsNamespace bool
-	fedClient         clientset.Interface
+	client            genericclient.Client
 	kubeConfig        *rest.Config
 	testClusters      map[string]TestCluster
 	waitInterval      time.Duration
@@ -71,7 +71,7 @@ func NewFederatedTypeCrudTester(testLogger TestLogger, typeConfig typeconfig.Int
 		tl:                 testLogger,
 		typeConfig:         typeConfig,
 		targetIsNamespace:  typeConfig.GetTarget().Kind == util.NamespaceKind,
-		fedClient:          clientset.NewForConfigOrDie(kubeConfig),
+		client:             genericclient.NewForConfigOrDie(kubeConfig),
 		kubeConfig:         kubeConfig,
 		testClusters:       testClusters,
 		waitInterval:       waitInterval,
@@ -487,7 +487,7 @@ func (c *FederatedTypeCrudTester) expectedVersion(qualifiedName util.QualifiedNa
 	}
 
 	loggedWaiting := false
-	adapter := versionmanager.NewVersionAdapter(c.fedClient, c.typeConfig.GetFederatedNamespaced())
+	adapter := versionmanager.NewVersionAdapter(c.client, c.typeConfig.GetFederatedNamespaced())
 	var version *fedv1a1.PropagatedVersionStatus
 	err := wait.PollImmediate(c.waitInterval, wait.ForeverTestTimeout, func() (bool, error) {
 		versionObj, err := adapter.Get(versionName)

--- a/test/common/dns.go
+++ b/test/common/dns.go
@@ -35,7 +35,7 @@ import (
 func NewDomainObject(federation, domain string) *dnsv1a1.Domain {
 	return &dnsv1a1.Domain{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: federation,
+			GenerateName: federation,
 		},
 		Domain: domain,
 	}

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/kubernetes-sigs/federation-v2/pkg/apis/core/typeconfig"
 	fedv1a1 "github.com/kubernetes-sigs/federation-v2/pkg/apis/core/v1alpha1"
-	fedclientset "github.com/kubernetes-sigs/federation-v2/pkg/client/clientset/versioned"
+	genericclient "github.com/kubernetes-sigs/federation-v2/pkg/client/generic"
 	"github.com/kubernetes-sigs/federation-v2/pkg/controller/util"
 	"github.com/kubernetes-sigs/federation-v2/test/common"
 	"github.com/kubernetes-sigs/federation-v2/test/e2e/framework/managed"
@@ -35,7 +35,6 @@ import (
 	kubeclientset "k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
 	crclientset "k8s.io/cluster-registry/pkg/client/clientset/versioned"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -52,7 +51,7 @@ type FederationFrameworkImpl interface {
 	KubeConfig() *restclient.Config
 
 	KubeClient(userAgent string) kubeclientset.Interface
-	FedClient(userAgent string) fedclientset.Interface
+	Client(userAgent string) genericclient.Client
 	CrClient(userAgent string) crclientset.Interface
 
 	ClusterConfigs(userAgent string) map[string]common.TestClusterConfig
@@ -165,8 +164,8 @@ func (f *frameworkWrapper) KubeClient(userAgent string) kubeclientset.Interface 
 	return f.framework().KubeClient(userAgent)
 }
 
-func (f *frameworkWrapper) FedClient(userAgent string) fedclientset.Interface {
-	return f.framework().FedClient(userAgent)
+func (f *frameworkWrapper) Client(userAgent string) genericclient.Client {
+	return f.framework().Client(userAgent)
 }
 
 func (f *frameworkWrapper) CrClient(userAgent string) crclientset.Interface {
@@ -235,7 +234,7 @@ func (f *frameworkWrapper) EnsureTestNamespacePropagation() {
 func (f *frameworkWrapper) EnsureTestFederatedNamespace(allClusters bool) *unstructured.Unstructured {
 	tl := f.Logger()
 
-	dynclient, err := client.New(f.KubeConfig(), client.Options{})
+	client, err := genericclient.New(f.KubeConfig())
 	if err != nil {
 		tl.Fatalf("Error initializing dynamic client: %v", err)
 	}
@@ -251,8 +250,7 @@ func (f *frameworkWrapper) EnsureTestFederatedNamespace(allClusters bool) *unstr
 	namespace := f.TestNamespaceName()
 
 	// Return an existing federated namespace if it already exists.
-	key := client.ObjectKey{Namespace: namespace, Name: namespace}
-	err = dynclient.Get(context.Background(), key, obj)
+	err = client.Get(context.Background(), obj, namespace, namespace)
 	if err == nil {
 		return obj
 	}
@@ -272,11 +270,11 @@ func (f *frameworkWrapper) EnsureTestFederatedNamespace(allClusters bool) *unstr
 		}
 	}
 
-	err = dynclient.Create(context.Background(), obj)
+	err = client.Create(context.Background(), obj)
 	if err != nil {
-		tl.Fatalf("Error creating %s %q: %v", apiResource.Kind, key, err)
+		tl.Fatalf("Error creating %s for namespace %q: %v", apiResource.Kind, namespace, err)
 	}
-	tl.Logf("Created new %s %q", apiResource.Kind, key)
+	tl.Logf("Created new %s %q", apiResource.Kind, namespace)
 
 	return obj
 }
@@ -284,18 +282,14 @@ func (f *frameworkWrapper) EnsureTestFederatedNamespace(allClusters bool) *unstr
 func (f *frameworkWrapper) namespaceTypeConfigOrDie() typeconfig.Interface {
 	if f.namespaceTypeConfig == nil {
 		tl := f.Logger()
-		dynClient, err := client.New(f.KubeConfig(), client.Options{})
+		client, err := genericclient.New(f.KubeConfig())
 		if err != nil {
 			tl.Fatalf("Error initializing dynamic client: %v", err)
 		}
-		key := client.ObjectKey{
-			Namespace: f.FederationSystemNamespace(),
-			Name:      util.NamespaceName,
-		}
 		typeConfig := &fedv1a1.FederatedTypeConfig{}
-		err = dynClient.Get(context.Background(), key, typeConfig)
+		err = client.Get(context.Background(), typeConfig, f.FederationSystemNamespace(), util.NamespaceName)
 		if err != nil {
-			tl.Fatalf("Error retrieving federatedtypeconfig for %q: %v", key.Name, err)
+			tl.Fatalf("Error retrieving federatedtypeconfig for %q: %v", util.NamespaceName, err)
 		}
 		f.namespaceTypeConfig = typeConfig
 	}

--- a/test/e2e/framework/managed.go
+++ b/test/e2e/framework/managed.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 
 	"github.com/kubernetes-sigs/federation-v2/pkg/apis/core/typeconfig"
-	fedclientset "github.com/kubernetes-sigs/federation-v2/pkg/client/clientset/versioned"
+	genericclient "github.com/kubernetes-sigs/federation-v2/pkg/client/generic"
 	"github.com/kubernetes-sigs/federation-v2/pkg/controller/util"
 	"github.com/kubernetes-sigs/federation-v2/test/common"
 	"github.com/kubernetes-sigs/federation-v2/test/e2e/framework/managed"
@@ -99,10 +99,10 @@ func (f *ManagedFramework) KubeConfig() *restclient.Config {
 	return fedFixture.KubeApi.NewConfig(f.logger)
 }
 
-func (f *ManagedFramework) FedClient(userAgent string) fedclientset.Interface {
+func (f *ManagedFramework) Client(userAgent string) genericclient.Client {
 	config := fedFixture.KubeApi.NewConfig(f.logger)
 	restclient.AddUserAgent(config, userAgent)
-	return fedclientset.NewForConfigOrDie(config)
+	return genericclient.NewForConfigOrDie(config)
 }
 
 func (f *ManagedFramework) KubeClient(userAgent string) kubeclientset.Interface {

--- a/test/e2e/servicedns.go
+++ b/test/e2e/servicedns.go
@@ -43,11 +43,12 @@ var _ = Describe("ServiceDNS", func() {
 
 	const userAgent = "test-service-dns"
 	const baseName = "test-service-dns-"
-	const federation = "galactic"
+	const federationPrefix = "galactic"
 	const Domain = "example.com"
 
 	var fedClient fedclientset.Interface
 	var clusterRegionZones map[string]fedv1a1.FederatedClusterStatus
+	var federation string
 	var namespace string
 	var domainClient dnsv1a1client.DomainInterface
 	var dnsClient dnsv1a1client.ServiceDNSRecordInterface
@@ -77,9 +78,11 @@ var _ = Describe("ServiceDNS", func() {
 			f.RegisterFixture(fixture)
 		}
 		f.EnsureTestNamespacePropagation()
-		domainObj := common.NewDomainObject(federation, Domain)
+		domainObj := common.NewDomainObject(federationPrefix, Domain)
+		domainObj.Namespace = f.FederationSystemNamespace()
 		_, err = domainClient.Create(domainObj)
 		framework.ExpectNoError(err, "Error creating Domain object")
+		federation = domainObj.Name
 	})
 
 	AfterEach(func() {


### PR DESCRIPTION
This pr builds on top of https://github.com/kubernetes-sigs/federation-v2/pull/602 and removes the usage of generated typed client for federation types. The usage is replaced by generic client from `sigs.k8s.io/controller-runtime` which will eventually aid us in upgrading to newer `kubebuilder` and also facilitate implementing leader election for federation controller.

/cc @marun