### PR TITLE
Build a Scheme for generic client at init time

### DIFF
--- a/pkg/apis/register.go
+++ b/pkg/apis/register.go
@@ -29,6 +29,11 @@ import (
 var Scheme = runtime.NewScheme()
 var Codecs = serializer.NewCodecFactory(Scheme)
 var ParameterCodec = runtime.NewParameterCodec(Scheme)
+var localSchemeBuilder = runtime.SchemeBuilder{
+	corev1alpha1.AddToScheme,
+	multiclusterdnsv1alpha1.AddToScheme,
+	schedulingv1alpha1.AddToScheme,
+}
 
 func init() {
 	v1.AddToGroupVersion(Scheme, schema.GroupVersion{Version: "v1"})
@@ -49,8 +54,4 @@ func init() {
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.
-func AddToScheme(scheme *runtime.Scheme) {
-	corev1alpha1.AddToScheme(scheme)
-	multiclusterdnsv1alpha1.AddToScheme(scheme)
-	schedulingv1alpha1.AddToScheme(scheme)
-}
+var AddToScheme = localSchemeBuilder.AddToScheme

--- a/pkg/client/generic/genericclient.go
+++ b/pkg/client/generic/genericclient.go
@@ -21,12 +21,10 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
-	k8sscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
-	crscheme "k8s.io/cluster-registry/pkg/client/clientset/versioned/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/kubernetes-sigs/federation-v2/pkg/apis"
+	"github.com/kubernetes-sigs/federation-v2/pkg/client/generic/scheme"
 )
 
 type Client interface {
@@ -43,10 +41,7 @@ type genericClient struct {
 }
 
 func New(config *rest.Config) (Client, error) {
-	scheme := apis.Scheme
-	k8sscheme.AddToScheme(scheme)
-	crscheme.AddToScheme(scheme)
-	client, err := client.New(config, client.Options{Scheme: scheme})
+	client, err := client.New(config, client.Options{Scheme: scheme.Scheme})
 	return &genericClient{client}, err
 }
 

--- a/pkg/client/generic/scheme/register.go
+++ b/pkg/client/generic/scheme/register.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheme
+
+import (
+	fedapis "github.com/kubernetes-sigs/federation-v2/pkg/apis"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	runtime "k8s.io/apimachinery/pkg/runtime"
+	schema "k8s.io/apimachinery/pkg/runtime/schema"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	k8sscheme "k8s.io/client-go/kubernetes/scheme"
+	crapis "k8s.io/cluster-registry/pkg/apis/clusterregistry/v1alpha1"
+)
+
+var Scheme = runtime.NewScheme()
+var localSchemeBuilder = runtime.SchemeBuilder{
+	fedapis.AddToScheme,
+	k8sscheme.AddToScheme,
+	crapis.AddToScheme,
+}
+
+func init() {
+	v1.AddToGroupVersion(Scheme, schema.GroupVersion{Version: "v1"})
+	utilruntime.Must(AddToScheme(Scheme))
+}
+
+var AddToScheme = localSchemeBuilder.AddToScheme


### PR DESCRIPTION
apis.Scheme is a global object.  AddToScheme to that is not
a concurrency safe operation and occasionally causes
"fatal error: concurrent map read and map write" panics
during e2e tests.