### PR TITLE
fix race condition in update propogated version

### DIFF
--- a/pkg/controller/sync/version/manager.go
+++ b/pkg/controller/sync/version/manager.go
@@ -281,9 +281,9 @@ func (m *VersionManager) writeVersion(qualifiedName util.QualifiedName) util.Rec
 	key := qualifiedName.String()
 	adapterType := m.adapter.TypeName()
 
-	m.RLock()
+	m.Lock()
 	obj, ok := m.versions[key]
-	m.RUnlock()
+	defer m.Unlock()
 	if !ok {
 		// Version is no longer tracked
 		return util.StatusAllOK
@@ -335,8 +335,6 @@ func (m *VersionManager) writeVersion(qualifiedName util.QualifiedName) util.Rec
 	updatedObj := obj.DeepCopyObject()
 	err = m.client.UpdateStatus(context.TODO(), updatedObj)
 	if err == nil {
-		m.Lock()
-		defer m.Unlock()
 		_, ok := m.versions[key]
 		if ok {
 			// Update the version since it is still being tracked.
@@ -388,8 +386,7 @@ func (m *VersionManager) refreshVersion(obj pkgruntime.Object) error {
 		return err
 	}
 	key := qualifiedName.String()
-	m.Lock()
-	defer m.Unlock()
+	// Should be Locked in caller function
 	_, ok := m.versions[key]
 	if !ok {
 		// Version has been deleted, no further action required
@@ -404,8 +401,7 @@ func (m *VersionManager) refreshVersion(obj pkgruntime.Object) error {
 }
 
 func (m *VersionManager) clearResourceVersion(key string) error {
-	m.Lock()
-	defer m.Unlock()
+	// Should be locked in calller function
 	obj, ok := m.versions[key]
 	if !ok {
 		// Version is deleted


### PR DESCRIPTION
It reproduced in CI environment sometimes. 

The case is `'Federated "serviceaccounts"'`
The message is:
```
• Failure [61.257 seconds]
Federated
/research/gowork/src/github.com/kubernetes-sigs/federation-v2/test/e2e/crud.go:36
  "serviceaccounts"
  /research/gowork/src/github.com/kubernetes-sigs/federation-v2/test/e2e/crud.go:50
    should be created, read, updated and deleted successfully [It]
    /research/gowork/src/github.com/kubernetes-sigs/federation-v2/test/e2e/crud.go:51

    Mar 17 22:10:57.228: Timeout verifying ServiceAccount "foo/test-e2e-8kz74" in cluster "cluster2": timed out waiting for the condition

    /research/gowork/src/github.com/kubernetes-sigs/federation-v2/test/e2e/framework/logger.go:39
```

It should be a bug. It happens in `ServiceAccount` resource test now. When a `SA` resource is propogated, it will quickly has `Secrets` attached. In such case, version manager will update and reconcile quickly for version twice. 

The correct sequences are:
```
VersionManager.Update
VersionManager.writeVersion
VersionManager.Update
VersionManager.writeVersion
```
However, as `writeVersion` lock/unlock twice in on function call, the second `Update` will update `VersinManager.versions` between a reading to the `version` and later a updating to the `version` of the first `writeVersion`. In such case, the `VersionManager.version` is override by old `version`
  

