### PR TITLE
make federation-role has enough permission for cluster-scope federation deployment

### DIFF
--- a/charts/federation-v2/charts/controllermanager/templates/clusterrole.yaml
+++ b/charts/federation-v2/charts/controllermanager/templates/clusterrole.yaml
@@ -13,35 +13,57 @@ rules:
   resources:
   - '*'
   verbs:
-  - '*'
+  - get
+  - watch
+  - list
+  - update
 - apiGroups:
   - multiclusterdns.federation.k8s.io
   resources:
   - '*'
   verbs:
-  - '*'
+  - get
+  - watch
+  - list
+  - create
+  - update
+  - delete
 - apiGroups:
   - core.federation.k8s.io
   resources:
   - '*'
   verbs:
-  - '*'
+  - get
+  - watch
+  - list
+  - create
+  - update
 - apiGroups:
   - types.federation.k8s.io
   resources:
   - '*'
   verbs:
-  - '*'
+  - get
+  - watch
+  - list
+  - update
 - apiGroups:
   - clusterregistry.k8s.io
   resources:
-  - '*'
+  - clusters
   verbs:
-  - '*'
+  - get
 - apiGroups:
   - ""
   resources:
-  - '*'
+  - configmaps
+  - secrets
+  - events
+  - namespaces
   verbs:
-  - '*'
+  - get
+  - watch
+  - list
+  - create
+  - update
 {{- end }}


### PR DESCRIPTION
cluster-admin is removed for the controller role binding in #673

However,  permission is not set correctly to have permission to make controller work.

- [ ] document update to tell `CRD` federation needs RBAC