### PR TITLE
support cluster RBAC for namespaced installation

### DIFF
--- a/pkg/kubefed2/join.go
+++ b/pkg/kubefed2/join.go
@@ -778,7 +778,7 @@ func createHealthCheckClusterRoleAndBinding(clientset kubeclient.Interface, saNa
 		return nil
 	}
 
-	roleName := util.HealthCheckRoleName(saName)
+	roleName := util.HealthCheckRoleName(saName, namespace)
 
 	role := &rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/kubefed2/unjoin.go
+++ b/pkg/kubefed2/unjoin.go
@@ -378,7 +378,7 @@ func deleteClusterRoleAndBinding(clusterClientset kubeclient.Interface, saName, 
 	}
 
 	roleName := util.RoleName(saName)
-	healthCheckRoleName := util.HealthCheckRoleName(saName)
+	healthCheckRoleName := util.HealthCheckRoleName(saName, namespace)
 
 	// Attempt to delete all role and role bindings created by join
 	// and ignore if there is any error

--- a/pkg/kubefed2/util/util.go
+++ b/pkg/kubefed2/util/util.go
@@ -116,6 +116,6 @@ func RoleName(serviceAccountName string) string {
 // HealthCheckRoleName returns the name of a ClusterRole and its
 // associated ClusterRoleBinding that is used to allow the service
 // account to check the health of the cluster and list nodes.
-func HealthCheckRoleName(serviceAccountName string) string {
-	return fmt.Sprintf("federation-controller-manager:healthcheck-%s", serviceAccountName)
+func HealthCheckRoleName(serviceAccountName, namespace string) string {
+	return fmt.Sprintf("federation-controller-manager:%s:healthcheck-%s", namespace, serviceAccountName)
 }


### PR DESCRIPTION
In namespaced federation, make RBAC for clusterrolebinding and clusterrole name contain namespace
So that each namespaced federation has its owned RBAC.

E.g. after installation of namespaced federation in `foo` namespace.
```
$ kubectl get clusterrole  | grep fed 
federation-controller-manager:foo:healthcheck-cluster1-cluster1        15s
$kubectl get clusterrolebindings  | grep fed
federation-controller-manager:foo:healthcheck-cluster1-cluster1   23s
```

This is better than sharing clusterrole and clusterolebindings for all namespaced federation as I implemented in https://github.com/kubernetes-sigs/federation-v2/pull/617 after considering marun's advise.

This method is simple to implement and easy to maintain.