### PR TITLE
Refactor makefile and reuse docker image build steps from imagebuild.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ ifeq ($(DIFF), 1)
 endif
 
 ifneq ($(VERBOSE),)
-VERBOSE_FLAG = -v
+    VERBOSE_FLAG = -v
 endif
 BUILDMNT = /go/src/$(GOTARGET)
 BUILD_IMAGE ?= golang:1.11.2
@@ -56,29 +56,24 @@ BUILD_KUBEFED2 = $(BUILDCMD_KUBEFED2) cmd/kubefed2/kubefed2.go
 
 BUILD_CONTROLLER_NATIVE = $(BUILDCMD_CONTROLLER_NATIVE) cmd/controller-manager/main.go
 
-TESTARGS ?= $(VERBOSE_FLAG) -timeout 60s
-TEST_PKGS ?= $(GOTARGET)/cmd/... $(GOTARGET)/pkg/...
-TEST_CMD = go test $(TESTARGS)
-TEST = $(TEST_CMD) $(TEST_PKGS)
-
 DOCKER_BUILD ?= $(DOCKER) run --rm -v $(DIR):$(BUILDMNT) -w $(BUILDMNT) $(BUILD_IMAGE) /bin/sh -c
 
 # TODO (irfanurrehman): can add local compile, and auto-generate targets also if needed
-.PHONY: all container push clean hyperfed controller kubefed2 test local-test vet fmt build
+.PHONY: all container push clean hyperfed controller kubefed2 test vet fmt build
 
 all: container hyperfed controller kubefed2
 
 # Unit tests
 test: vet
-	go test $(TEST_PKGS)
+	go test $(shell go list ./... | grep -v /test/)
 
 build: hyperfed controller kubefed2
 
 vet:
-	go vet $(TEST_PKGS)
+	go vet ./...
 
 fmt:
-	go fmt $(TEST_PKGS)
+	bash ./hack/go-tools/verify-gofmt.sh
 
 container: hyperfed
 	cp -f $(HYPERFED_TARGET) bin/hyperfed

--- a/test/e2e/framework/managed/federation.go
+++ b/test/e2e/framework/managed/federation.go
@@ -241,8 +241,8 @@ func (f *FederationFixture) ClusterConfigs(tl common.TestLogger, userAgent strin
 		config := cluster.NewConfig(tl)
 		rest.AddUserAgent(config, userAgent)
 		configMap[name] = common.TestClusterConfig{
-			config,
-			cluster.IsPrimary,
+			Config:    config,
+			IsPrimary: cluster.IsPrimary,
 		}
 	}
 	return configMap
@@ -256,8 +256,8 @@ func (f *FederationFixture) ClusterDynamicClients(tl common.TestLogger, apiResou
 			tl.Fatalf("Error creating a resource client in cluster %q for kind %q: %v", name, apiResource.Kind, err)
 		}
 		clientMap[name] = common.TestCluster{
-			clusterConfig,
-			client,
+			TestClusterConfig: clusterConfig,
+			Client:            client,
 		}
 	}
 	return clientMap

--- a/test/e2e/framework/unmanaged.go
+++ b/test/e2e/framework/unmanaged.go
@@ -213,8 +213,8 @@ func (f *UnmanagedFramework) ClusterDynamicClients(apiResource *metav1.APIResour
 		// Check if this cluster is the same name as the host cluster name to
 		// make it the primary cluster.
 		testClusters[clusterName] = common.TestCluster{
-			clusterConfig,
-			client,
+			TestClusterConfig: clusterConfig,
+			Client:            client,
 		}
 	}
 	return testClusters
@@ -252,8 +252,8 @@ func (f *UnmanagedFramework) ClusterConfigs(userAgent string) map[string]common.
 		Expect(err).NotTo(HaveOccurred())
 		restclient.AddUserAgent(config, userAgent)
 		clusterConfigs[cluster.Name] = common.TestClusterConfig{
-			config,
-			(cluster.Name == hostClusterName),
+			Config:    config,
+			IsPrimary: (cluster.Name == hostClusterName),
 		}
 	}
 

--- a/test/e2e/ingressdns.go
+++ b/test/e2e/ingressdns.go
@@ -159,7 +159,7 @@ func createClusterIngress(f framework.FederationFramework, name, namespace strin
 		createdIngress, err := client.ExtensionsV1beta1().Ingresses(namespace).Create(ingress)
 		framework.ExpectNoError(err, "Error creating ingress in cluster %q", clusterName)
 
-		createdIngress.Status = extv1b1.IngressStatus{lbStatus}
+		createdIngress.Status = extv1b1.IngressStatus{LoadBalancer: lbStatus}
 
 		// Fake out provisioning LoadBalancer by updating the ingress status in member cluster.
 		_, err = client.ExtensionsV1beta1().Ingresses(namespace).UpdateStatus(createdIngress)

--- a/test/e2e/servicedns.go
+++ b/test/e2e/servicedns.go
@@ -199,7 +199,7 @@ func createClusterServiceAndEndpoints(f framework.FederationFramework, name, nam
 		createdService, err := client.CoreV1().Services(namespace).Create(service)
 		framework.ExpectNoError(err, "Error creating service in cluster %q", clusterName)
 
-		createdService.Status = apiv1.ServiceStatus{loadbalancerStatus}
+		createdService.Status = apiv1.ServiceStatus{LoadBalancer: loadbalancerStatus}
 
 		// Fake out provisioning LoadBalancer by updating the service status in member cluster.
 		_, err = client.CoreV1().Services(namespace).UpdateStatus(createdService)


### PR DESCRIPTION
This PR does following things. Although none are critical and is done for easier maintenance.

- Makefile was using different steps to build image. It is unified with `./scripts/imagebuild.sh` now.
- ~~Building binary image inside docker was unnecessary overhead as the binaries are built from CI in fresh environment every-time. In local development environment it takes additional time to build. Hence removed.~~
- Fix few go vet issues in e2e test code.
- Simplified Makefile targets for vet, fmt & test