### PR TITLE
Fix namespace deletion handling

### DIFF
--- a/pkg/controller/sync/resource.go
+++ b/pkg/controller/sync/resource.go
@@ -190,6 +190,7 @@ func (r *federatedResource) EnsureDeletion() error {
 	r.DeleteVersions()
 	_, err := r.deletionHelper.HandleObjectInUnderlyingClusters(
 		r.federatedResource,
+		r.TargetName().String(),
 		func(clusterObj pkgruntime.Object) bool {
 			// Skip deletion of a namespace in the host cluster as it will be
 			// removed by the garbage collector once its contents are removed.


### PR DESCRIPTION
This commit fixes a test bug and the deletion helper bug it was masking to correct previously broken namespace deletion handling.

- Symptom: Deleting a federated namespace would not result in the removal of the namespaces it was managing in member clusters.
- Test bug: When 2 clusters (one of them the host cluster) were targeted by the crudtester's CheckPropagationChange method, the namespace in the non-host cluster would be removed.  A subsequent call to CheckDelete would automatically succeed since the namespace no longer existed in non-host member clusters.
- Deletion helper bug: The key being used to attempt retrieval of namespaces in member clusters was for the federated namespace (i.e. `<namespace>/<namespace>`) rather than the namespace that contained it (i.e. `<namespace>`). A call to the informer for the bad key returned no results, which the deletion helper took to mean that managed resources had already been removed and that the federated resource was safe to delete.

Fixes #618 