### PR TITLE
Configmap configures federation controller

### DIFF
--- a/cmd/controller-manager/app/controller-manager.go
+++ b/cmd/controller-manager/app/controller-manager.go
@@ -22,20 +22,26 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"strconv"
+	"strings"
+	"time"
 
 	"github.com/golang/glog"
 	"github.com/kubernetes-sigs/kubebuilder/pkg/install"
 	"github.com/kubernetes-sigs/kubebuilder/pkg/signals"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	"k8s.io/api/core/v1"
 	extv1b1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	flagutil "k8s.io/apiserver/pkg/util/flag"
 	"k8s.io/apiserver/pkg/util/logs"
 	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/kubernetes-sigs/federation-v2/cmd/controller-manager/app/leaderelection"
 	"github.com/kubernetes-sigs/federation-v2/cmd/controller-manager/app/options"
+	genericclient "github.com/kubernetes-sigs/federation-v2/pkg/client/generic"
 	"github.com/kubernetes-sigs/federation-v2/pkg/controller/dnsendpoint"
 	"github.com/kubernetes-sigs/federation-v2/pkg/controller/federatedcluster"
 	"github.com/kubernetes-sigs/federation-v2/pkg/controller/federatedtypeconfig"
@@ -91,16 +97,18 @@ func Run(opts *options.Options) error {
 	logs.InitLogs()
 	defer logs.FlushLogs()
 
-	if err := utilfeature.DefaultFeatureGate.SetFromMap(opts.FeatureGates); err != nil {
-		glog.Fatalf("Invalid Feature Gate: %v", err)
-	}
-
 	stopChan := signals.SetupSignalHandler()
 
 	var err error
 	opts.Config.KubeConfig, err = clientcmd.BuildConfigFromFlags(masterURL, kubeconfig)
 	if err != nil {
 		panic(err)
+	}
+
+	setOptionsByConfigMap(opts)
+
+	if err := utilfeature.DefaultFeatureGate.SetFromMap(opts.FeatureGates); err != nil {
+		glog.Fatalf("Invalid Feature Gate: %v", err)
 	}
 
 	if opts.InstallCRDs {
@@ -182,6 +190,97 @@ func startControllers(opts *options.Options, stopChan <-chan struct{}) {
 			glog.Fatalf("Error starting federated type config controller: %v", err)
 		}
 	}
+}
+
+func setOptionsByConfigMap(opts *options.Options) {
+	client := genericclient.NewForConfigOrDieWithUserAgent(opts.Config.KubeConfig, "federation-v2-configmap")
+
+	name := "federation-v2"
+	namespace := os.Getenv("FEDERATION_NAMESPACE")
+	configMap := &v1.ConfigMap{}
+	err := client.Get(context.Background(), configMap, namespace, name)
+	if err != nil {
+		glog.V(1).Infof("Cannot retrieve configmap %q in namespace %q: %v. Command line options are used.", name, namespace, err)
+		return
+	}
+
+	glog.V(1).Infof("Options are setting by configmap %q in namespace %q", name, namespace)
+
+	setBool(&opts.InstallCRDs, configMap.Data, "install-crds")
+	setBool(&opts.LimitedScope, configMap.Data, "limited-scope")
+	setDuration(&opts.ClusterMonitorPeriod, configMap.Data, "cluster-monitor-period")
+
+	setString(&opts.Config.ClusterNamespace, configMap.Data, "registry-namespace")
+	setString(&opts.Config.FederationNamespace, configMap.Data, "federation-namespace")
+	setDuration(&opts.Config.ClusterAvailableDelay, configMap.Data, "cluster-available-delay")
+	setDuration(&opts.Config.ClusterUnavailableDelay, configMap.Data, "cluster-unavailable-delay")
+
+	setBool(&opts.LeaderElection.LeaderElect, configMap.Data, "leader-elect")
+	setString(&opts.LeaderElection.ResourceLock, configMap.Data, "leader-elect-resource-lock")
+	setDuration(&opts.LeaderElection.RetryPeriod, configMap.Data, "leader-elect-retry-period")
+	setDuration(&opts.LeaderElection.RenewDeadline, configMap.Data, "leader-elect-renew-deadline")
+	setDuration(&opts.LeaderElection.LeaseDuration, configMap.Data, "leader-elect-lease-duration")
+
+	featureList, ok := configMap.Data["feature-gates"]
+	if !ok && len(featureList) <= 0 {
+		return
+	}
+	featureList = strings.Replace(featureList, "\n", ",", -1)
+	featureMap := flagutil.NewMapStringBool(new(map[string]bool))
+	featureMap.Set(featureList)
+	opts.FeatureGates = *featureMap.Map
+	glog.V(1).Infof("\"feature-gates\" are setting with %q", featureList)
+}
+
+func setDuration(target *time.Duration, data map[string]string, key string) {
+	value, ok := data[key]
+	if !ok || len(value) <= 0 {
+		return
+	}
+
+	duration, err := time.ParseDuration(value)
+	if err != nil {
+		glog.Warningf("Failed in parsing %q to duration. Ignored.", value)
+		return
+	}
+	if *target == duration {
+		return
+	}
+
+	glog.V(1).Infof("Option %q is changed from %q to %q by configmap", key, *target, duration)
+	*target = duration
+}
+
+func setString(target *string, data map[string]string, key string) {
+	value, ok := data[key]
+	if !ok || len(value) <= 0 {
+		return
+	}
+	if *target == value {
+		return
+	}
+
+	glog.V(1).Infof("Option %q is changed from %q to %q by configmap", key, *target, value)
+	*target = value
+}
+
+func setBool(target *bool, data map[string]string, key string) {
+	value, ok := data[key]
+	if !ok || len(value) <= 0 {
+		return
+	}
+
+	boolValue, err := strconv.ParseBool(value)
+	if err != nil {
+		glog.Warningf("Failed in parsing \"%v\" to bool. Ignored.", boolValue)
+		return
+	}
+	if *target == boolValue {
+		return
+	}
+
+	glog.V(1).Infof("Option %q is changed from \"%v\" to \"%v\" by configmap", key, *target, boolValue)
+	*target = boolValue
 }
 
 type InstallStrategy struct {

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,0 +1,22 @@
+kind: ConfigMap 
+apiVersion: v1 
+metadata:
+  name: federation-v2
+data:
+  install-crds: "false"
+  federation-namespace: federation-system
+  registry-namespace: kube-multicluster-public
+  cluster-available-delay: "20s"
+  cluster-unavailable-delay: "60s"
+  limited-scope: "false"
+  uster-monitor-period: "40s"
+  leader-elect: "true"
+  leader-elect-lease-duration: "15s"
+  leader-elect-renew-deadline: "10s"
+  leader-elect-retry-period: "5s"
+  leader-elect-resource-lock: configmaps
+  feature-gates: |
+    PushReconciler=true
+    SchedulerPreferences=true
+    CrossClusterServiceDiscovery=true
+    FederatedIngress=true


### PR DESCRIPTION
A `federation-v2` configmap is used to configure federation controller. It will override command line options if exists.

After this is merged, I will:
- [ ] make installer script uses configmap for configuration
- [ ] make helm chart uses configmap for configuration
- [ ] make `kubectl disable` reject in namespaced federation.

Fixes #114