### PR TITLE
make federation-role has enough permission for namespaced deployment

### DIFF
--- a/charts/federation-v2/charts/controllermanager/templates/role.yaml
+++ b/charts/federation-v2/charts/controllermanager/templates/role.yaml
@@ -14,29 +14,53 @@ rules:
   resources:
   - '*'
   verbs:
-  - '*'
+  - get
+  - watch
+  - list
+  - update
 - apiGroups:
   - multiclusterdns.federation.k8s.io
   resources:
   - '*'
   verbs:
-  - '*'
+  - get
+  - watch
+  - list
+  - create
+  - update
 - apiGroups:
   - core.federation.k8s.io
   resources:
   - '*'
   verbs:
-  - '*'
+  - get
+  - watch
+  - list
+  - create
+  - update
 - apiGroups:
   - types.federation.k8s.io
   resources:
   - '*'
   verbs:
-  - '*'
+  - get
+  - watch
+  - list
+  - update
 - apiGroups:
   - clusterregistry.k8s.io
   resources:
-  - '*'
+  - clusters
   verbs:
-  - '*'
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - secrets
+  - events
+  verbs:
+  - get
+  - create
+  - update
 {{- end }}

--- a/scripts/deploy-federation.sh
+++ b/scripts/deploy-federation.sh
@@ -190,17 +190,19 @@ if [[ ! "${NAMESPACED}" ]]; then
   fi
 fi
 
+USE_CHART="${USE_CHART:-}"
 # Create a permissive clusterrolebinding to allow federation controllers to run.
 if [[ "${NAMESPACED}" ]]; then
-  # TODO(marun) Investigate why cluster-admin is required to view cluster registry clusters in a namespace
-  kubectl -n "${NS}" create rolebinding federation-admin --clusterrole=cluster-admin --serviceaccount="${NS}:default"
+  if [[ ! "${USE_CHART}" ]]; then
+    # TODO(marun) Investigate why cluster-admin is required to view cluster registry clusters in a namespace
+    kubectl -n "${NS}" create rolebinding federation-admin --clusterrole=cluster-admin --serviceaccount="${NS}:default"
+  fi
 else
   # TODO(marun) Make this more restrictive.
   kubectl create clusterrolebinding federation-admin --clusterrole=cluster-admin --serviceaccount="${NS}:default"
 fi
 
 # Deploy federation resources
-USE_CHART="${USE_CHART:-}"
 if [[ "${USE_CHART}" ]]; then
   deploy-with-helm
 else


### PR DESCRIPTION
cluster-admin is removed for the controller role binding in https://github.com/kubernetes-sigs/federation-v2/pull/673

However, namespaced permission is not set correctly to have permission to access `configmaps`, `secrets`, `events` for controller-manager functions.
I just make it has consist rule with clusterrole.

@marun 