### PR TITLE
Implement -o yaml for federate resource

### DIFF
--- a/pkg/kubefed2/enable/enable.go
+++ b/pkg/kubefed2/enable/enable.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/ghodss/yaml"
 	"github.com/golang/glog"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
@@ -346,25 +345,7 @@ func writeObjectToYAML(obj pkgruntime.Object, w io.Writer) error {
 		return err
 	}
 
-	// Convert to unstructured to filter status out of the output.  If
-	// status is included in the yaml, attempting to create it in a
-	// kube API will cause an error.
 	unstructuredObj := &unstructured.Unstructured{}
 	unstructured.UnstructuredJSONScheme.Decode(json, nil, unstructuredObj)
-	delete(unstructuredObj.Object, "status")
-	// Also remove unnecessary field
-	metadataMap := unstructuredObj.Object["metadata"].(map[string]interface{})
-	delete(metadataMap, "creationTimestamp")
-
-	updatedJSON, err := unstructuredObj.MarshalJSON()
-	if err != nil {
-		return err
-	}
-
-	data, err := yaml.JSONToYAML(updatedJSON)
-	if err != nil {
-		return err
-	}
-	_, err = w.Write(data)
-	return err
+	return util.WriteUnstructuredToYaml(unstructuredObj, w)
 }

--- a/pkg/kubefed2/federate/federate.go
+++ b/pkg/kubefed2/federate/federate.go
@@ -205,7 +205,7 @@ func lookupTypeDetails(config *rest.Config, qualifiedTypeName ctlutil.QualifiedN
 		return nil, errors.Wrapf(err, "Error retrieving API resource for FederatedTypeConfig %q", qualifiedTypeName)
 	}
 
-	glog.Infof("FederatedTypeConfig: %q found", qualifiedTypeName)
+	glog.V(2).Infof("FederatedTypeConfig: %q found", qualifiedTypeName)
 	return typeConfig, nil
 }
 
@@ -222,7 +222,7 @@ func getTargetResource(hostConfig *rest.Config, typeConfig *fedv1a1.FederatedTyp
 		return nil, errors.Wrapf(err, "Error retrieving target %s %q", kind, qualifiedName)
 	}
 
-	glog.Infof("Target %s %q found", kind, qualifiedName)
+	glog.V(2).Infof("Target %s %q found", kind, qualifiedName)
 	return resource, nil
 }
 

--- a/pkg/kubefed2/federate/util.go
+++ b/pkg/kubefed2/federate/util.go
@@ -25,6 +25,7 @@ import (
 var systemMetadataFields = []string{"selfLink", "uid", "resourceVersion", "generation", "creationTimestamp", "deletionTimestamp", "deletionGracePeriodSeconds"}
 
 func RemoveUnwantedFields(resource *unstructured.Unstructured) {
+	unstructured.RemoveNestedField(resource.Object, "status")
 	for _, field := range systemMetadataFields {
 		unstructured.RemoveNestedField(resource.Object, "metadata", field)
 		// For resources with pod template subresource (jobs, deployments, replicasets)

--- a/pkg/kubefed2/util/yaml_writer.go
+++ b/pkg/kubefed2/util/yaml_writer.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"github.com/ghodss/yaml"
+	"io"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func WriteUnstructuredToYaml(unstructuredObj *unstructured.Unstructured, w io.Writer) error {
+	// If status is included in the yaml, attempting to create it in a
+	// kube API will cause an error.
+	obj := unstructuredObj.DeepCopy()
+	unstructured.RemoveNestedField(obj.Object, "status")
+	unstructured.RemoveNestedField(obj.Object, "metadata", "creationTimestamp")
+
+	objJSON, err := obj.MarshalJSON()
+	if err != nil {
+		return err
+	}
+
+	data, err := yaml.JSONToYAML(objJSON)
+	if err != nil {
+		return err
+	}
+	_, err = w.Write(data)
+	return err
+}


### PR DESCRIPTION
This PR is on top of #647 
#647 commits are not reviewable here.

To make it easier for review, the enhancements are implemented in a PR chain:
 - [x] Implements -o yaml option [this PR]
 - [x] Accept group qualified type name [#661]
 - [x] Usable without federation API, it needs a k8s cluster (if only yaml is needed)  [#662]
 - [x] Optional --enable-type to enable type also while federating resource  [#663]

cc @marun @xunpan 