### PR TITLE
Update crd test to use a permitted group/version

### DIFF
--- a/pkg/kubefed2/enable/directive.go
+++ b/pkg/kubefed2/enable/directive.go
@@ -52,8 +52,8 @@ type EnableTypeDirective struct {
 }
 
 func (ft *EnableTypeDirective) SetDefaults() {
-	ft.Spec.FederationGroup = defaultFederationGroup
-	ft.Spec.FederationVersion = defaultFederationVersion
+	ft.Spec.FederationGroup = DefaultFederationGroup
+	ft.Spec.FederationVersion = DefaultFederationVersion
 }
 
 func NewEnableTypeDirective() *EnableTypeDirective {

--- a/pkg/kubefed2/enable/enable.go
+++ b/pkg/kubefed2/enable/enable.go
@@ -44,8 +44,8 @@ import (
 )
 
 const (
-	defaultFederationGroup   = "types.federation.k8s.io"
-	defaultFederationVersion = "v1alpha1"
+	DefaultFederationGroup   = "types.federation.k8s.io"
+	DefaultFederationVersion = "v1alpha1"
 )
 
 var (
@@ -84,8 +84,8 @@ type enableTypeOptions struct {
 // argument.
 func (o *enableTypeOptions) Bind(flags *pflag.FlagSet) {
 	flags.StringVar(&o.targetVersion, "version", "", "Optional, the API version of the target type.")
-	flags.StringVar(&o.federationGroup, "federation-group", defaultFederationGroup, "The name of the API group to use for the generated federation type.")
-	flags.StringVar(&o.federationVersion, "federation-version", defaultFederationVersion, "The API version to use for the generated federation type.")
+	flags.StringVar(&o.federationGroup, "federation-group", DefaultFederationGroup, "The name of the API group to use for the generated federation type.")
+	flags.StringVar(&o.federationVersion, "federation-version", DefaultFederationVersion, "The API version to use for the generated federation type.")
 	flags.StringVarP(&o.output, "output", "o", "", "If provided, the resources that would be created in the API by the command are instead output to stdout in the provided format.  Valid values are ['yaml'].")
 	flags.StringVarP(&o.filename, "filename", "f", "", "If provided, the command will be configured from the provided yaml file.  Only --output will be accepted from the command line")
 }

--- a/test/e2e/crd.go
+++ b/test/e2e/crd.go
@@ -81,12 +81,13 @@ var _ = Describe("Federated CRD resources", func() {
 func validateCrdCrud(f framework.FederationFramework, targetCrdKind string, namespaced bool) {
 	tl := framework.NewE2ELogger()
 
-	group := "example.com"
-	version := "v1alpha1"
-
 	targetAPIResource := metav1.APIResource{
-		Group:      group,
-		Version:    version,
+		// Need to reuse a group and version for which the helm chart
+		// is granted rbac permissions for.  The default group and
+		// version used by `kubefed2 enable` meets this criteria.
+		Group:   kfenable.DefaultFederationGroup,
+		Version: kfenable.DefaultFederationVersion,
+
 		Kind:       targetCrdKind,
 		Name:       fedv1a1.PluralName(targetCrdKind),
 		Namespaced: namespaced,


### PR DESCRIPTION
Previously the crd e2e test was using a random group/version, but this was breaking a helm deploy that was granted only selective permissions.  Switching to the default group/version used by enable ensures the test will always have sufficient privileges to run.

This PR is now in support of #710.