### PR TITLE
Fix binary name break in scripts/imagebuild.sh

### DIFF
--- a/scripts/imagebuild.sh
+++ b/scripts/imagebuild.sh
@@ -21,7 +21,7 @@ set -o pipefail
 base_dir="$(cd "$(dirname "$0")/.." ; pwd)"
 dockerfile_dir="${base_dir}/images/federation-v2"
 
-[ -f "$base_dir/bin/hyperfed" ] || { echo "$base_dir/bin/hyperfed not found" ; exit 1 ;}
+[ -f "$base_dir/bin/hyperfed-linux" ] || { echo "$base_dir/bin/hyperfed-linux not found" ; exit 1 ;}
 echo "travis tag: ${TRAVIS_TAG}"
 echo "travis branch:${TRAVIS_BRANCH}"
 if [[ "${TRAVIS_TAG}" =~ ^v([0-9]\.)+([0-9])[-a-zA-Z0-9]*([.0-9])* ]]; then
@@ -42,7 +42,7 @@ export REGISTRY=quay.io/
 export REPO=kubernetes-multicluster
 
 echo "Copy hyperfed"
-cp ${base_dir}/bin/hyperfed ${dockerfile_dir}/hyperfed
+cp ${base_dir}/bin/hyperfed-linux ${dockerfile_dir}/hyperfed
 
 echo "Logging into registry ${REGISTRY///}"
 docker login -u "${QUAY_USERNAME}" -p "${QUAY_PASSWORD}" quay.io


### PR DESCRIPTION
In the 0.0.7 release, the binary name built in CI changed from `hyperfed` to `hyperfed-linux`. This broke the imagebuild.sh script that pushes to quay during a release; this PR makes a tactical fix to that script. Longer term, we should just run a make command to build and push the image to reduce the risk of name changes causing future breaks.