### PR TITLE
deploy-federation.sh: Wait for the propagation of clusterregistry CRD

### DIFF
--- a/scripts/deploy-federation.sh
+++ b/scripts/deploy-federation.sh
@@ -67,6 +67,11 @@ function deploy-with-script() {
   # TODO(marun) Ensure federatdtypeconfig is available before creating instances
   # TODO(marun) Ensure crds are created for a given federated type before starting sync controller for that type
 
+  # Wait for the propagation of the clusterregistry CRD
+  util::wait-for-condition "propagation of the clusterregistry CRD" \
+    "kubectl api-resources | grep clusterregistry.k8s.io > /dev/null" \
+    10
+
   # Enable available types
   for filename in ./config/enabletypedirectives/*.yaml; do
     ./bin/kubefed2 enable -f "${filename}" --federation-namespace="${NS}"


### PR DESCRIPTION
To workaround the following error on the following invocation of
"kubefed2 enable".

customresourcedefinition.apiextensions.k8s.io/clusters.clusterregistry.k8s.io created
F0304 09:24:34.796992    2281 enable.go:111] error: Error listing api resources: unable to retrieve the complete list of server APIs: clusterregistry.k8s.io/v1alpha1: the server could not find the requested resource