### PR TITLE
Remove invalid option from `kubefed2 enable` example

### DIFF
--- a/pkg/kubefed2/enable/enable.go
+++ b/pkg/kubefed2/enable/enable.go
@@ -60,8 +60,8 @@ var (
 		--host-cluster-context flag otherwise.`
 
 	enable_example = `
-		# Enable federation of Services with service type overrideable
-		kubefed2 enable Service --override-paths=spec.type --host-cluster-context=cluster1`
+		# Enable federation of Deployments
+		kubefed2 enable deployments.apps --host-cluster-context=cluster1`
 )
 
 type enableType struct {


### PR DESCRIPTION
`--override-paths` was removed with the implementation of generic overrides.