### PR TITLE
Federate resource

### DIFF
--- a/pkg/controller/sync/placement_test.go
+++ b/pkg/controller/sync/placement_test.go
@@ -83,7 +83,7 @@ func TestSelectedClusterNames(t *testing.T) {
 				unstructured.SetNestedStringSlice(obj.Object, testCase.clusterNames, util.SpecField, util.PlacementField, util.ClusterNamesField)
 			}
 			if testCase.clusterSelector != nil {
-				unstructured.SetNestedStringMap(obj.Object, testCase.clusterSelector, util.SpecField, util.PlacementField, util.ClusterSelectorField, "matchLabels")
+				unstructured.SetNestedStringMap(obj.Object, testCase.clusterSelector, util.SpecField, util.PlacementField, util.ClusterSelectorField, util.MatchLabelsField)
 			}
 
 			selectedNames, err := selectedClusterNames(obj, clusters)

--- a/pkg/controller/sync/resource_test.go
+++ b/pkg/controller/sync/resource_test.go
@@ -20,9 +20,8 @@ import (
 	"strings"
 	"testing"
 
+	kfenable "github.com/kubernetes-sigs/federation-v2/pkg/kubefed2/enable"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-
-	"github.com/kubernetes-sigs/federation-v2/pkg/kubefed2/federate"
 )
 
 func TestGetTemplateHash(t *testing.T) {
@@ -34,7 +33,7 @@ spec:
     spec:
       foo:
 `
-	err := federate.DecodeYAML(strings.NewReader(yaml), template)
+	err := kfenable.DecodeYAML(strings.NewReader(yaml), template)
 	if err != nil {
 		t.Fatalf("An unexpected error occurred: %v", err)
 	}

--- a/pkg/controller/util/constants.go
+++ b/pkg/controller/util/constants.go
@@ -35,7 +35,8 @@ const (
 	// resources.
 
 	// Common fields
-	SpecField = "spec"
+	SpecField     = "spec"
+	MetadataField = "metadata"
 
 	// ServiceAccount fields
 	SecretsField = "secrets"

--- a/pkg/controller/util/constants.go
+++ b/pkg/controller/util/constants.go
@@ -47,6 +47,7 @@ const (
 	PlacementField       = "placement"
 	ClusterNamesField    = "clusterNames"
 	ClusterSelectorField = "clusterSelector"
+	MatchLabelsField     = "matchLabels"
 
 	// Override fields
 	OverridesField        = "overrides"

--- a/pkg/kubefed2/disable.go
+++ b/pkg/kubefed2/disable.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package federate
+package kubefed2
 
 import (
 	"context"

--- a/pkg/kubefed2/enable/directive.go
+++ b/pkg/kubefed2/enable/directive.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package federate
+package enable
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/kubefed2/enable/enable.go
+++ b/pkg/kubefed2/enable/enable.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package federate
+package enable
 
 import (
 	"context"

--- a/pkg/kubefed2/enable/schema.go
+++ b/pkg/kubefed2/enable/schema.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package federate
+package enable
 
 import (
 	"fmt"

--- a/pkg/kubefed2/enable/util.go
+++ b/pkg/kubefed2/enable/util.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package federate
+package enable
 
 import (
 	"fmt"

--- a/pkg/kubefed2/enable/validation.go
+++ b/pkg/kubefed2/enable/validation.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package federate
+package enable
 
 import (
 	v1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"

--- a/pkg/kubefed2/federate/disable.go
+++ b/pkg/kubefed2/federate/disable.go
@@ -34,6 +34,7 @@ import (
 	fedv1a1 "github.com/kubernetes-sigs/federation-v2/pkg/apis/core/v1alpha1"
 	genericclient "github.com/kubernetes-sigs/federation-v2/pkg/client/generic"
 	ctlutil "github.com/kubernetes-sigs/federation-v2/pkg/controller/util"
+	"github.com/kubernetes-sigs/federation-v2/pkg/kubefed2/enable"
 	"github.com/kubernetes-sigs/federation-v2/pkg/kubefed2/options"
 	"github.com/kubernetes-sigs/federation-v2/pkg/kubefed2/util"
 )
@@ -127,7 +128,7 @@ func (j *disableType) Run(cmdOut io.Writer, config util.FedConfig) error {
 	// for which the corresponding target has been removed.
 	name := j.targetName
 	if !strings.Contains(j.targetName, ".") {
-		apiResource, err := LookupAPIResource(hostConfig, j.targetName, "")
+		apiResource, err := enable.LookupAPIResource(hostConfig, j.targetName, "")
 		if err != nil {
 			return err
 		}

--- a/pkg/kubefed2/federate/federate.go
+++ b/pkg/kubefed2/federate/federate.go
@@ -197,6 +197,11 @@ func createFedResource(hostConfig *rest.Config, typeConfig *fedv1a1.FederatedTyp
 		return nil, errors.Wrapf(err, "Error creating client for %s", fedAPIResource.Kind)
 	}
 
+	targetKind := typeConfig.GetTarget().Kind
+	if targetKind == ctlutil.ServiceAccountKind {
+		unstructured.RemoveNestedField(template.Object, ctlutil.SecretsField)
+	}
+
 	qualifiedName := ctlutil.NewQualifiedName(template)
 	resourceNamespace := ""
 	if typeConfig.GetTarget().Kind == ctlutil.NamespaceKind {

--- a/pkg/kubefed2/federate/federate.go
+++ b/pkg/kubefed2/federate/federate.go
@@ -1,0 +1,233 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package federate
+
+import (
+	"context"
+	"io"
+
+	"github.com/golang/glog"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	genericclient "github.com/kubernetes-sigs/federation-v2/pkg/client/generic"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/rest"
+
+	fedv1a1 "github.com/kubernetes-sigs/federation-v2/pkg/apis/core/v1alpha1"
+	ctlutil "github.com/kubernetes-sigs/federation-v2/pkg/controller/util"
+	"github.com/kubernetes-sigs/federation-v2/pkg/kubefed2/enable"
+	"github.com/kubernetes-sigs/federation-v2/pkg/kubefed2/options"
+	"github.com/kubernetes-sigs/federation-v2/pkg/kubefed2/util"
+)
+
+var (
+	federate_long = `
+		Federate creates a federated resource from a kubernetes resource.
+		The target resource must exist in the cluster hosting the federation
+		control plane. The control plane must have a FederatedTypeConfig
+		for the type of the kubernetes resource. The new federated resource
+		will be created with the same name and namespace (if namespaced) as
+		the kubernetes resource.
+
+		Current context is assumed to be a Kubernetes cluster hosting
+		the federation control plane. Please use the --host-cluster-context
+		flag otherwise.`
+
+	federate_example = `
+		# Federate resource named "my-dep" in namespace "my-ns" of type identified by FederatedTypeConfig "deployment.apps"
+		kubefed2 federate deployment.apps my-dep -n "my-ns" --host-cluster-context=cluster1`
+	// TODO(irfanurrehman): implement —contents flag applicable to namespaces
+)
+
+type federateResource struct {
+	options.SubcommandOptions
+	typeName          string
+	resourceName      string
+	resourceNamespace string
+}
+
+func (j *federateResource) Bind(flags *pflag.FlagSet) {
+	flags.StringVarP(&j.resourceNamespace, "namespace", "n", "default", "The namespace of the resource to federate.")
+}
+
+// Complete ensures that options are valid.
+func (j *federateResource) Complete(args []string) error {
+	if len(args) == 0 {
+		return errors.New("FEDERATED-TYPE-NAME is required")
+	}
+	j.typeName = args[0]
+
+	if len(args) == 1 {
+		return errors.New("RESOURCE-NAME is required")
+	}
+	j.resourceName = args[1]
+
+	if j.typeName == ctlutil.NamespaceName {
+		glog.Infof("Resource to federate is a namespace. Given namespace will itself be the container for the federated namespace")
+		j.resourceNamespace = ""
+	}
+
+	return nil
+}
+
+// NewCmdFederateResource defines the `federate` command that federates a
+// Kubernetes resource of the given kubernetes type.
+func NewCmdFederateResource(cmdOut io.Writer, config util.FedConfig) *cobra.Command {
+	opts := &federateResource{}
+
+	cmd := &cobra.Command{
+		Use:     "federate FEDERATED-TYPE-NAME RESOURCE-NAME",
+		Short:   "Federate creates a federated resource from a kubernetes resource",
+		Long:    federate_long,
+		Example: federate_example,
+		Run: func(cmd *cobra.Command, args []string) {
+			err := opts.Complete(args)
+			if err != nil {
+				glog.Fatalf("error: %v", err)
+			}
+
+			err = opts.Run(cmdOut, config)
+			if err != nil {
+				glog.Fatalf("error: %v", err)
+			}
+		},
+	}
+
+	flags := cmd.Flags()
+	opts.CommonBind(flags)
+	opts.Bind(flags)
+
+	return cmd
+}
+
+// Run is the implementation of the `federate resource` command.
+func (j *federateResource) Run(cmdOut io.Writer, config util.FedConfig) error {
+	hostConfig, err := config.HostConfig(j.HostClusterContext, j.Kubeconfig)
+	if err != nil {
+		return errors.Wrap(err, "Failed to get host cluster config")
+	}
+
+	qualifiedTypeName := ctlutil.QualifiedName{
+		Namespace: j.FederationNamespace,
+		Name:      j.typeName,
+	}
+
+	qualifiedResourceName := ctlutil.QualifiedName{
+		Namespace: j.resourceNamespace,
+		Name:      j.resourceName,
+	}
+
+	_, err = FederateResource(hostConfig, qualifiedTypeName, qualifiedResourceName, j.DryRun)
+	return err
+}
+
+func FederateResource(hostConfig *rest.Config, qualifiedTypeName, qualifiedResourceName ctlutil.QualifiedName, dryrun bool) (*unstructured.Unstructured, error) {
+	typeConfig, err := lookupTypeDetails(hostConfig, qualifiedTypeName)
+	if err != nil {
+		return nil, err
+	}
+
+	templateResource, err := getTargetResource(hostConfig, typeConfig, qualifiedResourceName)
+	if err != nil {
+		return nil, err
+	}
+
+	return createFedResource(hostConfig, typeConfig, templateResource, dryrun)
+}
+
+func lookupTypeDetails(config *rest.Config, qualifiedTypeName ctlutil.QualifiedName) (*fedv1a1.FederatedTypeConfig, error) {
+	client, err := genericclient.New(config)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to get federation client")
+	}
+
+	typeConfig := &fedv1a1.FederatedTypeConfig{}
+	err = client.Get(context.TODO(), typeConfig, qualifiedTypeName.Namespace, qualifiedTypeName.Name)
+	if err != nil {
+		return nil, errors.Wrapf(err, "Error retrieving FederatedTypeConfig %q", qualifiedTypeName)
+	}
+
+	_, err = enable.LookupAPIResource(config, typeConfig.Name, typeConfig.APIVersion)
+	if err != nil {
+		return nil, errors.Wrapf(err, "Error retrieving API resource for FederatedTypeConfig %q", qualifiedTypeName)
+	}
+
+	glog.Infof("FederatedTypeConfig: %q found", qualifiedTypeName)
+	return typeConfig, nil
+}
+
+func getTargetResource(hostConfig *rest.Config, typeConfig *fedv1a1.FederatedTypeConfig, qualifiedName ctlutil.QualifiedName) (*unstructured.Unstructured, error) {
+	targetAPIResource := typeConfig.GetTarget()
+	targetClient, err := ctlutil.NewResourceClient(hostConfig, &targetAPIResource)
+	if err != nil {
+		return nil, errors.Wrapf(err, "Error creating client for %s", targetAPIResource.Kind)
+	}
+
+	kind := targetAPIResource.Kind
+	resource, err := targetClient.Resources(qualifiedName.Namespace).Get(qualifiedName.Name, metav1.GetOptions{})
+	if err != nil {
+		return nil, errors.Wrapf(err, "Error retrieving target %s %q", kind, qualifiedName)
+	}
+
+	glog.Infof("Target %s %q found", kind, qualifiedName)
+	return resource, nil
+}
+
+func createFedResource(hostConfig *rest.Config, typeConfig *fedv1a1.FederatedTypeConfig, template *unstructured.Unstructured, dryrun bool) (*unstructured.Unstructured, error) {
+	fedAPIResource := typeConfig.GetFederatedType()
+	fedClient, err := ctlutil.NewResourceClient(hostConfig, &fedAPIResource)
+	if err != nil {
+		return nil, errors.Wrapf(err, "Error creating client for %s", fedAPIResource.Kind)
+	}
+
+	qualifiedName := ctlutil.NewQualifiedName(template)
+	resourceNamespace := ""
+	if typeConfig.GetTarget().Kind == ctlutil.NamespaceKind {
+		resourceNamespace = qualifiedName.Name
+	} else {
+		resourceNamespace = qualifiedName.Namespace
+	}
+	fedResource := &unstructured.Unstructured{}
+	SetBasicMetaFields(fedResource, fedAPIResource, qualifiedName.Name, resourceNamespace, "")
+	RemoveUnwantedFields(template)
+
+	fedKind := fedAPIResource.Kind
+	qualifiedFedName := ctlutil.NewQualifiedName(fedResource)
+	err = unstructured.SetNestedField(fedResource.Object, template.Object, ctlutil.SpecField, ctlutil.TemplateField)
+	if err != nil {
+		return nil, errors.Wrapf(err, "Error setting template into %s %q ", fedKind, qualifiedFedName)
+	}
+
+	err = unstructured.SetNestedStringMap(fedResource.Object, map[string]string{}, ctlutil.SpecField, ctlutil.PlacementField, ctlutil.ClusterSelectorField, ctlutil.MatchLabelsField)
+	if err != nil {
+		return nil, errors.Wrapf(err, "Error setting placement into %s %q", fedKind, qualifiedFedName)
+	}
+
+	var createdResource *unstructured.Unstructured = nil
+	if !dryrun {
+		createdResource, err = fedClient.Resources(resourceNamespace).Create(fedResource, metav1.CreateOptions{})
+		if err != nil {
+			return nil, errors.Wrapf(err, "Error creating %s %q", fedKind, qualifiedFedName)
+		}
+	}
+
+	glog.Infof("Successfully created a %s from %s %q", fedKind, typeConfig.GetTarget().Kind, qualifiedName)
+	return createdResource, nil
+}

--- a/pkg/kubefed2/federate/util.go
+++ b/pkg/kubefed2/federate/util.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package federate
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+var systemMetadataFields = []string{"selfLink", "uid", "resourceVersion", "generation", "creationTimestamp", "deletionTimestamp", "deletionGracePeriodSeconds"}
+
+func RemoveUnwantedFields(resource *unstructured.Unstructured) {
+	for _, field := range systemMetadataFields {
+		unstructured.RemoveNestedField(resource.Object, "metadata", field)
+		// For resources with pod template subresource (jobs, deployments, replicasets)
+		unstructured.RemoveNestedField(resource.Object, "spec", "template", "metadata", field)
+	}
+	unstructured.RemoveNestedField(resource.Object, "metadata", "name")
+	unstructured.RemoveNestedField(resource.Object, "metadata", "namespace")
+}
+
+func SetBasicMetaFields(resource *unstructured.Unstructured, apiResource metav1.APIResource, name, namespace, generateName string) {
+	resource.SetKind(apiResource.Kind)
+	gv := schema.GroupVersion{Group: apiResource.Group, Version: apiResource.Version}
+	resource.SetAPIVersion(gv.String())
+	resource.SetName(name)
+	if generateName != "" {
+		resource.SetGenerateName(generateName)
+	}
+	if apiResource.Namespaced {
+		resource.SetNamespace(namespace)
+	}
+}

--- a/pkg/kubefed2/kubefed2.go
+++ b/pkg/kubefed2/kubefed2.go
@@ -25,6 +25,7 @@ import (
 	apiserverflag "k8s.io/apiserver/pkg/util/flag"
 	"k8s.io/client-go/tools/clientcmd"
 
+	"github.com/kubernetes-sigs/federation-v2/pkg/kubefed2/enable"
 	"github.com/kubernetes-sigs/federation-v2/pkg/kubefed2/federate"
 	"github.com/kubernetes-sigs/federation-v2/pkg/kubefed2/util"
 )
@@ -53,7 +54,7 @@ func NewKubeFed2Command(out io.Writer) *cobra.Command {
 	flag.CommandLine.Parse(nil)
 
 	fedConfig := util.NewFedConfig(clientcmd.NewDefaultPathOptions())
-	rootCmd.AddCommand(federate.NewCmdTypeEnable(out, fedConfig))
+	rootCmd.AddCommand(enable.NewCmdTypeEnable(out, fedConfig))
 	rootCmd.AddCommand(federate.NewCmdTypeDisable(out, fedConfig))
 	rootCmd.AddCommand(NewCmdJoin(out, fedConfig))
 	rootCmd.AddCommand(NewCmdUnjoin(out, fedConfig))

--- a/pkg/kubefed2/kubefed2.go
+++ b/pkg/kubefed2/kubefed2.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/kubernetes-sigs/federation-v2/pkg/kubefed2/enable"
+	"github.com/kubernetes-sigs/federation-v2/pkg/kubefed2/federate"
 	"github.com/kubernetes-sigs/federation-v2/pkg/kubefed2/util"
 )
 
@@ -55,6 +56,7 @@ func NewKubeFed2Command(out io.Writer) *cobra.Command {
 	fedConfig := util.NewFedConfig(clientcmd.NewDefaultPathOptions())
 	rootCmd.AddCommand(enable.NewCmdTypeEnable(out, fedConfig))
 	rootCmd.AddCommand(NewCmdTypeDisable(out, fedConfig))
+	rootCmd.AddCommand(federate.NewCmdFederateResource(out, fedConfig))
 	rootCmd.AddCommand(NewCmdJoin(out, fedConfig))
 	rootCmd.AddCommand(NewCmdUnjoin(out, fedConfig))
 	rootCmd.AddCommand(NewCmdVersion(out))

--- a/pkg/kubefed2/kubefed2.go
+++ b/pkg/kubefed2/kubefed2.go
@@ -26,7 +26,6 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/kubernetes-sigs/federation-v2/pkg/kubefed2/enable"
-	"github.com/kubernetes-sigs/federation-v2/pkg/kubefed2/federate"
 	"github.com/kubernetes-sigs/federation-v2/pkg/kubefed2/util"
 )
 
@@ -55,7 +54,7 @@ func NewKubeFed2Command(out io.Writer) *cobra.Command {
 
 	fedConfig := util.NewFedConfig(clientcmd.NewDefaultPathOptions())
 	rootCmd.AddCommand(enable.NewCmdTypeEnable(out, fedConfig))
-	rootCmd.AddCommand(federate.NewCmdTypeDisable(out, fedConfig))
+	rootCmd.AddCommand(NewCmdTypeDisable(out, fedConfig))
 	rootCmd.AddCommand(NewCmdJoin(out, fedConfig))
 	rootCmd.AddCommand(NewCmdUnjoin(out, fedConfig))
 	rootCmd.AddCommand(NewCmdVersion(out))

--- a/test/common/fixtures.go
+++ b/test/common/fixtures.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/kubernetes-sigs/federation-v2/pkg/kubefed2/federate"
+	kfenable "github.com/kubernetes-sigs/federation-v2/pkg/kubefed2/enable"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
@@ -58,7 +58,7 @@ func typeConfigFixtures() (map[string]*unstructured.Unstructured, error) {
 
 		filename := filepath.Join(path, file.Name())
 		fixture := &unstructured.Unstructured{}
-		err := federate.DecodeYAMLFromFile(filename, fixture)
+		err := kfenable.DecodeYAMLFromFile(filename, fixture)
 		if err != nil {
 			return nil, errors.Wrapf(err, "Error reading fixture for %q", typeConfigName)
 		}

--- a/test/common/typeconfig.go
+++ b/test/common/typeconfig.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"context"
+
+	"github.com/kubernetes-sigs/federation-v2/pkg/apis/core/typeconfig"
+	fedv1a1 "github.com/kubernetes-sigs/federation-v2/pkg/apis/core/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func GetTypeConfig(genericClient client.Client, name, namespace string) (typeconfig.Interface, error) {
+	typeConfig := &fedv1a1.FederatedTypeConfig{}
+	key := client.ObjectKey{Name: name, Namespace: namespace}
+	err := genericClient.Get(context.Background(), key, typeConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	return typeConfig, nil
+}

--- a/test/e2e/crd.go
+++ b/test/e2e/crd.go
@@ -34,8 +34,8 @@ import (
 	apicommon "github.com/kubernetes-sigs/federation-v2/pkg/apis/core/common"
 	fedv1a1 "github.com/kubernetes-sigs/federation-v2/pkg/apis/core/v1alpha1"
 	"github.com/kubernetes-sigs/federation-v2/pkg/controller/util"
+	"github.com/kubernetes-sigs/federation-v2/pkg/kubefed2"
 	kfenable "github.com/kubernetes-sigs/federation-v2/pkg/kubefed2/enable"
-	"github.com/kubernetes-sigs/federation-v2/pkg/kubefed2/federate"
 	"github.com/kubernetes-sigs/federation-v2/test/common"
 	"github.com/kubernetes-sigs/federation-v2/test/e2e/framework"
 
@@ -159,7 +159,7 @@ func validateCrdCrud(f framework.FederationFramework, targetCrdKind string, name
 		// CRDs is attempted even if the removal of any one CRD fails.
 		objectMeta := typeConfig.GetObjectMeta()
 		qualifiedName := util.QualifiedName{Namespace: f.FederationSystemNamespace(), Name: objectMeta.Name}
-		err := federate.DisableFederation(nil, hostConfig, qualifiedName, delete, dryRun)
+		err := kubefed2.DisableFederation(nil, hostConfig, qualifiedName, delete, dryRun)
 		if err != nil {
 			tl.Fatalf("Error disabling federation of target type %q: %v", targetAPIResource.Kind, err)
 		}

--- a/test/e2e/crd.go
+++ b/test/e2e/crd.go
@@ -34,6 +34,7 @@ import (
 	apicommon "github.com/kubernetes-sigs/federation-v2/pkg/apis/core/common"
 	fedv1a1 "github.com/kubernetes-sigs/federation-v2/pkg/apis/core/v1alpha1"
 	"github.com/kubernetes-sigs/federation-v2/pkg/controller/util"
+	kfenable "github.com/kubernetes-sigs/federation-v2/pkg/kubefed2/enable"
 	"github.com/kubernetes-sigs/federation-v2/pkg/kubefed2/federate"
 	"github.com/kubernetes-sigs/federation-v2/test/common"
 	"github.com/kubernetes-sigs/federation-v2/test/e2e/framework"
@@ -90,7 +91,7 @@ func validateCrdCrud(f framework.FederationFramework, targetCrdKind string, name
 		Namespaced: namespaced,
 	}
 
-	validationSchema := federate.ValidationSchema(apiextv1b1.JSONSchemaProps{
+	validationSchema := kfenable.ValidationSchema(apiextv1b1.JSONSchemaProps{
 		Type: "object",
 		Properties: map[string]apiextv1b1.JSONSchemaProps{
 			"bar": {
@@ -99,7 +100,7 @@ func validateCrdCrud(f framework.FederationFramework, targetCrdKind string, name
 		},
 	})
 
-	targetCrd := federate.CrdForAPIResource(targetAPIResource, validationSchema)
+	targetCrd := kfenable.CrdForAPIResource(targetAPIResource, validationSchema)
 
 	userAgent := fmt.Sprintf("test-%s-crud", strings.ToLower(targetCrdKind))
 
@@ -119,7 +120,7 @@ func validateCrdCrud(f framework.FederationFramework, targetCrdKind string, name
 
 	targetName := targetAPIResource.Name
 	err := wait.PollImmediate(framework.PollInterval, framework.TestContext.SingleCallTimeout, func() (bool, error) {
-		_, err := federate.LookupAPIResource(hostConfig, targetName, targetAPIResource.Version)
+		_, err := kfenable.LookupAPIResource(hostConfig, targetName, targetAPIResource.Version)
 		if err != nil {
 			tl.Logf("An error was reported while waiting for target type %q to be published as an available resource: %v", targetName, err)
 		}
@@ -129,11 +130,11 @@ func validateCrdCrud(f framework.FederationFramework, targetCrdKind string, name
 		tl.Fatalf("Timed out waiting for target type %q to be published as an available resource", targetName)
 	}
 
-	enableTypeDirective := &federate.EnableTypeDirective{
+	enableTypeDirective := &kfenable.EnableTypeDirective{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: targetAPIResource.Name,
 		},
-		Spec: federate.EnableTypeDirectiveSpec{
+		Spec: kfenable.EnableTypeDirectiveSpec{
 			TargetVersion:     targetAPIResource.Version,
 			FederationGroup:   targetAPIResource.Group,
 			FederationVersion: targetAPIResource.Version,
@@ -141,13 +142,13 @@ func validateCrdCrud(f framework.FederationFramework, targetCrdKind string, name
 		},
 	}
 
-	resources, err := federate.GetResources(hostConfig, enableTypeDirective)
+	resources, err := kfenable.GetResources(hostConfig, enableTypeDirective)
 	if err != nil {
 		tl.Fatalf("Error retrieving resources to enable federation of target type %q: %v", targetAPIResource.Kind, err)
 	}
 	typeConfig := resources.TypeConfig
 
-	err = federate.CreateResources(nil, hostConfig, resources, f.FederationSystemNamespace())
+	err = kfenable.CreateResources(nil, hostConfig, resources, f.FederationSystemNamespace())
 	if err != nil {
 		tl.Fatalf("Error creating resources to enable federation of target type %q: %v", targetAPIResource.Kind, err)
 	}
@@ -189,7 +190,7 @@ overrides:
       - bang
 `
 		fixture := &unstructured.Unstructured{}
-		err = federate.DecodeYAML(strings.NewReader(fixtureYAML), fixture)
+		err = kfenable.DecodeYAML(strings.NewReader(fixtureYAML), fixture)
 		if err != nil {
 			return nil, errors.Wrap(err, "Error reading test fixture")
 		}

--- a/test/e2e/framework/managed/federation.go
+++ b/test/e2e/framework/managed/federation.go
@@ -31,7 +31,7 @@ import (
 	genericclient "github.com/kubernetes-sigs/federation-v2/pkg/client/generic"
 	"github.com/kubernetes-sigs/federation-v2/pkg/controller/util"
 	"github.com/kubernetes-sigs/federation-v2/pkg/inject"
-	"github.com/kubernetes-sigs/federation-v2/pkg/kubefed2/federate"
+	kfenable "github.com/kubernetes-sigs/federation-v2/pkg/kubefed2/enable"
 	"github.com/kubernetes-sigs/federation-v2/test/common"
 	apiv1 "k8s.io/api/core/v1"
 	apiextv1b1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
@@ -372,11 +372,11 @@ func waitForCrd(tl common.TestLogger, config *rest.Config, crd *apiextv1b1.Custo
 func federateCoreTypes(tl common.TestLogger, config *rest.Config, namespace string) []*apiextv1b1.CustomResourceDefinition {
 	crds := []*apiextv1b1.CustomResourceDefinition{}
 	for _, enableTypeDirective := range LoadEnableTypeDirectives(tl) {
-		resources, err := federate.GetResources(config, enableTypeDirective)
+		resources, err := kfenable.GetResources(config, enableTypeDirective)
 		if err != nil {
 			tl.Fatalf("Error retrieving resource definitions for EnableTypeDirective %q: %v", enableTypeDirective.Name, err)
 		}
-		err = federate.CreateResources(nil, config, resources, namespace)
+		err = kfenable.CreateResources(nil, config, resources, namespace)
 		if err != nil {
 			tl.Fatalf("Error creating resources for EnableTypeDirective %q: %v", enableTypeDirective.Name, err)
 		}
@@ -384,21 +384,22 @@ func federateCoreTypes(tl common.TestLogger, config *rest.Config, namespace stri
 	}
 	return crds
 }
-func LoadEnableTypeDirectives(tl common.TestLogger) []*federate.EnableTypeDirective {
+
+func LoadEnableTypeDirectives(tl common.TestLogger) []*kfenable.EnableTypeDirective {
 	path := enableTypeDirectivesPath(tl)
 	files, err := ioutil.ReadDir(path)
 	if err != nil {
 		tl.Fatalf("Error reading EnableTypeDirective resources from path %q: %v", path, err)
 	}
-	enableTypeDirectives := []*federate.EnableTypeDirective{}
+	enableTypeDirectives := []*kfenable.EnableTypeDirective{}
 	suffix := ".yaml"
 	for _, file := range files {
 		if !strings.HasSuffix(file.Name(), suffix) {
 			continue
 		}
 		filename := filepath.Join(path, file.Name())
-		obj := federate.NewEnableTypeDirective()
-		err := federate.DecodeYAMLFromFile(filename, obj)
+		obj := kfenable.NewEnableTypeDirective()
+		err := kfenable.DecodeYAMLFromFile(filename, obj)
 		if err != nil {
 			tl.Fatalf("Error loading EnableTypeDirective from file %q: %v", filename, err)
 		}

--- a/test/e2e/placement.go
+++ b/test/e2e/placement.go
@@ -82,11 +82,15 @@ var _ = Describe("Placement", func() {
 		}
 
 		// Propagate a resource to member clusters
-		testObjectFunc := func(namespace string, clusterNames []string) (*unstructured.Unstructured, error) {
-			return common.NewTestObject(selectedTypeConfig, namespace, clusterNames, fixture)
+		testObjectsFunc := func(namespace string, clusterNames []string) (*unstructured.Unstructured, []interface{}, error) {
+			targetObject, err := common.NewTestTargetObject(selectedTypeConfig, namespace, fixture)
+			if err != nil {
+				return nil, nil, err
+			}
+			return targetObject, nil, err
 		}
-		crudTester, desiredFedObject := initCrudTest(f, tl, selectedTypeConfig, testObjectFunc)
-		fedObject := crudTester.CheckCreate(desiredFedObject)
+		crudTester, desiredTargetObject, _ := initCrudTest(f, tl, selectedTypeConfig, testObjectsFunc)
+		fedObject := crudTester.CheckCreate(desiredTargetObject, nil)
 		defer func() {
 			orphanDependents := false
 			crudTester.CheckDelete(fedObject, &orphanDependents)

--- a/test/e2e/scheduling.go
+++ b/test/e2e/scheduling.go
@@ -33,6 +33,7 @@ import (
 	genericclient "github.com/kubernetes-sigs/federation-v2/pkg/client/generic"
 	"github.com/kubernetes-sigs/federation-v2/pkg/controller/schedulingmanager"
 	"github.com/kubernetes-sigs/federation-v2/pkg/controller/util"
+	kfenable "github.com/kubernetes-sigs/federation-v2/pkg/kubefed2/enable"
 	"github.com/kubernetes-sigs/federation-v2/pkg/kubefed2/federate"
 	"github.com/kubernetes-sigs/federation-v2/pkg/schedulingtypes"
 	"github.com/kubernetes-sigs/federation-v2/test/common"
@@ -383,13 +384,13 @@ func int32MapToInt64(original map[string]int32) map[string]int64 {
 
 func enableTypeConfigResource(name, namespace string, config *restclient.Config, tl common.TestLogger) {
 	for _, enableTypeDirective := range managed.LoadEnableTypeDirectives(tl) {
-		resources, err := federate.GetResources(config, enableTypeDirective)
+		resources, err := kfenable.GetResources(config, enableTypeDirective)
 		if err != nil {
 			tl.Fatalf("Error retrieving resource definitions for EnableTypeDirective %q: %v", enableTypeDirective.Name, err)
 		}
 
 		if enableTypeDirective.Name == name {
-			err = federate.CreateResources(nil, config, resources, namespace)
+			err = kfenable.CreateResources(nil, config, resources, namespace)
 			if err != nil {
 				tl.Fatalf("Error creating resources for EnableTypeDirective %q: %v", enableTypeDirective.Name, err)
 			}

--- a/test/e2e/scheduling.go
+++ b/test/e2e/scheduling.go
@@ -33,8 +33,8 @@ import (
 	genericclient "github.com/kubernetes-sigs/federation-v2/pkg/client/generic"
 	"github.com/kubernetes-sigs/federation-v2/pkg/controller/schedulingmanager"
 	"github.com/kubernetes-sigs/federation-v2/pkg/controller/util"
+	"github.com/kubernetes-sigs/federation-v2/pkg/kubefed2"
 	kfenable "github.com/kubernetes-sigs/federation-v2/pkg/kubefed2/enable"
-	"github.com/kubernetes-sigs/federation-v2/pkg/kubefed2/federate"
 	"github.com/kubernetes-sigs/federation-v2/pkg/schedulingtypes"
 	"github.com/kubernetes-sigs/federation-v2/test/common"
 	"github.com/kubernetes-sigs/federation-v2/test/e2e/framework"
@@ -400,7 +400,7 @@ func enableTypeConfigResource(name, namespace string, config *restclient.Config,
 
 func deleteTypeConfigResource(name, namespace string, config *restclient.Config, tl common.TestLogger) {
 	qualifiedName := util.QualifiedName{Namespace: namespace, Name: name}
-	err := federate.DisableFederation(nil, config, qualifiedName, true, false)
+	err := kubefed2.DisableFederation(nil, config, qualifiedName, true, false)
 	if err != nil {
 		tl.Fatalf("Error disabling federation of target type %q: %v", qualifiedName, err)
 	}

--- a/test/e2e/scheduling.go
+++ b/test/e2e/scheduling.go
@@ -28,7 +28,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kubernetes-sigs/federation-v2/pkg/apis/core/typeconfig"
-	fedv1a1 "github.com/kubernetes-sigs/federation-v2/pkg/apis/core/v1alpha1"
 	fedschedulingv1a1 "github.com/kubernetes-sigs/federation-v2/pkg/apis/scheduling/v1alpha1"
 	genericclient "github.com/kubernetes-sigs/federation-v2/pkg/client/generic"
 	"github.com/kubernetes-sigs/federation-v2/pkg/controller/schedulingmanager"
@@ -78,12 +77,7 @@ var _ = Describe("Scheduling", func() {
 				tl.Fatalf("Error initializing dynamic client: %v", err)
 			}
 			for targetTypeName := range schedulingTypes {
-				typeConfig := &fedv1a1.FederatedTypeConfig{}
-				key := client.ObjectKey{
-					Namespace: f.FederationSystemNamespace(),
-					Name:      targetTypeName,
-				}
-				err = dynClient.Get(context.Background(), key, typeConfig)
+				typeConfig, err := common.GetTypeConfig(dynClient, targetTypeName, f.FederationSystemNamespace())
 				if err != nil {
 					tl.Fatalf("Error retrieving federatedtypeconfig for %q: %v", targetTypeName, err)
 				}

--- a/test/e2e/version.go
+++ b/test/e2e/version.go
@@ -41,7 +41,7 @@ import (
 	"github.com/kubernetes-sigs/federation-v2/pkg/controller/sync"
 	"github.com/kubernetes-sigs/federation-v2/pkg/controller/sync/version"
 	"github.com/kubernetes-sigs/federation-v2/pkg/controller/util"
-	"github.com/kubernetes-sigs/federation-v2/pkg/kubefed2/federate"
+	kfenable "github.com/kubernetes-sigs/federation-v2/pkg/kubefed2/enable"
 	"github.com/kubernetes-sigs/federation-v2/test/common"
 	"github.com/kubernetes-sigs/federation-v2/test/e2e/framework"
 
@@ -262,7 +262,7 @@ var _ = Describe("VersionManager", func() {
 				// finalizer to the object that would complicate
 				// validating garbage collection.
 				fedObject = &unstructured.Unstructured{}
-				err := federate.DecodeYAML(strings.NewReader(adapter.FederatedObjectYAML()), fedObject)
+				err := kfenable.DecodeYAML(strings.NewReader(adapter.FederatedObjectYAML()), fedObject)
 				if err != nil {
 					tl.Fatalf("Failed to parse yaml: %v", err)
 				}


### PR DESCRIPTION
Implements `kubefed2 federate <type-name> <resource-name>`.
Follow ups:
a. Federate a namespace (needs special handling)
b. Emit federated yaml rather then creating actual federated resource
c. Fetch resource to federate from any federated cluster 

cc @marun 
