### PR TITLE
Make federate resource usable without federation API

### DIFF
--- a/pkg/kubefed2/enable/enable.go
+++ b/pkg/kubefed2/enable/enable.go
@@ -198,9 +198,9 @@ func GetResources(config *rest.Config, enableTypeDirective *EnableTypeDirective)
 	if err != nil {
 		return nil, err
 	}
-	glog.V(2).Infof("Found resource %q", resourceKey(*apiResource))
+	glog.V(2).Infof("Found type %q", resourceKey(*apiResource))
 
-	typeConfig := typeConfigForTarget(*apiResource, enableTypeDirective)
+	typeConfig := GenerateTypeConfigForTarget(*apiResource, enableTypeDirective)
 
 	accessor, err := newSchemaAccessor(config, *apiResource)
 	if err != nil {
@@ -279,7 +279,7 @@ func CreateResources(cmdOut io.Writer, config *rest.Config, resources *typeResou
 	return nil
 }
 
-func typeConfigForTarget(apiResource metav1.APIResource, enableTypeDirective *EnableTypeDirective) typeconfig.Interface {
+func GenerateTypeConfigForTarget(apiResource metav1.APIResource, enableTypeDirective *EnableTypeDirective) typeconfig.Interface {
 	spec := enableTypeDirective.Spec
 	kind := apiResource.Kind
 	pluralName := apiResource.Name
@@ -333,7 +333,7 @@ func writeObjectsToYAML(objects []pkgruntime.Object, w io.Writer) error {
 		w.Write([]byte("---\n"))
 		err := writeObjectToYAML(obj, w)
 		if err != nil {
-			return errors.Wrap(err, "Error encoding resource to yaml")
+			return errors.Wrap(err, "Error encoding object to yaml")
 		}
 	}
 	return nil

--- a/pkg/kubefed2/enable/util.go
+++ b/pkg/kubefed2/enable/util.go
@@ -137,6 +137,7 @@ func LookupAPIResource(config *rest.Config, key, targetVersion string) (*metav1.
 	if targetResource != nil {
 		return targetResource, nil
 	}
+
 	return nil, errors.Errorf("Unable to find api resource named %q.", key)
 }
 

--- a/test/e2e/federate.go
+++ b/test/e2e/federate.go
@@ -95,7 +95,7 @@ var _ = Describe("Federate resource", func() {
 
 			tl.Logf("Federating %s %q", kind, testResourceName)
 			fedKind := typeConfig.GetFederatedType().Kind
-			resources, err := federate.GetFedResources(kubeConfig, typeName, testResourceName)
+			resources, err := federate.GetFedResources(kubeConfig, typeName, testResourceName, false)
 			if err != nil {
 				tl.Fatalf("Error getting %s from %s %q: %v", fedKind, kind, testResourceName, err)
 			}


### PR DESCRIPTION
This implements:
  - [x] Federate resource usable without federation API, it needs a k8s cluster (if only yaml translation is needed). 

cc @marun @xunpan 