### PR TITLE
Update kube-openapi to include compatibility fixes required by openshift

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1003,11 +1003,12 @@
   version = "kubernetes-1.12.4"
 
 [[projects]]
-  digest = "1:e0d6dcb28c42a53c7243bb6380badd17f92fbd8488a075a07e984f91a07c0d23"
+  branch = "master"
+  digest = "1:03a96603922fc1f6895ae083e1e16d943b55ef0656b56965351bd87e7d90485f"
   name = "k8s.io/kube-openapi"
   packages = ["pkg/util/proto"]
   pruneopts = "NUT"
-  revision = "f08db293d3ef80052d6513ece19792642a289fea"
+  revision = "15615b16d372105f0c69ff47dfe7402926a65aaa"
 
 [[projects]]
   branch = "master"

--- a/vendor/k8s.io/kube-openapi/pkg/util/proto/document.go
+++ b/vendor/k8s.io/kube-openapi/pkg/util/proto/document.go
@@ -21,8 +21,8 @@ import (
 	"sort"
 	"strings"
 
-	openapi_v2 "github.com/googleapis/gnostic/OpenAPIv2"
-	yaml "gopkg.in/yaml.v2"
+	"github.com/googleapis/gnostic/OpenAPIv2"
+	"gopkg.in/yaml.v2"
 )
 
 func newSchemaError(path *Path, format string, a ...interface{}) error {
@@ -126,12 +126,17 @@ func (d *Definitions) parseMap(s *openapi_v2.Schema, path *Path) (Schema, error)
 	if len(s.GetType().GetValue()) != 0 && s.GetType().GetValue()[0] != object {
 		return nil, newSchemaError(path, "invalid object type")
 	}
+	var sub Schema
 	if s.GetAdditionalProperties().GetSchema() == nil {
-		return nil, newSchemaError(path, "invalid object doesn't have additional properties")
-	}
-	sub, err := d.ParseSchema(s.GetAdditionalProperties().GetSchema(), path)
-	if err != nil {
-		return nil, err
+		sub = &Arbitrary{
+			BaseSchema: d.parseBaseSchema(s, path),
+		}
+	} else {
+		var err error
+		sub, err = d.ParseSchema(s.GetAdditionalProperties().GetSchema(), path)
+		if err != nil {
+			return nil, err
+		}
 	}
 	return &Map{
 		BaseSchema: d.parseBaseSchema(s, path),
@@ -148,12 +153,10 @@ func (d *Definitions) parsePrimitive(s *openapi_v2.Schema, path *Path) (Schema, 
 		t = s.GetType().GetValue()[0]
 	}
 	switch t {
-	case String:
-	case Number:
-	case Integer:
-	case Boolean:
-	case "": // Some models are completely empty, and can be safely ignored.
-		// Do nothing
+	case String: // do nothing
+	case Number: // do nothing
+	case Integer: // do nothing
+	case Boolean: // do nothing
 	default:
 		return nil, newSchemaError(path, "Unknown primitive type: %q", t)
 	}
@@ -193,20 +196,24 @@ func (d *Definitions) parseKind(s *openapi_v2.Schema, path *Path) (Schema, error
 	}
 
 	fields := map[string]Schema{}
+	fieldOrder := []string{}
 
 	for _, namedSchema := range s.GetProperties().GetAdditionalProperties() {
 		var err error
-		path := path.FieldPath(namedSchema.GetName())
-		fields[namedSchema.GetName()], err = d.ParseSchema(namedSchema.GetValue(), &path)
+		name := namedSchema.GetName()
+		path := path.FieldPath(name)
+		fields[name], err = d.ParseSchema(namedSchema.GetValue(), &path)
 		if err != nil {
 			return nil, err
 		}
+		fieldOrder = append(fieldOrder, name)
 	}
 
 	return &Kind{
 		BaseSchema:     d.parseBaseSchema(s, path),
 		RequiredFields: s.GetRequired(),
 		Fields:         fields,
+		FieldOrder:     fieldOrder,
 	}, nil
 }
 
@@ -219,27 +226,38 @@ func (d *Definitions) parseArbitrary(s *openapi_v2.Schema, path *Path) (Schema, 
 // ParseSchema creates a walkable Schema from an openapi schema. While
 // this function is public, it doesn't leak through the interface.
 func (d *Definitions) ParseSchema(s *openapi_v2.Schema, path *Path) (Schema, error) {
-	objectTypes := s.GetType().GetValue()
-	if len(objectTypes) == 1 {
-		t := objectTypes[0]
-		switch t {
-		case object:
-			return d.parseMap(s, path)
-		case array:
-			return d.parseArray(s, path)
-		}
-
-	}
 	if s.GetXRef() != "" {
 		return d.parseReference(s, path)
 	}
-	if s.GetProperties() != nil {
-		return d.parseKind(s, path)
+	objectTypes := s.GetType().GetValue()
+	switch len(objectTypes) {
+	case 0:
+		// in the OpenAPI schema served by older k8s versions, object definitions created from structs did not include
+		// the type:object property (they only included the "properties" property), so we need to handle this case
+		if s.GetProperties() != nil {
+			return d.parseKind(s, path)
+		} else {
+			// Definition has no type and no properties. Treat it as an arbitrary value
+			// TODO: what if it has additionalProperties or patternProperties?
+			return d.parseArbitrary(s, path)
+		}
+	case 1:
+		t := objectTypes[0]
+		switch t {
+		case object:
+			if s.GetProperties() != nil {
+				return d.parseKind(s, path)
+			} else {
+				return d.parseMap(s, path)
+			}
+		case array:
+			return d.parseArray(s, path)
+		}
+		return d.parsePrimitive(s, path)
+	default:
+		// the OpenAPI generator never generates (nor it ever did in the past) OpenAPI type definitions with multiple types
+		return nil, newSchemaError(path, "definitions with multiple types aren't supported")
 	}
-	if len(objectTypes) == 0 || (len(objectTypes) == 1 && objectTypes[0] == "") {
-		return d.parseArbitrary(s, path)
-	}
-	return d.parsePrimitive(s, path)
 }
 
 // LookupModel is public through the interface of Models. It

--- a/vendor/k8s.io/kube-openapi/pkg/util/proto/openapi.go
+++ b/vendor/k8s.io/kube-openapi/pkg/util/proto/openapi.go
@@ -59,7 +59,7 @@ type SchemaVisitor interface {
 }
 
 // SchemaVisitorArbitrary is an additional visitor interface which handles
-// arbitrary types. For backwards compatability, it's a separate interface
+// arbitrary types. For backwards compatibility, it's a separate interface
 // which is checked for at runtime.
 type SchemaVisitorArbitrary interface {
 	SchemaVisitor
@@ -173,6 +173,8 @@ type Kind struct {
 	RequiredFields []string
 	// Maps field names to types.
 	Fields map[string]Schema
+	// FieldOrder reports the canonical order for the fields.
+	FieldOrder []string
 }
 
 var _ Schema = &Kind{}


### PR DESCRIPTION
[k8s.io/kube-openapi](https://github.com/kubernetes/kube-openapi) has seen recent fixes to ensure compliance with the openapi standard.  Recent builds of openshift return openapi that reflects these fixes but that break our older vendored version of kube-openapi.  This PR updates the vendored version of kube-openapi to ensure compatibility with both openshift and future versions of kubernetes.