### PR TITLE
Refactor sync controller reconcile loop

### DIFF
--- a/pkg/controller/sync/accessor.go
+++ b/pkg/controller/sync/accessor.go
@@ -47,6 +47,9 @@ type resourceAccessor struct {
 	targetIsNamespace bool
 	fedNamespace      string
 
+	// The informer for target types in the member clusters
+	federatedInformer util.FederatedInformer
+
 	// The informer for the federated type.
 	federatedStore      cache.Store
 	federatedController cache.Controller
@@ -92,6 +95,7 @@ func NewFederatedResourceAccessor(
 		fedNamespace:            controllerConfig.FederationNamespace,
 		fedNamespaceAPIResource: fedNamespaceAPIResource,
 		eventRecorder:           eventRecorder,
+		federatedInformer:       informer,
 	}
 
 	targetNamespace := controllerConfig.TargetNamespace
@@ -286,6 +290,7 @@ func (a *resourceAccessor) FederatedResource(eventSource util.QualifiedName) (Fe
 		namespace:         namespace,
 		fedNamespace:      fedNamespace,
 		eventRecorder:     a.eventRecorder,
+		informer:          a.federatedInformer,
 	}, nil
 }
 

--- a/pkg/controller/sync/accessor.go
+++ b/pkg/controller/sync/accessor.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	pkgruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/record"
 
 	"github.com/kubernetes-sigs/federation-v2/pkg/apis/core/typeconfig"
 	genericclient "github.com/kubernetes-sigs/federation-v2/pkg/client/generic"
