### PR TITLE
e2eLogger: Make the summary a little more useful

### DIFF
--- a/test/e2e/framework/logger.go
+++ b/test/e2e/framework/logger.go
@@ -32,11 +32,11 @@ func (e2eLogger) Errorf(format string, args ...interface{}) {
 
 func (e2eLogger) Fatal(args ...interface{}) {
 	// TODO(marun) Is there a nicer way to do this?
-	Failf("%v", args)
+	FailfWithOffset(1, "%v", args)
 }
 
 func (e2eLogger) Fatalf(format string, args ...interface{}) {
-	Failf(format, args...)
+	FailfWithOffset(1, format, args...)
 }
 
 func (e2eLogger) Log(args ...interface{}) {


### PR DESCRIPTION
Show where it failed in the summary, instead of always showing logger.go.

Before:
	[Fail] Federated "namespaces" [It] should be created, read, updated and deleted successfully
	/home/ubuntu/go/src/github.com/kubernetes-sigs/federation-v2/test/e2e/framework/logger.go:39

After:
	[Fail] Federated "namespaces" [It] should be created, read, updated and deleted successfully
	/home/ubuntu/go/src/github.com/kubernetes-sigs/federation-v2/test/common/crudtester.go:339