### PR TITLE
WIP example of RBAC resource propagation to member clusters for different…

### DIFF
--- a/docs/propagation-rbac-for-member-clusters.md
+++ b/docs/propagation-rbac-for-member-clusters.md
@@ -1,0 +1,192 @@
+This guide shows a way to make a user propagate federated resources to a set of member clusters in kubernetes federation.
+
+`FederatedNamespace` controls which cluster a federated namespace can be propogated to. It also determines which clusters a federated resource of the namespace can be propagated to. `RBAC` can be created to make a user only operate resources in the specified namespace. Here is an example to leverage both `FederatedNamespace` and `RBAC` to limit user propagation rights to a set of member clusters.
+
+This example shows that `user1` only progagates federated resources to `cluster1` and `user2` can propagate federated resources to both `cluster2` and `cluster3`.
+
+# Prerequisite
+Federation control plane should be deployed with 3 member clusters: `cluster1`, `cluster2` and `cluster3`. Refer to [User Guide](https://github.com/kubernetes-sigs/federation-v2/blob/master/docs/userguide.md) for details in federation deployment.
+
+# Creating FederatedNamespace
+Administrator creates `FederatedNamespace` resources and specifies proper placement for different federated namespaces.
+`namespace1` is propagated to member `cluster1`. `namespace2` is propagated to member `cluster2` and `cluster3`.
+```bash
+$ cat <<EOF | kubectl create -f -
+---
+apiVersion: v1                                  
+kind: Namespace
+metadata:
+  name: namespace1
+---
+apiVersion: types.federation.k8s.io/v1alpha1                
+kind: FederatedNamespace
+metadata:
+  name: namespace1
+  namespace: namespace1
+spec:
+  placement:
+    clusterNames:
+    - cluster1
+---
+apiVersion: v1                                  
+kind: Namespace
+metadata:
+  name: namespace2
+---
+apiVersion: types.federation.k8s.io/v1alpha1                
+kind: FederatedNamespace
+metadata:
+  name: namespace2
+  namespace: namespace2
+spec:
+  placement:
+    clusterNames:
+    - cluster2
+    - cluster3
+EOF
+```
+
+# Configuring RBAC
+Administrator configures RBAC to limit a user to access the specified namespace. `user1` can operate federated resources in `namespace1` and `user2` can operate federated resources in `namespace2`.
+```bash
+$ cat <<EOF | kubectl create -f -
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: user1
+  namespace: namespace1
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: namespaced-access
+  namespace: namespace1
+rules:
+- apiGroups: ["types.federation.k8s.io"]
+  resources: ["*"]
+  verbs: ["*"]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: user1
+  namespace: namespace1
+subjects:
+- kind: ServiceAccount
+  name: user1
+  namespace: namespace1
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: namespaced-access
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: user2
+  namespace: namespace2
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: namespaced-access
+  namespace: namespace2
+rules:
+- apiGroups: ["types.federation.k8s.io"]
+  resources: ["*"]
+  verbs: ["*"]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: user2
+  namespace: namespace2
+subjects:
+- kind: ServiceAccount
+  name: user2
+  namespace: namespace2
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: namespaced-access
+EOF
+```
+In this case, a user can only access the specified namespace. So, he can propagate his resources to the related member clusters with the namespace isolation.
+
+# Deploying Federated Resource
+End user can use the secret information to access the namespace. Create `Config` for `user2` as an example.
+```bash
+$ cat <<EOF > user2-config.yaml
+apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority: /usr/local/work/minikube/.minikube/ca.crt
+    server: https://192.168.99.100:8443
+  name: cluster1
+contexts:
+- context:
+    cluster: cluster1
+    namespace: namespace2
+    user: user2
+  name: user2
+current-context: user2
+kind: Config
+preferences: {}
+users:
+EOF
+$ kubectl get sa -n namespace2 user2 -o "jsonpath={.secrets[0].name}";echo
+user2-token-vh2sb
+$ kubectl config set-credentials user2 --token `kubectl get secret  -n namespace2 user2-token-vh2sb -o "jsonpath={.data.token}" | base64 -d` --kubeconfig user2-config.yaml
+```
+`user2` creates `FederatedDeployment` in the host cluster to propagate resource to member clusters. With help of federation controller, federated resources can only be propagated to specified member clusters for the user.
+```bash
+$ cat <<EOF | kubectl --kubeconfig user2-config.yaml create -f -
+---
+apiVersion: types.federation.k8s.io/v1alpha1
+kind: FederatedDeployment
+metadata:
+  name: test-deployment
+  namespace: namespace2
+spec:
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      replicas: 3
+      selector:
+        matchLabels:
+          app: nginx
+      template:
+        metadata:
+          labels:
+            app: nginx
+        spec:
+          containers:
+          - image: nginx
+            name: nginx
+
+  placement:
+    clusterNames:
+    - cluster1
+    - cluster2
+    - cluster3
+EOF
+$ kubectl get deployment -n namespace2 --context cluster1
+No resources found.
+$ kubectl get deployment -n namespace2 --context cluster2
+NAME              DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
+test-deployment   3         3         3            3           5m
+$ kubectl get deployment -n namespace2 --context cluster3
+NAME              DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
+test-deployment   3         3         3            3           5m
+
+$ kubectl get federateddeployment -n namespace2 --kubeconfig user2-config.yaml
+NAME              AGE
+test-deployment   1h
+$ kubectl get federateddeployment -n namespace1 --kubeconfig user2-config.yaml
+No resources found.
+Error from server (Forbidden): federateddeployments.types.federation.k8s.io is forbidden: User "system:serviceaccount:namespace2:user2" cannot list federateddeployments.types.federation.k8s.io in the namespace "namespace1"
+```
+`Deployment` cannot be propagated to `cluster1` even it is specified in placement of `FederatedDeployment`.

--- a/docs/userguide.md
+++ b/docs/userguide.md
@@ -16,17 +16,19 @@
   - [Enabling federation of an API type](#enabling-federation-of-an-api-type)
   - [Disabling federation of an API type](#disabling-federation-of-an-api-type)
   - [Example](#example)
-    - [Create the Test Namespace](#create-the-test-namespace)
-    - [Create Test Resources](#create-test-resources)
-    - [Check Status of Resources](#check-status-of-resources)
-    - [Update FederatedNamespace Placement](#update-federatednamespace)
-      - [Using Cluster Selector](#using-cluster-selector)
-        - [Neither `spec.placement.clusterNames` nor `spec.placement.clusterSelector` is provided](#neither-specplacementclusternames-nor-specplacementclusterselector-is-provided)
-        - [Both `spec.placement.clusterNames` and `spec.placement.clusterSelector` are provided](#both-specplacementclusternames-and-specplacementclusterselector-are-provided)
-        - [`spec.placement.clusterNames` is not provided, `spec.placement.clusterSelector` is provided but empty](#specplacementclusternames-is-not-provided-specplacementclusterselector-is-provided-but-empty)
-        - [`spec.placementclusterNames` is not provided, `spec.placement.clusterSelector` is provided and not empty](#specplacementclusternames-is-not-provided-specplacementclusterselector-is-provided-and-not-empty)
-    - [Example Cleanup](#example-cleanup)
-    - [Troubleshooting](#troubleshooting)
+    - [Basic Resource Propogation](#basic-resource-propogation)
+      - [Create the Test Namespace](#create-the-test-namespace)
+      - [Create Test Resources](#create-test-resources)
+      - [Check Status of Resources](#check-status-of-resources)
+      - [Update FederatedNamespace Placement](#update-federatednamespace-placement)
+        - [Using Cluster Selector](#using-cluster-selector)
+          - [Neither `spec.placement.clusterNames` nor `spec.placement.clusterSelector` is provided](#neither-specplacementclusternames-nor-specplacementclusterselector-is-provided)
+          - [Both `spec.placement.clusterNames` and `spec.placement.clusterSelector` are provided](#both-specplacementclusternames-and-specplacementclusterselector-are-provided)
+          - [`spec.placement.clusterNames` is not provided, `spec.placement.clusterSelector` is provided but empty](#specplacementclusternames-is-not-provided-specplacementclusterselector-is-provided-but-empty)
+          - [`spec.placement.clusterNames` is not provided, `spec.placement.clusterSelector` is provided and not empty](#specplacementclusternames-is-not-provided-specplacementclusterselector-is-provided-and-not-empty)
+      - [Example Cleanup](#example-cleanup)
+      - [Troubleshooting](#troubleshooting)
+    - [Resource Propagation RBAC for Member Clusters](#resource-propagation-rbac-for-member-clusters)
   - [Cleanup](#cleanup)
     - [Deployment Cleanup](#deployment-cleanup)
   - [Namespaced Federation](#namespaced-federation)
@@ -226,6 +228,7 @@ kubefed2 disable <FederatedTypeConfig Name> --delete-from-api
 **WARNING: All custom resources for the type will be removed by this command.**
 
 ## Example
+### Basic Resource Propogation
 
 Follow these instructions for running an example to verify your deployment is
 working. The example will create a test namespace with a `federatednamespace`
@@ -233,7 +236,7 @@ resource as well as a federated resource for the following k8s resources:
 `configmap`, `secret`, `deployment`, `service` and `serviceaccount`. It will
 then show how to update the `federatednamespace` resource to move resources.
 
-### Create the Test Namespace
+#### Create the Test Namespace
 
 First create the `test-namespace` for the test resources:
 
@@ -242,7 +245,7 @@ kubectl apply -f example/sample1/namespace.yaml \
     -f example/sample1/federatednamespace.yaml
 ```
 
-### Create Test Resources
+#### Create Test Resources
 
 Create all the test resources by running:
 
@@ -259,7 +262,7 @@ unable to recognize "example/sample1/federated<type>.yaml": no matches for kind 
 
 then it indicates that a given type may need to be enabled with `kubefed2 enable <type>`
 
-### Check Status of Resources
+#### Check Status of Resources
 
 Check the status of all the resources in each cluster by running:
 
@@ -285,7 +288,7 @@ for c in cluster1 cluster2; do
 done
 ```
 
-### Update FederatedNamespace Placement
+#### Update FederatedNamespace Placement
 
 Remove `cluster2` via a patch command or manually:
 
@@ -346,7 +349,7 @@ done
 If you were able to verify the resources removed and added back then you have
 successfully verified a working federation-v2 deployment.
 
-#### Using Cluster Selector
+##### Using Cluster Selector
 
 In addition to specifying an explicit list of clusters that a resource should be propagated
 to via the `spec.placement.clusterNames` field of a federated resource, it is possible to
@@ -369,7 +372,7 @@ The following sections detail how `spec.placement.clusterNames` and
 `spec.placement.clusterSelector` are used in determining the clusters that a federated
 resource should be propagated to.
 
-##### Neither `spec.placement.clusterNames` nor `spec.placement.clusterSelector` is provided
+###### Neither `spec.placement.clusterNames` nor `spec.placement.clusterSelector` is provided
 
 ```yaml
 spec:
@@ -379,7 +382,7 @@ spec:
 In this case, you can either set `spec: {}` as above or remove `spec` field from your
 placement policy. The resource will not be propagated to member clusters.
 
-##### Both `spec.placement.clusterNames` and `spec.placement.clusterSelector` are provided
+###### Both `spec.placement.clusterNames` and `spec.placement.clusterSelector` are provided
 
 ```yaml
 spec:
@@ -396,7 +399,7 @@ For this case, `spec.placement.clusterSelector` will be ignored as
 `spec.placement.clusterNames` is provided. This ensures that the results of runtime
 scheduling have priority over manual definition of a cluster selector.
 
-##### `spec.placement.clusterNames` is not provided, `spec.placement.clusterSelector` is provided but empty
+###### `spec.placement.clusterNames` is not provided, `spec.placement.clusterSelector` is provided but empty
 
 ```yaml
 spec:
@@ -406,7 +409,7 @@ spec:
 
 In this case, the resource will be propagated to all member clusters.
 
-##### `spec.placement.clusterNames` is not provided, `spec.placement.clusterSelector` is provided and not empty
+###### `spec.placement.clusterNames` is not provided, `spec.placement.clusterSelector` is provided and not empty
 
 ```yaml
 spec:
@@ -419,7 +422,7 @@ spec:
 In this case, the resource will only be propagated to member clusters that are labeled
 with `foo: bar`.
 
-### Example Cleanup
+#### Example Cleanup
 
 To cleanup the example simply delete the namespace:
 
@@ -427,7 +430,7 @@ To cleanup the example simply delete the namespace:
 kubectl delete ns test-namespace
 ```
 
-### Troubleshooting
+#### Troubleshooting
 
 If federated resources are not propagated as expected to the member clusters, you can
 use the following command to view `Events` which may aid in diagnosing the problem.
@@ -447,6 +450,10 @@ It may also be useful to inspect the federation controller log as follows:
 ```bash
 kubectl logs -f federation-controller-manager-0 -n federation-system
 ```
+### Resource Propagation RBAC for Member Clusters
+Different users may have requirements to propagate resources to different set of member clusters.
+Review the [RBAC guide](./propagation-rbac-for-member-clusters.md) for RBAC configuration example
+to learn more.
 
 ## Cleanup
 


### PR DESCRIPTION
This example is try to help on #526. A cluster scope federation cluster is installed. The RBAC to limit different users access different member clusters within their namespace.

@gyliu513 