### PR TITLE
Switch to having the FederatedNamespace define the template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Unreleased
+ - [#652](https://github.com/kubernetes-sigs/federation-v2/pull/652) -
+   Switch to sourcing the template for a FederatedNamespace from a
+   field rather than the containing namespace.  This ensures
+   uniformity in template handling across all federated types.
  - [#716](https://github.com/kubernetes-sigs/federation-v2/pull/716) -
    Upgrade kubebuilder version to v1.0.8
    - Removed generated typed clients for federation apis from tree.

--- a/charts/federation-v2/templates/crds.yaml
+++ b/charts/federation-v2/templates/crds.yaml
@@ -5344,6 +5344,145 @@ spec:
                       type: object
                   type: object
               type: object
+            template:
+              properties:
+                apiVersion:
+                  type: string
+                kind:
+                  type: string
+                metadata:
+                  properties:
+                    annotations:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    clusterName:
+                      type: string
+                    creationTimestamp:
+                      format: date-time
+                      type: string
+                    deletionGracePeriodSeconds:
+                      format: int64
+                      type: integer
+                    deletionTimestamp:
+                      format: date-time
+                      type: string
+                    finalizers:
+                      items:
+                        type: string
+                      type: array
+                    generateName:
+                      type: string
+                    generation:
+                      format: int64
+                      type: integer
+                    initializers:
+                      properties:
+                        pending:
+                          items:
+                            properties:
+                              name:
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          type: array
+                        result:
+                          properties:
+                            apiVersion:
+                              type: string
+                            code:
+                              format: int32
+                              type: integer
+                            details:
+                              properties:
+                                causes:
+                                  items:
+                                    properties:
+                                      field:
+                                        type: string
+                                      message:
+                                        type: string
+                                      reason:
+                                        type: string
+                                    type: object
+                                  type: array
+                                group:
+                                  type: string
+                                kind:
+                                  type: string
+                                name:
+                                  type: string
+                                retryAfterSeconds:
+                                  format: int32
+                                  type: integer
+                                uid:
+                                  type: string
+                              type: object
+                            kind:
+                              type: string
+                            message:
+                              type: string
+                            metadata:
+                              properties:
+                                continue:
+                                  type: string
+                                resourceVersion:
+                                  type: string
+                                selfLink:
+                                  type: string
+                              type: object
+                            reason:
+                              type: string
+                          type: object
+                      required:
+                      - pending
+                      type: object
+                    labels:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    name:
+                      type: string
+                    namespace:
+                      type: string
+                    ownerReferences:
+                      items:
+                        properties:
+                          apiVersion:
+                            type: string
+                          blockOwnerDeletion:
+                            type: boolean
+                          controller:
+                            type: boolean
+                          kind:
+                            type: string
+                          name:
+                            type: string
+                          uid:
+                            type: string
+                        required:
+                        - apiVersion
+                        - kind
+                        - name
+                        - uid
+                        type: object
+                      type: array
+                    resourceVersion:
+                      type: string
+                    selfLink:
+                      type: string
+                    uid:
+                      type: string
+                  type: object
+                spec:
+                  properties:
+                    finalizers:
+                      items:
+                        type: string
+                      type: array
+                  type: object
+              type: object
           type: object
   version: v1alpha1
 ---

--- a/pkg/controller/sync/controller.go
+++ b/pkg/controller/sync/controller.go
@@ -330,7 +330,7 @@ func (s *FederationSyncController) syncToClusters(fedResource FederatedResource,
 
 		// Resource should not exist in the named cluster
 		if !selectedClusterNames.Has(clusterName) {
-			if clusterObj != nil && !fedResource.SkipClusterChange(clusterObj) {
+			if clusterObj != nil && !fedResource.SkipClusterDeletion(clusterObj) {
 				updater.Delete(clusterName)
 			}
 			continue

--- a/pkg/controller/sync/controller.go
+++ b/pkg/controller/sync/controller.go
@@ -328,13 +328,9 @@ func (s *FederationSyncController) syncToClusters(fedResource FederatedResource,
 			clusterObj = rawClusterObj.(*unstructured.Unstructured)
 		}
 
-		if clusterObj != nil && fedResource.SkipClusterChange(clusterObj) {
-			continue
-		}
-
 		// Resource should not exist in the named cluster
 		if !selectedClusterNames.Has(clusterName) {
-			if clusterObj != nil {
+			if clusterObj != nil && !fedResource.SkipClusterChange(clusterObj) {
 				updater.Delete(clusterName)
 			}
 			continue

--- a/pkg/controller/sync/resource_test.go
+++ b/pkg/controller/sync/resource_test.go
@@ -37,7 +37,7 @@ spec:
 	if err != nil {
 		t.Fatalf("An unexpected error occurred: %v", err)
 	}
-	hash, err := GetTemplateHash(template.Object, false)
+	hash, err := GetTemplateHash(template.Object)
 	if err != nil {
 		t.Fatalf("An unexpected error occurred: %v", err)
 	}

--- a/pkg/kubefed2/enable/enable.go
+++ b/pkg/kubefed2/enable/enable.go
@@ -38,7 +38,6 @@ import (
 	"github.com/kubernetes-sigs/federation-v2/pkg/apis/core/typeconfig"
 	fedv1a1 "github.com/kubernetes-sigs/federation-v2/pkg/apis/core/v1alpha1"
 	genericclient "github.com/kubernetes-sigs/federation-v2/pkg/client/generic"
-	ctlutil "github.com/kubernetes-sigs/federation-v2/pkg/controller/util"
 	"github.com/kubernetes-sigs/federation-v2/pkg/kubefed2/options"
 	"github.com/kubernetes-sigs/federation-v2/pkg/kubefed2/util"
 )
@@ -316,15 +315,8 @@ func typeConfigForTarget(apiResource metav1.APIResource, enableTypeDirective *En
 
 func federatedTypeCRD(typeConfig typeconfig.Interface, accessor schemaAccessor, shortNames []string) *apiextv1b1.CustomResourceDefinition {
 	var templateSchema map[string]apiextv1b1.JSONSchemaProps
-	// Define the template field for everything but namespaces.
-	// A FederatedNamespace uses the containing namespace as the
-	// template.
-	if typeConfig.GetTarget().Kind != ctlutil.NamespaceKind {
-		templateSchema = accessor.templateSchema()
-	}
-
+	templateSchema = accessor.templateSchema()
 	schema := federatedTypeValidationSchema(templateSchema)
-
 	return CrdForAPIResource(typeConfig.GetFederatedType(), schema, shortNames)
 }
 

--- a/test/e2e/version.go
+++ b/test/e2e/version.go
@@ -261,7 +261,7 @@ var _ = Describe("VersionManager", func() {
 				fedObject.SetResourceVersion(metaAccessor.GetResourceVersion())
 				fedObjectName = util.NewQualifiedName(fedObject)
 
-				templateVersion, err := sync.GetTemplateHash(fedObject.Object, false)
+				templateVersion, err := sync.GetTemplateHash(fedObject.Object)
 				if err != nil {
 					tl.Fatalf("Failed to determine template version: %v", err)
 				}


### PR DESCRIPTION
Previously the template for a FederatedNamespace namespace was sourced from the containing namespace.  This divergence from the norm of sourcing the template from a field in the federated resource was a source of user confusion.

Fixes #652 

4th in a series targeting #612