### PR TITLE
Fix races in version manager and generic client construction

### DIFF
--- a/pkg/client/generic/genericclient.go
+++ b/pkg/client/generic/genericclient.go
@@ -54,8 +54,9 @@ func NewForConfigOrDie(config *rest.Config) Client {
 }
 
 func NewForConfigOrDieWithUserAgent(config *rest.Config, userAgent string) Client {
-	rest.AddUserAgent(config, userAgent)
-	return NewForConfigOrDie(config)
+	configCopy := rest.CopyConfig(config)
+	rest.AddUserAgent(configCopy, userAgent)
+	return NewForConfigOrDie(configCopy)
 }
 
 func (c *genericClient) Create(ctx context.Context, obj runtime.Object) error {

--- a/pkg/controller/sync/version/adapter.go
+++ b/pkg/controller/sync/version/adapter.go
@@ -21,30 +21,27 @@ import (
 	pkgruntime "k8s.io/apimachinery/pkg/runtime"
 
 	fedv1a1 "github.com/kubernetes-sigs/federation-v2/pkg/apis/core/v1alpha1"
-	"github.com/kubernetes-sigs/federation-v2/pkg/client/generic"
 	"github.com/kubernetes-sigs/federation-v2/pkg/controller/util"
 )
 
 type VersionAdapter interface {
 	TypeName() string
 
-	// Create a new instance of the version type
+	// Create an empty instance of the version type
+	NewObject() pkgruntime.Object
+	// Create an empty instance of list version type
+	NewListObject() pkgruntime.Object
+	// Create a populated instance of the version type
 	NewVersion(qualifiedName util.QualifiedName, ownerReference metav1.OwnerReference, status *fedv1a1.PropagatedVersionStatus) pkgruntime.Object
 
 	// Type-agnostic access / mutation of the Status field of a version resource
 	GetStatus(obj pkgruntime.Object) *fedv1a1.PropagatedVersionStatus
 	SetStatus(obj pkgruntime.Object, status *fedv1a1.PropagatedVersionStatus)
-
-	// Methods that interact with the API
-	Create(obj pkgruntime.Object) (pkgruntime.Object, error)
-	Get(qualifiedName util.QualifiedName) (pkgruntime.Object, error)
-	List(namespace string) (pkgruntime.Object, error)
-	UpdateStatus(obj pkgruntime.Object) (pkgruntime.Object, error)
 }
 
-func NewVersionAdapter(client generic.Client, namespaced bool) VersionAdapter {
+func NewVersionAdapter(namespaced bool) VersionAdapter {
 	if namespaced {
-		return newNamespacedVersionAdapter(client)
+		return &namespacedVersionAdapter{}
 	}
-	return newClusterVersionAdapter(client)
+	return &clusterVersionAdapter{}
 }

--- a/pkg/controller/sync/version/cluster.go
+++ b/pkg/controller/sync/version/cluster.go
@@ -17,35 +17,28 @@ limitations under the License.
 package version
 
 import (
-	"context"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	pkgruntime "k8s.io/apimachinery/pkg/runtime"
 
 	fedv1a1 "github.com/kubernetes-sigs/federation-v2/pkg/apis/core/v1alpha1"
-	genericclient "github.com/kubernetes-sigs/federation-v2/pkg/client/generic"
 	"github.com/kubernetes-sigs/federation-v2/pkg/controller/util"
 )
 
-type clusterVersionAdapter struct {
-	client genericclient.Client
-}
+type clusterVersionAdapter struct{}
 
-func newClusterVersionAdapter(client genericclient.Client) VersionAdapter {
-	return &clusterVersionAdapter{client}
-}
-
-func (a *clusterVersionAdapter) TypeName() string {
+func (*clusterVersionAdapter) TypeName() string {
 	return "ClusterPropagatedVersion"
 }
 
-func (a *clusterVersionAdapter) List(namespace string) (pkgruntime.Object, error) {
-	clusterPropagatedVersionList := &fedv1a1.ClusterPropagatedVersionList{}
-	err := a.client.List(context.TODO(), clusterPropagatedVersionList, namespace)
-	return clusterPropagatedVersionList, err
+func (*clusterVersionAdapter) NewListObject() pkgruntime.Object {
+	return &fedv1a1.ClusterPropagatedVersionList{}
 }
 
-func (a *clusterVersionAdapter) NewVersion(qualifiedName util.QualifiedName, ownerReference metav1.OwnerReference, status *fedv1a1.PropagatedVersionStatus) pkgruntime.Object {
+func (*clusterVersionAdapter) NewObject() pkgruntime.Object {
+	return &fedv1a1.ClusterPropagatedVersion{}
+}
+
+func (*clusterVersionAdapter) NewVersion(qualifiedName util.QualifiedName, ownerReference metav1.OwnerReference, status *fedv1a1.PropagatedVersionStatus) pkgruntime.Object {
 	return &fedv1a1.ClusterPropagatedVersion{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            qualifiedName.Name,
@@ -55,31 +48,13 @@ func (a *clusterVersionAdapter) NewVersion(qualifiedName util.QualifiedName, own
 	}
 }
 
-func (a *clusterVersionAdapter) GetStatus(obj pkgruntime.Object) *fedv1a1.PropagatedVersionStatus {
+func (*clusterVersionAdapter) GetStatus(obj pkgruntime.Object) *fedv1a1.PropagatedVersionStatus {
 	version := obj.(*fedv1a1.ClusterPropagatedVersion)
 	status := version.Status
 	return &status
 }
 
-func (a *clusterVersionAdapter) SetStatus(obj pkgruntime.Object, status *fedv1a1.PropagatedVersionStatus) {
+func (*clusterVersionAdapter) SetStatus(obj pkgruntime.Object, status *fedv1a1.PropagatedVersionStatus) {
 	version := obj.(*fedv1a1.ClusterPropagatedVersion)
 	version.Status = *status
-}
-
-func (a *clusterVersionAdapter) Create(obj pkgruntime.Object) (pkgruntime.Object, error) {
-	version := obj.(*fedv1a1.ClusterPropagatedVersion)
-	err := a.client.Create(context.TODO(), version)
-	return version, err
-}
-
-func (a *clusterVersionAdapter) Get(qualifiedName util.QualifiedName) (pkgruntime.Object, error) {
-	clusterPropagatedVersion := &fedv1a1.ClusterPropagatedVersion{}
-	err := a.client.Get(context.TODO(), clusterPropagatedVersion, qualifiedName.Namespace, qualifiedName.Name)
-	return clusterPropagatedVersion, err
-}
-
-func (a *clusterVersionAdapter) UpdateStatus(obj pkgruntime.Object) (pkgruntime.Object, error) {
-	version := obj.(*fedv1a1.ClusterPropagatedVersion)
-	err := a.client.UpdateStatus(context.TODO(), version)
-	return version, err
 }

--- a/pkg/controller/sync/version/namespaced.go
+++ b/pkg/controller/sync/version/namespaced.go
@@ -17,35 +17,28 @@ limitations under the License.
 package version
 
 import (
-	"context"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	pkgruntime "k8s.io/apimachinery/pkg/runtime"
 
 	fedv1a1 "github.com/kubernetes-sigs/federation-v2/pkg/apis/core/v1alpha1"
-	genericclient "github.com/kubernetes-sigs/federation-v2/pkg/client/generic"
 	"github.com/kubernetes-sigs/federation-v2/pkg/controller/util"
 )
 
-type namespacedVersionAdapter struct {
-	client genericclient.Client
-}
+type namespacedVersionAdapter struct{}
 
-func newNamespacedVersionAdapter(client genericclient.Client) VersionAdapter {
-	return &namespacedVersionAdapter{client}
-}
-
-func (a *namespacedVersionAdapter) TypeName() string {
+func (*namespacedVersionAdapter) TypeName() string {
 	return "PropagatedVersion"
 }
 
-func (a *namespacedVersionAdapter) List(namespace string) (pkgruntime.Object, error) {
-	propagatedVersionList := &fedv1a1.PropagatedVersionList{}
-	err := a.client.List(context.TODO(), propagatedVersionList, namespace)
-	return propagatedVersionList, err
+func (*namespacedVersionAdapter) NewListObject() pkgruntime.Object {
+	return &fedv1a1.PropagatedVersionList{}
 }
 
-func (a *namespacedVersionAdapter) NewVersion(qualifiedName util.QualifiedName, ownerReference metav1.OwnerReference, status *fedv1a1.PropagatedVersionStatus) pkgruntime.Object {
+func (*namespacedVersionAdapter) NewObject() pkgruntime.Object {
+	return &fedv1a1.PropagatedVersion{}
+}
+
+func (*namespacedVersionAdapter) NewVersion(qualifiedName util.QualifiedName, ownerReference metav1.OwnerReference, status *fedv1a1.PropagatedVersionStatus) pkgruntime.Object {
 	return &fedv1a1.PropagatedVersion{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace:       qualifiedName.Namespace,
@@ -56,31 +49,13 @@ func (a *namespacedVersionAdapter) NewVersion(qualifiedName util.QualifiedName, 
 	}
 }
 
-func (a *namespacedVersionAdapter) GetStatus(obj pkgruntime.Object) *fedv1a1.PropagatedVersionStatus {
+func (*namespacedVersionAdapter) GetStatus(obj pkgruntime.Object) *fedv1a1.PropagatedVersionStatus {
 	version := obj.(*fedv1a1.PropagatedVersion)
 	status := version.Status
 	return &status
 }
 
-func (a *namespacedVersionAdapter) SetStatus(obj pkgruntime.Object, status *fedv1a1.PropagatedVersionStatus) {
+func (*namespacedVersionAdapter) SetStatus(obj pkgruntime.Object, status *fedv1a1.PropagatedVersionStatus) {
 	version := obj.(*fedv1a1.PropagatedVersion)
 	version.Status = *status
-}
-
-func (a *namespacedVersionAdapter) Create(obj pkgruntime.Object) (pkgruntime.Object, error) {
-	version := obj.(*fedv1a1.PropagatedVersion)
-	err := a.client.Create(context.TODO(), version)
-	return version, err
-}
-
-func (a *namespacedVersionAdapter) Get(qualifiedName util.QualifiedName) (pkgruntime.Object, error) {
-	propogatedVersion := &fedv1a1.PropagatedVersion{}
-	err := a.client.Get(context.TODO(), propogatedVersion, qualifiedName.Namespace, qualifiedName.Name)
-	return propogatedVersion, err
-}
-
-func (a *namespacedVersionAdapter) UpdateStatus(obj pkgruntime.Object) (pkgruntime.Object, error) {
-	version := obj.(*fedv1a1.PropagatedVersion)
-	err := a.client.UpdateStatus(context.TODO(), version)
-	return version, err
 }

--- a/test/common/crudtester.go
+++ b/test/common/crudtester.go
@@ -17,6 +17,7 @@ limitations under the License.
 package common
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"time"
@@ -542,10 +543,11 @@ func (c *FederatedTypeCrudTester) expectedVersion(qualifiedName util.QualifiedNa
 	}
 
 	loggedWaiting := false
-	adapter := versionmanager.NewVersionAdapter(c.client, c.typeConfig.GetFederatedNamespaced())
+	adapter := versionmanager.NewVersionAdapter(c.typeConfig.GetFederatedNamespaced())
 	var version *fedv1a1.PropagatedVersionStatus
 	err := wait.PollImmediate(c.waitInterval, wait.ForeverTestTimeout, func() (bool, error) {
-		versionObj, err := adapter.Get(versionName)
+		versionObj := adapter.NewObject()
+		err := c.client.Get(context.TODO(), versionObj, versionName.Namespace, versionName.Name)
 		if apierrors.IsNotFound(err) {
 			if !loggedWaiting {
 				loggedWaiting = true

--- a/test/e2e/framework/unmanaged.go
+++ b/test/e2e/framework/unmanaged.go
@@ -187,8 +187,7 @@ func (f *UnmanagedFramework) KubeClient(userAgent string) kubeclientset.Interfac
 }
 
 func (f *UnmanagedFramework) Client(userAgent string) genericclient.Client {
-	restclient.AddUserAgent(f.Config, userAgent)
-	return genericclient.NewForConfigOrDie(f.Config)
+	return genericclient.NewForConfigOrDieWithUserAgent(f.Config, userAgent)
 }
 
 func (f *UnmanagedFramework) ClusterNames(userAgent string) []string {


### PR DESCRIPTION
- The switch to the generic client voilated some of the assumptions behind version manager client usage.  This PR updates the version manager to be fully compatible with the generic client.
- The generic client will trigger race detection if a client is constructed with a shared kubeconfig object that is changed after client construction.  The most common change in the codebase is the addition of a user agent.  This PR ensures a request for a new client with a user agent is always constructed with a copied kubeconfig.

Partially addresses #623.