### PR TITLE
Fix helm chart rules to allow types instead of primitives

### DIFF
--- a/charts/federation-v2/charts/controllermanager/templates/clusterrole.yaml
+++ b/charts/federation-v2/charts/controllermanager/templates/clusterrole.yaml
@@ -27,7 +27,7 @@ rules:
   verbs:
   - '*'
 - apiGroups:
-  - primitives.federation.k8s.io
+  - types.federation.k8s.io
   resources:
   - '*'
   verbs:

--- a/charts/federation-v2/charts/controllermanager/templates/role.yaml
+++ b/charts/federation-v2/charts/controllermanager/templates/role.yaml
@@ -28,7 +28,7 @@ rules:
   verbs:
   - '*'
 - apiGroups:
-  - primitives.federation.k8s.io
+  - types.federation.k8s.io
   resources:
   - '*'
   verbs:


### PR DESCRIPTION
This has been breaking new users attempting to try federation.  I had assumed that the CI testing of helm would catch this sort of thing, but as per #670 that doesn't appear to be the case.