### PR TITLE
Revert "Some OSX support"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,11 +37,9 @@ endif
 BUILDMNT = /go/src/$(GOTARGET)
 BUILD_IMAGE ?= golang:1.11.2
 
-HYPERFED_TARGET = bin/hyperfed-linux
-CONTROLLER_TARGET = bin/controller-manager-linux
-KUBEFED2_TARGET = bin/kubefed2-linux
-
-CONTROLLER_TARGET_NATIVE = bin/controller-manager
+HYPERFED_TARGET = bin/hyperfed
+CONTROLLER_TARGET = bin/controller-manager
+KUBEFED2_TARGET = bin/kubefed2
 
 LDFLAG_OPTIONS = -ldflags "-X github.com/kubernetes-sigs/federation-v2/pkg/version.version=$(GIT_VERSION) \
                       -X github.com/kubernetes-sigs/federation-v2/pkg/version.gitCommit=$(GIT_HASH) \
@@ -51,13 +49,9 @@ BUILDCMD_HYPERFED = CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o $(HYPERFED
 BUILDCMD_CONTROLLER = CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o $(CONTROLLER_TARGET) $(VERBOSE_FLAG) $(LDFLAG_OPTIONS)
 BUILDCMD_KUBEFED2 = go build -o $(KUBEFED2_TARGET) $(VERBOSE_FLAG) $(LDFLAG_OPTIONS)
 
-BUILDCMD_CONTROLLER_NATIVE = CGO_ENABLED=0 go build -o $(CONTROLLER_TARGET_NATIVE) $(VERBOSE_FLAG) $(LDFLAG_OPTIONS)
-
 BUILD_HYPERFED = $(BUILDCMD_HYPERFED) cmd/hyperfed/main.go
 BUILD_CONTROLLER = $(BUILDCMD_CONTROLLER) cmd/controller-manager/main.go
 BUILD_KUBEFED2 = $(BUILDCMD_KUBEFED2) cmd/kubefed2/kubefed2.go
-
-BUILD_CONTROLLER_NATIVE = $(BUILDCMD_CONTROLLER_NATIVE) cmd/controller-manager/main.go
 
 TESTARGS ?= $(VERBOSE_FLAG) -timeout 60s
 TEST_PKGS ?= $(GOTARGET)/cmd/... $(GOTARGET)/pkg/...
@@ -84,7 +78,7 @@ fmt:
 	go fmt $(TEST_PKGS)
 
 container: hyperfed
-	cp -f $(HYPERFED_TARGET) images/federation-v2/hyperfed
+	cp -f bin/hyperfed images/federation-v2/
 	$(DOCKER) build images/federation-v2 \
 		-t $(REGISTRY)/$(TARGET):$(GIT_VERSION)
 	rm -f images/federation-v2/hyperfed
@@ -100,9 +94,6 @@ controller: $(BIN_DIR)
 
 kubefed2: $(BIN_DIR)
 	$(DOCKER_BUILD) '$(BUILD_KUBEFED2)'
-
-controller-native: $(BIN_DIR)
-	$(BUILD_CONTROLLER_NATIVE)
 
 push:
 	$(DOCKER) push $(REGISTRY)/$(TARGET):$(GIT_VERSION)

--- a/scripts/download-binaries.sh
+++ b/scripts/download-binaries.sh
@@ -41,19 +41,18 @@ root_dir="$(cd "$(dirname "$0")/.." ; pwd)"
 dest_dir="${root_dir}/bin"
 mkdir -p "${dest_dir}"
 
-platform=$(uname -s|tr A-Z a-z)
 kb_version="1.0.4"
-kb_tgz="kubebuilder_${kb_version}_${platform}_amd64.tar.gz"
+kb_tgz="kubebuilder_${kb_version}_linux_amd64.tar.gz"
 kb_url="https://github.com/kubernetes-sigs/kubebuilder/releases/download/v${kb_version}/${kb_tgz}"
 curl "${curl_args}O" "${kb_url}" \
   && tar xzfP "${kb_tgz}" -C "${dest_dir}" --strip-components=2 \
   && rm "${kb_tgz}"
 
 helm_version="2.11.0"
-helm_tgz="helm-v${helm_version}-${platform}-amd64.tar.gz"
+helm_tgz="helm-v${helm_version}-linux-amd64.tar.gz"
 helm_url="https://storage.googleapis.com/kubernetes-helm/$helm_tgz"
 curl "${curl_args}O" "${helm_url}" \
-    && tar xzfp "${helm_tgz}" -C "${dest_dir}" --strip-components=1 "${platform}-amd64/helm" \
+    && tar xzfp "${helm_tgz}" -C "${dest_dir}" --strip-components=1 linux-amd64/helm \
     && rm "${helm_tgz}"
 
 echo    "# destination:"

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -35,7 +35,7 @@ UNMANAGED_E2E_TEST_CMD="${COMMON_TEST_CMD} ${COMMON_TEST_ARGS} -kubeconfig=${HOM
 
 function build-binaries() {
   ${MAKE_CMD} hyperfed
-  ${MAKE_CMD} controller-native
+  ${MAKE_CMD} controller
   ${MAKE_CMD} kubefed2
 }
 


### PR DESCRIPTION
Reverts kubernetes-sigs/federation-v2#650

I regret having merged this.  I missed the consequences of `kubefed2` being generated as `kubefed2-linux`, and I think there needs to be greater thought put into supporting osx without breaking current expectations about binary names. 