### PR TITLE
Simplify placement computation

### DIFF
--- a/pkg/controller/sync/placement_test.go
+++ b/pkg/controller/sync/placement_test.go
@@ -22,6 +22,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	fedv1a1 "github.com/kubernetes-sigs/federation-v2/pkg/apis/core/v1alpha1"
 	"github.com/kubernetes-sigs/federation-v2/pkg/controller/util"
@@ -47,28 +48,25 @@ func TestSelectedClusterNames(t *testing.T) {
 	testCases := map[string]struct {
 		clusterNames    []string
 		clusterSelector map[string]string
-		expectedNames   []string
+		expectedNames   sets.String
 	}{
 		"ignore cluster selector when cluster names present": {
 			clusterNames:    []string{"cluster1"},
 			clusterSelector: map[string]string{},
-			expectedNames:   []string{"cluster1"},
+			expectedNames:   sets.NewString("cluster1"),
 		},
 		"no clusters when cluster names and selector absent": {
-			expectedNames: []string{},
+			expectedNames: sets.NewString(),
 		},
 		"all clusters when cluster names absent and selector empty": {
 			clusterSelector: map[string]string{},
-			expectedNames: []string{
-				"cluster1",
-				"cluster2",
-			},
+			expectedNames:   sets.NewString("cluster1", "cluster2"),
 		},
 		"selected clusters when cluster names absent and selector not empty": {
 			clusterSelector: map[string]string{
 				"foo": "bar",
 			},
-			expectedNames: []string{"cluster2"},
+			expectedNames: sets.NewString("cluster2"),
 		},
 	}
 

--- a/pkg/controller/sync/resource.go
+++ b/pkg/controller/sync/resource.go
@@ -45,7 +45,7 @@ type FederatedResource interface {
 	GetVersions() (map[string]string, error)
 	UpdateVersions(selectedClusters []string, versionMap map[string]string) error
 	DeleteVersions()
-	ComputePlacement(clusters []*fedv1a1.FederatedCluster) (selectedClusters, unselectedClusters []string, err error)
+	ComputePlacement(clusters []*fedv1a1.FederatedCluster) (selectedClusters sets.String, err error)
 	SkipClusterChange(clusterObj pkgruntime.Object) bool
 	ObjectForCluster(clusterName string) (*unstructured.Unstructured, error)
 	MarkedForDeletion() bool
@@ -106,7 +106,7 @@ func (r *federatedResource) DeleteVersions() {
 	r.versionManager.Delete(r.federatedName)
 }
 
-func (r *federatedResource) ComputePlacement(clusters []*fedv1a1.FederatedCluster) ([]string, []string, error) {
+func (r *federatedResource) ComputePlacement(clusters []*fedv1a1.FederatedCluster) (sets.String, error) {
 	if r.typeConfig.GetNamespaced() {
 		return computeNamespacedPlacement(r.federatedResource, r.fedNamespace, clusters, r.limitedScope)
 	}


### PR DESCRIPTION
Placement computation is updated to return a set of the selected clusters rather than slices of both selected and unselected clusters.  This is in anticipation of collapsing the current sync loops for add/update and deletion into a single sync loop.

2nd in a series targeting #612