@@ -69,6 +70,9 @@ type resourceAccessor struct {
 
 	// Adds finalizers to resources and performs cleanup of target resources.
 	deletionHelper *deletionhelper.DeletionHelper
+
+	// Records events on the federated resource
+	eventRecorder record.EventRecorder
 }
 
 func NewFederatedResourceAccessor(
@@ -78,7 +82,8 @@ func NewFederatedResourceAccessor(
 	client genericclient.Client,
 	enqueueObj func(pkgruntime.Object),
 	informer util.FederatedInformer,
-	updater util.FederatedUpdater) (FederatedResourceAccessor, error) {
+	updater util.FederatedUpdater,
+	eventRecorder record.EventRecorder) (FederatedResourceAccessor, error) {
 
 	a := &resourceAccessor{
 		limitedScope:            controllerConfig.LimitedScope(),
@@ -86,6 +91,7 @@ func NewFederatedResourceAccessor(
 		targetIsNamespace:       typeConfig.GetTarget().Kind == util.NamespaceKind,
 		fedNamespace:            controllerConfig.FederationNamespace,
 		fedNamespaceAPIResource: fedNamespaceAPIResource,
+		eventRecorder:           eventRecorder,
 	}
 
 	targetNamespace := controllerConfig.TargetNamespace
@@ -279,6 +285,7 @@ func (a *resourceAccessor) FederatedResource(eventSource util.QualifiedName) (Fe
 		deletionHelper:    a.deletionHelper,
 		namespace:         namespace,
 		fedNamespace:      fedNamespace,
+		eventRecorder:     a.eventRecorder,
 	}, nil
 }
 

--- a/pkg/controller/sync/controller.go
+++ b/pkg/controller/sync/controller.go
@@ -242,15 +242,17 @@ func (s *FederationSyncController) reconcile(qualifiedName util.QualifiedName) u
 		return util.StatusNotSynced
 	}
 
+	kind := s.typeConfig.GetFederatedType().Kind
+
 	fedResource, err := s.fedAccessor.FederatedResource(qualifiedName)
 	if err != nil {
+		runtime.HandleError(errors.Wrapf(err, "Error creating FederatedResource helper for %s %q", kind, qualifiedName))
 		return util.StatusError
 	}
 	if fedResource == nil {
 		return util.StatusAllOK
 	}
 
-	kind := s.typeConfig.GetFederatedType().Kind
 	key := fedResource.FederatedName().String()
 
 	glog.V(4).Infof("Starting to reconcile %s %q", kind, key)

--- a/pkg/controller/sync/controller.go
+++ b/pkg/controller/sync/controller.go
@@ -167,7 +167,7 @@ func newFederationSyncController(controllerConfig *util.ControllerConfig, typeCo
 
 	s.fedAccessor, err = NewFederatedResourceAccessor(
 		controllerConfig, typeConfig, fedNamespaceAPIResource,
-		client, s.worker.EnqueueObject, s.informer, s.updater)
+		client, s.worker.EnqueueObject, s.informer, s.updater, recorder)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/sync/updater.go
+++ b/pkg/controller/sync/updater.go
@@ -1,0 +1,221 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sync
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/pkg/errors"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/kubernetes-sigs/federation-v2/pkg/controller/util"
+)
+
+type FederatedUpdater interface {
+	NoChanges() bool
+	Wait() (map[string]string, bool)
+
+	Create(clusterName string)
+	Update(clusterName string, clusterObj *unstructured.Unstructured)
+	Delete(clusterName string)
+}
+
+type updaterResult struct {
+	clusterName string
+	version     string
+	ok          bool
+}
+
+type federatedUpdaterImpl struct {
+	sync.RWMutex
+
+	fedView util.FederationView
+
+	fedResource FederatedResource
+
+	resultChan     chan updaterResult
+	operationCount int
+
+	timeout time.Duration
+}
+
+func NewFederatedUpdater(fedView util.FederationView, fedResource FederatedResource) FederatedUpdater {
+	return &federatedUpdaterImpl{
+		fedView:     fedView,
+		fedResource: fedResource,
+		resultChan:  make(chan updaterResult),
+		timeout:     30 * time.Second, // TODO(marun) Make this configurable
+	}
+}
+
+func (u *federatedUpdaterImpl) NoChanges() bool {
+	return u.operationCount == 0
+}
+
+func (u *federatedUpdaterImpl) Wait() (map[string]string, bool) {
+	versions := make(map[string]string)
+	ok := true
+
+	timedOut := false
+	start := time.Now()
+	for i := 0; i < u.operationCount; i++ {
+		now := time.Now()
+		if !now.Before(start.Add(u.timeout)) {
+			timedOut = true
+			break
+		}
+		select {
+		case result := <-u.resultChan:
+			if !result.ok {
+				ok = false
+				break
+			}
+			if len(result.version) > 0 {
+				versions[result.clusterName] = result.version
+			}
+		case <-time.After(start.Add(u.timeout).Sub(now)):
+			timedOut = true
+			break
+		}
+	}
+	if timedOut {
+		ok = false
+		u.fedResource.RecordError("OperationTimeoutError", errors.Errorf("Failed to finish all operations in %v", u.timeout))
+	}
+
+	return versions, ok
+}
+
+func (u *federatedUpdaterImpl) Create(clusterName string) {
+	u.operationCount += 1
+	const op = "create"
+	go u.clusterOperation(clusterName, op, func(client util.ResourceClient) (string, error) {
+		u.recordEvent(clusterName, op, "Creating")
+
+		obj, err := u.fedResource.ObjectForCluster(clusterName)
+		if err != nil {
+			return "", err
+		}
+		createdObj, err := client.Resources(obj.GetNamespace()).Create(obj, metav1.CreateOptions{})
+		if err != nil {
+			return "", err
+		}
+		return util.ObjectVersion(createdObj), err
+	})
+}
+
+func (u *federatedUpdaterImpl) Update(clusterName string, clusterObj *unstructured.Unstructured) {
+	u.operationCount += 1
+	const op = "update"
+	go u.clusterOperation(clusterName, op, func(client util.ResourceClient) (string, error) {
+		obj, err := u.fedResource.ObjectForCluster(clusterName)
+		if err != nil {
+			return "", err
+		}
+		err = RetainClusterFields(u.fedResource.TargetKind(), obj, clusterObj, u.fedResource.Object())
+		if err != nil {
+			wrappedErr := errors.Wrapf(err, "Failed to retain fields from %s %q for cluster %q",
+				u.fedResource.FederatedKind(), u.fedResource.FederatedName(), clusterName)
+			return "", wrappedErr
+		}
+
+		version, err := u.fedResource.VersionForCluster(clusterName)
+		if err != nil {
+			return "", err
+		}
+		if !util.ObjectNeedsUpdate(obj, clusterObj, version) {
+			// Resource is current
+			return "", nil
+		}
+
+		// Only record an event if the resource is not current
+		u.recordEvent(clusterName, op, "Updating")
+
+		updatedObj, err := client.Resources(obj.GetNamespace()).Update(obj, metav1.UpdateOptions{})
+		if err != nil {
+			return "", err
+		}
+		return util.ObjectVersion(updatedObj), nil
+	})
+}
+
+func (u *federatedUpdaterImpl) Delete(clusterName string) {
+	u.operationCount += 1
+	const op = "delete"
+	go u.clusterOperation(clusterName, op, func(client util.ResourceClient) (string, error) {
+		u.recordEvent(clusterName, op, "Deleting")
+
+		qualifiedName := u.fedResource.TargetName()
+		err := client.Resources(qualifiedName.Namespace).Delete(qualifiedName.Name, &metav1.DeleteOptions{})
+		if apierrors.IsNotFound(err) {
+			err = nil
+		}
+		return "", err
+	})
+}
+
+func (u *federatedUpdaterImpl) clusterOperation(clusterName, op string, opFunc func(util.ResourceClient) (string, error)) {
+	result := updaterResult{
+		clusterName: clusterName,
+		ok:          true,
+	}
+
+	// TODO(marun) Update to generic client and support cancellation
+	// on timeout.
+	client, err := u.fedView.GetClientForCluster(clusterName)
+	if err != nil {
+		u.recordError(clusterName, op, errors.Wrapf(err, "Error retrieving client for cluster"))
+		result.ok = false
+		u.resultChan <- result
+		return
+	}
+
+	// TODO(marun) Retry on recoverable errors (e.g. IsConflict, AlreadyExists)
+	version, err := opFunc(client)
+	if err != nil {
+		u.recordError(clusterName, op, err)
+		result.ok = false
+	}
+	result.version = version
+	u.resultChan <- result
+}
+
+func (u *federatedUpdaterImpl) recordError(clusterName, operation string, err error) {
+	args := []interface{}{operation, u.fedResource.TargetKind(), u.fedResource.TargetName(), clusterName}
+
+	// TODO(marun) It will be necessary to log rather than record an event when
+	// the federated resource has been deleted.
+
+	eventType := fmt.Sprintf("%sInClusterFailed", strings.Replace(strings.Title(operation), " ", "", -1))
+	u.fedResource.RecordError(eventType, errors.Wrapf(err, "Failed to %s %s %q in cluster %q", args...))
+}
+
+func (u *federatedUpdaterImpl) recordEvent(clusterName, operation, operationContinuous string) {
+	args := []interface{}{operationContinuous, u.fedResource.TargetKind(), u.fedResource.TargetName(), clusterName}
+
+	// TODO(marun) It will be necessary to log rather than record an event when
+	// the federated resource has been deleted.
+
+	eventType := fmt.Sprintf("%sInCluster", strings.Replace(strings.Title(operation), " ", "", -1))
+	u.fedResource.RecordEvent(eventType, "%s %s %q in cluster %q", args...)
+}

--- a/pkg/controller/util/federated_updater.go
+++ b/pkg/controller/util/federated_updater.go
@@ -14,6 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// TODO(marun) Remove this once its use is entirely replaced with the
+// new sync controller updater.
+
 package util
 
 import (


### PR DESCRIPTION
The existing federated updater required that cluster operations be pre-computed.  This complicated the proposal to cleanly implement support for limiting the federation informers to managed resources and then adopt resources as necessary (which would involve converting an add to an update).

This PR refactors the sync controller's reconcile loop and implements a new updater to allow cluster operations to be dispatched individually.  It also ensures that reconciliation events are logged on federated resources where possible.

The current federated updater is left in place for now since the deletion helper is still using it.  Future PRs in this series are intended to rewrite the deletion helper to use the new updater and remove the old federated updater.

3rd in a series targeting #612