### PR TITLE
Fix leader election e2e test

### DIFF
--- a/cmd/controller-manager/app/leaderelection/leaderelection.go
+++ b/cmd/controller-manager/app/leaderelection/leaderelection.go
@@ -72,6 +72,7 @@ func NewFederationLeaderElector(opts *options.Options, fnStartControllers func(*
 		RetryPeriod:   opts.LeaderElection.RetryPeriod,
 		Callbacks: leaderelection.LeaderCallbacks{
 			OnStartedLeading: func(ctx context.Context) {
+				glog.Info("promoted as leader")
 				stopChan := ctx.Done()
 				fnStartControllers(opts, stopChan)
 				<-stopChan


### PR DESCRIPTION
Fixes: https://github.com/kubernetes-sigs/federation-v2/issues/642

It is observed that leader election e2e test is flaky due to multiple go routines involved in the test, which results in timeout issue. This pr introduces the synchronisation between go routine methods in the test.

It is also observed that the leader election library from client-go is not concurrent safe which results in error like below:
```
WARNING: DATA RACE
Read at 0x00c000836148 by goroutine 204:
  github.com/kubernetes-sigs/federation-v2/vendor/k8s.io/client-go/tools/leaderelection.(*LeaderElector).IsLeader()
      /home/s70553/gopath/src/github.com/kubernetes-sigs/federation-v2/vendor/k8s.io/client-go/tools/leaderelection/leaderelection.go:195 +0x7a
  github.com/kubernetes-sigs/federation-v2/test/e2e.waitToBecomeLeader.func1()
      /home/s70553/gopath/src/github.com/kubernetes-sigs/federation-v2/test/e2e/leaderelection.go:109 +0x41
  github.com/kubernetes-sigs/federation-v2/vendor/k8s.io/apimachinery/pkg/util/wait.pollImmediateInternal()
      /home/s70553/gopath/src/github.com/kubernetes-sigs/federation-v2/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:245 +0x38
  github.com/kubernetes-sigs/federation-v2/vendor/k8s.io/apimachinery/pkg/util/wait.PollImmediate()
      /home/s70553/gopath/src/github.com/kubernetes-sigs/federation-v2/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:241 +0x5e
  github.com/kubernetes-sigs/federation-v2/test/e2e.waitToBecomeLeader()
      /home/s70553/gopath/src/github.com/kubernetes-sigs/federation-v2/test/e2e/leaderelection.go:108 +0xb1
  github.com/kubernetes-sigs/federation-v2/test/e2e.glob..func8.2.4()
      /home/s70553/gopath/src/github.com/kubernetes-sigs/federation-v2/test/e2e/leaderelection.go:92 +0x89

Previous write at 0x00c000836148 by goroutine 24:
  github.com/kubernetes-sigs/federation-v2/vendor/k8s.io/client-go/tools/leaderelection.(*LeaderElector).tryAcquireOrRenew()
      /home/s70553/gopath/src/github.com/kubernetes-sigs/federation-v2/vendor/k8s.io/client-go/tools/leaderelection/leaderelection.go:284 +0xb7b
  github.com/kubernetes-sigs/federation-v2/vendor/k8s.io/client-go/tools/leaderelection.(*LeaderElector).renew.func1.1.1()
      /home/s70553/gopath/src/github.com/kubernetes-sigs/federation-v2/vendor/k8s.io/client-go/tools/leaderelection/leaderelection.go:231 +0x62
```
So leader election test is run with race detector disabled. The concurrency issue, only affects the tests and not the actual functionality of leader election. Also appreciate, any alternate suggestions to resolve this issue.

/cc @xunpan @marun 