### PR TITLE
update create-cluster/delete-cluster scripts to fit the latest kind

### DIFF
--- a/scripts/create-clusters.sh
+++ b/scripts/create-clusters.sh
@@ -88,7 +88,7 @@ function create-clusters() {
   local num_clusters=${1}
 
   for i in $(seq ${num_clusters}); do
-    # kind will create cluster with name: kind-${i}
+    # kind will create cluster with name: ${i}
     kind create cluster --name ${i}
     # TODO(font): remove once all workarounds are addressed.
     fixup-cluster ${i}
@@ -118,13 +118,13 @@ function fixup-cluster() {
   export KUBECONFIG="${KUBECONFIG:-}:${kubeconfig_path}"
 
   # Simplify context name
-  kubectl config rename-context kubernetes-admin@kind-${i} cluster${i}
+  kubectl config rename-context kubernetes-admin@${i} cluster${i}
 
   # TODO(font): Need to set container IP address in order for clusters to reach
   # kube API servers in other clusters until
   # https://github.com/kubernetes-sigs/kind/issues/111 is resolved.
-  local container_ip_addr=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' kind-${i}-control-plane)
-  sed -i "s/localhost/${container_ip_addr}/" ${kubeconfig_path}
+  local container_ip_addr=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' ${i}-control-plane)
+  sed -i "s/localhost.*$/${container_ip_addr}:6443/" ${kubeconfig_path}
 
   # TODO(font): Need to rename auth user name to avoid conflicts when using
   # multiple cluster kubeconfigs. Remove once
@@ -139,7 +139,7 @@ function check-clusters-ready() {
 }
 
 function configure-insecure-registry-on-cluster() {
-  configure-insecure-registry-and-reload "docker exec kind-${1}-control-plane bash -c" '$(pgrep dockerd)'
+  configure-insecure-registry-and-reload "docker exec ${1}-control-plane bash -c" '$(pgrep dockerd)'
 }
 
 if [[ "${CREATE_INSECURE_REGISTRY}" ]]; then

--- a/scripts/delete-clusters.sh
+++ b/scripts/delete-clusters.sh
@@ -33,7 +33,7 @@ function delete-clusters() {
   local num_clusters=${1}
 
   for i in $(seq ${num_clusters}); do
-    # kind will delete cluster with name: kind-${i}
+    # kind will delete cluster with name: ${i}
     echo "Deleting cluster ${i} ..."
     kind delete cluster --name ${i}
   done


### PR DESCRIPTION
The latest version of `kind` changes the way clusters are created, eliminating the fixed prefix "kind-" for cluster name.
Also, the API Server listener port is fixed to 6443 in the Node container.

Therefore, I updated the scripts to accommodate this changes.

Fixes: #640