### PR TITLE
support multiple namespaced federation with script

### DIFF
--- a/scripts/delete-federation.sh
+++ b/scripts/delete-federation.sh
@@ -110,9 +110,7 @@ fi
 ${KCD} ns "${NS}"
 
 # Remove permissive rolebinding that allows federation controllers to run.
-if [[ "${NAMESPACED}" ]]; then
-  ${KCD} -n "${NS}" rolebinding federation-admin
-else
+if [[ ! "${NAMESPACED}" ]]; then
   ${KCD} clusterrolebinding federation-admin
 fi
 

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -193,7 +193,7 @@ echo "Running go e2e tests with unmanaged fixture deployed by script"
 run-namespaced-e2e-tests-with-unmanaged-fixture
 
 echo "Deleting namespaced federation-v2"
-FEDERATION_NAMESPACE=foo NAMESPACED=y ./scripts/delete-federation.sh
+FEDERATION_NAMESPACE=foo NAMESPACED=y DELETE_CLUSTER_RESOURCE=y ./scripts/delete-federation.sh
 
 echo "Deploying federation-v2 with helm chart"
 FEDERATION_NAMESPACE=foo NAMESPACED=y USE_CHART=true ./scripts/deploy-federation.sh ${CONTAINER_REGISTRY_HOST}/federation-v2:e2e $(join-cluster-list)


### PR DESCRIPTION
 - cluster scope resource CRDs are created on demand and not deleted in delete-deployment operation to avoid breaking other namespaced federations
 - an option to clean all cluster scope resources. 