### PR TITLE
Fix orphan deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Unreleased
- - [#698](https://github.com/kubernetes-sigs/federation-v2/pull/698) -
+ - [#622](https://github.com/kubernetes-sigs/federation-v2/pull/622) -
+   Switched the sync controller to using a new finalizer
+   (`federation.k8s.io/sync-controller` instead of
+   `federation.kubernetes.io/delete-from-underlying-clusters`) and
+   replaced the use of the kube `orphan` finalizer in favor of an
+   annotation to avoid conflicting with the garbage collector.  This
+   change in finalizer usage represents a breaking change since
+   resources reconciled by previous versions of the sync controller
+   will have the old finalizer.  The old finalizer would need to be
+   manually removed from a resource for that resource to be garbage
+   collected after deletion.
+- [#698](https://github.com/kubernetes-sigs/federation-v2/pull/698) -
    Fix the generated CRD schema of scalable resources to define the
    `retainReplicas` of type `boolean` rather than the invalid type
    `bool`.

--- a/pkg/controller/sync/controller.go
+++ b/pkg/controller/sync/controller.go
@@ -270,10 +270,10 @@ func (s *FederationSyncController) reconcile(qualifiedName util.QualifiedName) u
 		// It should now be possible to garbage collect the finalization target.
 		return util.StatusAllOK
 	}
-	glog.V(3).Infof("Ensuring finalizers exist on %s %q", kind, key)
-	err = fedResource.EnsureFinalizers()
+	glog.V(3).Infof("Ensuring finalizer exists on %s %q", kind, key)
+	err = fedResource.EnsureFinalizer()
 	if err != nil {
-		runtime.HandleError(errors.Wrapf(err, "Failed to ensure finalizers for %s %q", kind, key))
+		runtime.HandleError(errors.Wrapf(err, "Failed to ensure finalizer for %s %q", kind, key))
 		return util.StatusError
 	}
 

--- a/pkg/controller/sync/resource.go
+++ b/pkg/controller/sync/resource.go
@@ -50,7 +50,7 @@ type FederatedResource interface {
 	ObjectForCluster(clusterName string) (*unstructured.Unstructured, error)
 	MarkedForDeletion() bool
 	EnsureDeletion() error
-	EnsureFinalizers() error
+	EnsureFinalizer() error
 }
 
 type federatedResource struct {
@@ -200,8 +200,8 @@ func (r *federatedResource) EnsureDeletion() error {
 	return err
 }
 
-func (r *federatedResource) EnsureFinalizers() error {
-	updatedObj, err := r.deletionHelper.EnsureFinalizers(r.federatedResource)
+func (r *federatedResource) EnsureFinalizer() error {
+	updatedObj, err := r.deletionHelper.EnsureFinalizer(r.federatedResource)
 	if updatedObj != nil {
 		// Retain the updated template for use in future API calls.
 		r.federatedResource = updatedObj.(*unstructured.Unstructured)

--- a/pkg/controller/util/deletionhelper/deletion_helper.go
+++ b/pkg/controller/util/deletionhelper/deletion_helper.go
@@ -71,7 +71,7 @@ func NewDeletionHelper(
 // The finalizer ensures that the controller is always notified when a
 // federated resource is deleted so that host and member cluster cleanup can be
 // performed.
-func (dh *DeletionHelper) EnsureFinalizers(obj runtime.Object) (runtime.Object, error) {
+func (dh *DeletionHelper) EnsureFinalizer(obj runtime.Object) (runtime.Object, error) {
 	isUpdated, err := finalizersutil.AddFinalizers(obj, sets.NewString(FinalizerSyncController))
 	if err != nil || !isUpdated {
 		return nil, err

--- a/pkg/controller/util/deletionhelper/deletion_helper.go
+++ b/pkg/controller/util/deletionhelper/deletion_helper.go
@@ -25,22 +25,25 @@ import (
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
 
-	"github.com/kubernetes-sigs/federation-v2/pkg/controller/util"
-	finalizersutil "github.com/kubernetes-sigs/federation-v2/pkg/controller/util/finalizers"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	meta "k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
+
+	"github.com/kubernetes-sigs/federation-v2/pkg/controller/util"
+	finalizersutil "github.com/kubernetes-sigs/federation-v2/pkg/controller/util/finalizers"
 )
 
 const (
-	// Add this finalizer to a federation resource if the resource should be
-	// deleted from all underlying clusters before being deleted from
-	// federation control plane.
-	// This is ignored if FinalizerOrphan is also present on the resource.
-	// In that case, both finalizers are removed from the resource and the
-	// resource is deleted from federation control plane without affecting
-	// the underlying clusters.
-	FinalizerDeleteFromUnderlyingClusters string = "federation.kubernetes.io/delete-from-underlying-clusters"
+	// If this finalizer is present on a federated resource, the sync
+	// controller will have the opportunity to perform pre-deletion operations
+	// (like deleting managed resources from member clusters).
+	FinalizerSyncController = "federation.k8s.io/sync-controller"
+
+	// If this annotation is present on a federated resource, resources in the
+	// member clusters managed by the federated resource should be orphaned.
+	// If the annotation is not present (the default), resources in member
+	// clusters will be deleted before the federated resource is deleted.
+	OrphanManagedResources = "federation.k8s.io/orphan"
 )
 
 type UpdateObjFunc func(runtime.Object) (runtime.Object, error)
@@ -64,68 +67,53 @@ func NewDeletionHelper(
 	}
 }
 
-// Ensures that the given object has both FinalizerDeleteFromUnderlyingClusters
-// and FinalizerOrphan finalizers.
-// We do this so that the controller is always notified when a federation resource is deleted.
-// If user deletes the resource with nil DeleteOptions or
-// DeletionOptions.OrphanDependents = true then the apiserver removes the orphan finalizer
-// and deletion helper does a cascading deletion.
-// Otherwise, deletion helper just removes the federation resource and orphans
-// the corresponding resources in underlying clusters.
-// This method should be called before creating objects in underlying clusters.
-func (dh *DeletionHelper) EnsureFinalizers(obj runtime.Object) (
-	runtime.Object, error) {
-	finalizers := sets.String{}
-	hasFinalizer, err := finalizersutil.HasFinalizer(obj, FinalizerDeleteFromUnderlyingClusters)
-	if err != nil {
+// Ensures that the given object has the FinalizerSyncController finalizer.
+// The finalizer ensures that the controller is always notified when a
+// federated resource is deleted so that host and member cluster cleanup can be
+// performed.
+func (dh *DeletionHelper) EnsureFinalizers(obj runtime.Object) (runtime.Object, error) {
+	isUpdated, err := finalizersutil.AddFinalizers(obj, sets.NewString(FinalizerSyncController))
+	if err != nil || !isUpdated {
 		return nil, err
 	}
-	if !hasFinalizer {
-		finalizers.Insert(FinalizerDeleteFromUnderlyingClusters)
-	}
-	hasFinalizer, err = finalizersutil.HasFinalizer(obj, metav1.FinalizerOrphanDependents)
+	glog.V(2).Infof("Adding finalizer %s to %s", FinalizerSyncController, dh.objNameFunc(obj))
+	// Send the update to apiserver.
+	updatedObj, err := dh.updateObjFunc(obj)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrapf(err, "failed to add finalizer %s to object %s", FinalizerSyncController, dh.objNameFunc(obj))
 	}
-	if !hasFinalizer {
-		finalizers.Insert(metav1.FinalizerOrphanDependents)
-	}
-	if finalizers.Len() != 0 {
-		glog.V(2).Infof("Adding finalizers %v to %s", finalizers.List(), dh.objNameFunc(obj))
-		return dh.addFinalizers(obj, finalizers)
-	}
-	return nil, nil
+	return updatedObj, nil
 }
 
-// Deletes the resources corresponding to the given federated resource from
-// all underlying clusters, unless it has the FinalizerOrphan finalizer.
-// Removes FinalizerOrphan and FinalizerDeleteFromUnderlyingClusters finalizers
-// when done.
-// Callers are expected to keep calling this (with appropriate backoff) until
-// it succeeds.
+// Deletes the resources in member clusters managed by the given federated
+// resource unless the OrphanManagedResources annotation is present and has a
+// value of 'true'.  Callers are expected to keep calling this (with
+// appropriate backoff) until it succeeds.
 func (dh *DeletionHelper) HandleObjectInUnderlyingClusters(obj runtime.Object, targetKey string, skipDelete func(runtime.Object) bool) (
 	runtime.Object, error) {
+
 	objName := dh.objNameFunc(obj)
 	glog.V(2).Infof("Handling deletion of federated dependents for object: %s", objName)
-	hasFinalizer, err := finalizersutil.HasFinalizer(obj, FinalizerDeleteFromUnderlyingClusters)
+
+	metaAccessor, err := meta.Accessor(obj)
 	if err != nil {
 		return obj, err
 	}
-	if !hasFinalizer {
-		glog.V(2).Infof("obj does not have %s finalizer. Nothing to do", FinalizerDeleteFromUnderlyingClusters)
+
+	finalizers := sets.NewString(metaAccessor.GetFinalizers()...)
+	if !finalizers.Has(FinalizerSyncController) {
+		glog.V(2).Infof("obj does not have the %q finalizer. Nothing to do", FinalizerSyncController)
 		return obj, nil
 	}
-	hasOrphanFinalizer, err := finalizersutil.HasFinalizer(obj, metav1.FinalizerOrphanDependents)
-	if err != nil {
-		return obj, err
-	}
-	if hasOrphanFinalizer {
-		glog.V(2).Infof("Found finalizer orphan. Nothing to do, just remove the finalizer")
-		// If the obj has FinalizerOrphan finalizer, then we need to orphan the
-		// corresponding objects in underlying clusters.
-		// Just remove both the finalizers in that case.
-		finalizers := sets.NewString(FinalizerDeleteFromUnderlyingClusters, metav1.FinalizerOrphanDependents)
-		return dh.removeFinalizers(obj, finalizers)
+
+	annotations := metaAccessor.GetAnnotations()
+	orphanResources := annotations != nil && annotations[OrphanManagedResources] == "true"
+	if orphanResources {
+		glog.V(2).Infof("Found %q annotation. Nothing to do, just remove the finalizer", OrphanManagedResources)
+		// If the obj has the OrphanManagedResources annotation, then we need to
+		// orphan the corresponding objects in underlying clusters.  Just
+		// remove the finalizer.
+		return dh.removeFinalizers(obj, sets.NewString(FinalizerSyncController))
 	}
 
 	glog.V(2).Infof("Deleting obj %s from underlying clusters", objName)
@@ -181,21 +169,7 @@ func (dh *DeletionHelper) HandleObjectInUnderlyingClusters(obj runtime.Object, t
 	}
 
 	// All done. Just remove the finalizer.
-	return dh.removeFinalizers(obj, sets.NewString(FinalizerDeleteFromUnderlyingClusters))
-}
-
-// Adds the given finalizers to the given objects ObjectMeta.
-func (dh *DeletionHelper) addFinalizers(obj runtime.Object, finalizers sets.String) (runtime.Object, error) {
-	isUpdated, err := finalizersutil.AddFinalizers(obj, finalizers)
-	if err != nil || !isUpdated {
-		return nil, err
-	}
-	// Send the update to apiserver.
-	updatedObj, err := dh.updateObjFunc(obj)
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to add finalizers %v to object %s", finalizers, dh.objNameFunc(obj))
-	}
-	return updatedObj, nil
+	return dh.removeFinalizers(obj, sets.NewString(FinalizerSyncController))
 }
 
 // Removes the given finalizers from the given objects ObjectMeta.

--- a/test/e2e/crd.go
+++ b/test/e2e/crd.go
@@ -209,8 +209,23 @@ overrides:
 		return targetObj, overrides, nil
 	}
 
-	validateCrud(f, tl, concreteTypeConfig, testObjectsFunc)
+	crudTester, targetObject, overrides := initCrudTest(f, tl, typeConfig, testObjectsFunc)
+	// Make a copy for use in the orphan check.
+	deletionTargetObject := targetObject.DeepCopy()
+	crudTester.CheckLifecycle(targetObject, overrides)
 
+	if namespaced {
+		// This check should not fail so long as the main test loop
+		// skips for limited scope.  If it does fail, manual cleanup
+		// after CheckDelete may need to be implemented.
+		if framework.TestContext.LimitedScope {
+			tl.Fatalf("Test of orphaned deletion assumes deletion of the containing namespace")
+		}
+		// Perform a check of orphan deletion.
+		fedObject := crudTester.CheckCreate(deletionTargetObject, nil)
+		orphanDeletion := true
+		crudTester.CheckDelete(fedObject, orphanDeletion)
+	}
 }
 
 func waitForCrd(config *rest.Config, tl common.TestLogger, apiResource metav1.APIResource) {

--- a/test/e2e/crud.go
+++ b/test/e2e/crud.go
@@ -87,7 +87,8 @@ var _ = Describe("Federated", func() {
 					return targetObject, overrides, err
 				}
 
-				validateCrud(f, tl, typeConfig, testObjectsFunc)
+				crudTester, targetObject, overrides := initCrudTest(f, tl, typeConfig, testObjectsFunc)
+				crudTester.CheckLifecycle(targetObject, overrides)
 			})
 		})
 	}
@@ -136,11 +137,4 @@ func initCrudTest(f framework.FederationFramework, tl common.TestLogger,
 	}
 
 	return crudTester, targetObject, overrides
-}
-
-func validateCrud(f framework.FederationFramework, tl common.TestLogger,
-	typeConfig typeconfig.Interface, testObjectsFunc testObjectsAccessor) {
-
-	crudTester, targetObject, overrides := initCrudTest(f, tl, typeConfig, testObjectsFunc)
-	crudTester.CheckLifecycle(targetObject, overrides)
 }

--- a/test/e2e/placement.go
+++ b/test/e2e/placement.go
@@ -92,8 +92,7 @@ var _ = Describe("Placement", func() {
 		crudTester, desiredTargetObject, _ := initCrudTest(f, tl, selectedTypeConfig, testObjectsFunc)
 		fedObject := crudTester.CheckCreate(desiredTargetObject, nil)
 		defer func() {
-			orphanDependents := false
-			crudTester.CheckDelete(fedObject, &orphanDependents)
+			crudTester.CheckDelete(fedObject, false)
 		}()
 
 		// Wait until pending events for the templates have cleared


### PR DESCRIPTION
fedv2 has been using the `orphan` finalizer in attempt to integrate with kube deletion policy.  This use of `orphan` proved problematic, though, since kube deletion policy is internal to a single cluster and the sync controller ends up racing with the gc (as per #622).  This PR switches to a new finalizer (`federation.k8s.io/sync-controller`) that ensures that deletion of federated resources will be visible to the sync controller and a new annotation (`federation.k8s.io/orphan`) in place of the `orphan` finalizer to indicate that managed resources should be retained on deletion of their managing federated resource.  

Documentation of the new deletion policy and use of finalizers is included, as is a test of orphan deletion (superceding that proposed by #606).

Due to the finalizer change, this PR will break deletion of federated resources reconciled by previous versions of the sync controller.  It may be desirable to highlight this fact along with a workaround (e.g. `kubectl patch` command to remove the previous finalizers) in something like a changelog. 

Fixes #622

cc: @yamt 