### PR TITLE
Update kind to 0.2.0

### DIFF
--- a/scripts/create-clusters.sh
+++ b/scripts/create-clusters.sh
@@ -88,8 +88,7 @@ function create-clusters() {
   local num_clusters=${1}
 
   for i in $(seq ${num_clusters}); do
-    # kind will create cluster with name: kind-${i}
-    kind create cluster --name ${i}
+    kind create cluster --name "cluster${i}"
     # TODO(font): remove once all workarounds are addressed.
     fixup-cluster ${i}
     echo
@@ -114,22 +113,24 @@ function create-clusters() {
 function fixup-cluster() {
   local i=${1} # cluster num
 
-  local kubeconfig_path="$(kind get kubeconfig-path --name ${i})"
+  local kubeconfig_path="$(kind get kubeconfig-path --name cluster${i})"
   export KUBECONFIG="${KUBECONFIG:-}:${kubeconfig_path}"
 
   # Simplify context name
-  kubectl config rename-context kubernetes-admin@kind-${i} cluster${i}
+  kubectl config rename-context "kubernetes-admin@cluster${i}" "cluster${i}"
 
   # TODO(font): Need to set container IP address in order for clusters to reach
   # kube API servers in other clusters until
   # https://github.com/kubernetes-sigs/kind/issues/111 is resolved.
-  local container_ip_addr=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' kind-${i}-control-plane)
-  sed -i "s/localhost/${container_ip_addr}/" ${kubeconfig_path}
+  local container_ip_addr=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' cluster${i}-control-plane)
+  # Using the container ip allows the use of port 6443 instead of the
+  # random port intended to be exposed on localhost.
+  sed -i "s/localhost.*$/${container_ip_addr}:6443/" ${kubeconfig_path}
 
   # TODO(font): Need to rename auth user name to avoid conflicts when using
   # multiple cluster kubeconfigs. Remove once
   # https://github.com/kubernetes-sigs/kind/issues/112 is resolved.
-  sed -i "s/kubernetes-admin/kubernetes-kind-${i}-admin/" ${kubeconfig_path}
+  sed -i "s/kubernetes-admin/kubernetes-cluster${i}-admin/" ${kubeconfig_path}
 }
 
 function check-clusters-ready() {
@@ -139,7 +140,7 @@ function check-clusters-ready() {
 }
 
 function configure-insecure-registry-on-cluster() {
-  configure-insecure-registry-and-reload "docker exec kind-${1}-control-plane bash -c" '$(pgrep dockerd)'
+  configure-insecure-registry-and-reload "docker exec cluster${1}-control-plane bash -c" '$(pgrep dockerd)'
 }
 
 if [[ "${CREATE_INSECURE_REGISTRY}" ]]; then

--- a/scripts/delete-clusters.sh
+++ b/scripts/delete-clusters.sh
@@ -33,9 +33,7 @@ function delete-clusters() {
   local num_clusters=${1}
 
   for i in $(seq ${num_clusters}); do
-    # kind will delete cluster with name: kind-${i}
-    echo "Deleting cluster ${i} ..."
-    kind delete cluster --name ${i}
+    kind delete cluster --name cluster${i}
   done
 }
 

--- a/scripts/download-e2e-binaries.sh
+++ b/scripts/download-e2e-binaries.sh
@@ -30,22 +30,17 @@ trap 'logEnd $?' EXIT
 
 echo "About to download some binaries. This might take a while..."
 
-GOPATH=$(go env GOPATH)
-GOBIN="${GOPATH}/bin"
+root_dir="$(cd "$(dirname "$0")/.." ; pwd)"
+dest_dir="${root_dir}/bin"
+mkdir -p "${dest_dir}"
 
 # kind
-# TODO(font): kind does not have versioning yet.
-kind_version="4d7dded365359afeb1831292cd1a3a3e15fff0b2"
-kind_bin="kind"
-kind_url="sigs.k8s.io"
-go get -d ${kind_url}/${kind_bin}
-pushd ${GOPATH}/src/${kind_url}/${kind_bin}
-git checkout ${kind_version}
-popd
-go install ${kind_url}/${kind_bin}
+kind_version="0.2.0"
+kind_path="${dest_dir}/kind"
+kind_url="https://github.com/kubernetes-sigs/kind/releases/download/${kind_version}/kind-linux-amd64"
+curl -Lo "${kind_path}" "${kind_url}" && chmod +x "${kind_path}"
 
 # Pull the busybox image (used in tests of workload types)
 docker pull busybox
 
-echo    "# bin destination:    ${GOBIN}"
-echo    "# kind installation:  ${GOBIN}/kind"
+echo    "# kind installation:  ${kind_path}"


### PR DESCRIPTION
Part of the fix for #699

`kind create cluster` now respects the name provided rather than always prefixing with `kind-`, so this PR has changed the way names are handled.