### PR TITLE
Only watched managed resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Unreleased
+ - [#549](https://github.com/kubernetes-sigs/federation-v2/pull/549) -
+   As a result of watching only labled resources, unlabled resources
+   in unselected clusters will no longer be deleted.
 
 # v0.0.8
  - [#652](https://github.com/kubernetes-sigs/federation-v2/pull/652) -

--- a/pkg/controller/sync/controller.go
+++ b/pkg/controller/sync/controller.go
@@ -330,8 +330,14 @@ func (s *FederationSyncController) syncToClusters(fedResource FederatedResource,
 
 		// Resource should not exist in the named cluster
 		if !selectedClusterNames.Has(clusterName) {
-			if clusterObj != nil && !fedResource.SkipClusterDeletion(clusterObj) {
-				updater.Delete(clusterName)
+			if clusterObj != nil {
+				if fedResource.IsNamespaceInHostCluster(clusterObj) {
+					// Host cluster namespace needs to have the managed
+					// label removed so it won't be cached anymore.
+					updater.RemoveManagedLabel(clusterName, clusterObj)
+				} else {
+					updater.Delete(clusterName)
+				}
 			}
 			continue
 		}

--- a/pkg/controller/sync/controller.go
+++ b/pkg/controller/sync/controller.go
@@ -365,10 +365,10 @@ func (s *FederationSyncController) syncToClusters(fedResource FederatedResource,
 	// Always attempt to update versions even if the updater reported errors.
 	err = fedResource.UpdateVersions(selectedClusterNames.List(), updatedVersionMap)
 	if err != nil {
-		fedResource.RecordError("VersionUpdateError", errors.Wrapf(err, "Failed to update version status"))
 		// Versioning of federated resources is an optimization to
 		// avoid unnecessary updates, and failure to record version
 		// information does not indicate a failure of propagation.
+		runtime.HandleError(err)
 	}
 
 	return status

--- a/pkg/controller/sync/resource.go
+++ b/pkg/controller/sync/resource.go
@@ -196,6 +196,16 @@ func (r *federatedResource) ObjectForCluster(clusterName string) (*unstructured.
 		}
 	}
 
+	// Ensure that resources managed by federation always have the
+	// managed label.  The label is intended to be targeted by all the
+	// federation controllers.
+	labels := obj.GetLabels()
+	if labels == nil {
+		labels = make(map[string]string)
+	}
+	labels[util.ManagedByFederationLabelKey] = util.ManagedByFederationLabelValue
+	obj.SetLabels(labels)
+
 	return obj, nil
 }
 

--- a/pkg/controller/sync/resource.go
+++ b/pkg/controller/sync/resource.go
@@ -51,7 +51,7 @@ type FederatedResource interface {
 	UpdateVersions(selectedClusters []string, versionMap map[string]string) error
 	DeleteVersions()
 	ComputePlacement(clusters []*fedv1a1.FederatedCluster) (selectedClusters sets.String, err error)
-	SkipClusterDeletion(clusterObj pkgruntime.Object) bool
+	IsNamespaceInHostCluster(clusterObj pkgruntime.Object) bool
 	ObjectForCluster(clusterName string) (*unstructured.Unstructured, error)
 	MarkedForDeletion() bool
 	EnsureDeletion() error
@@ -140,7 +140,11 @@ func (r *federatedResource) ComputePlacement(clusters []*fedv1a1.FederatedCluste
 	return computePlacement(r.federatedResource, clusters)
 }
 
-func (r *federatedResource) SkipClusterDeletion(clusterObj pkgruntime.Object) bool {
+func (r *federatedResource) IsNamespaceInHostCluster(clusterObj pkgruntime.Object) bool {
+	// TODO(marun) This comment should be added to the documentation
+	// and removed from this function (where it is no longer
+	// relevant).
+	//
 	// `Namespace` is the only Kubernetes type that can contain other
 	// types, and adding a federation-specific container type would be
 	// difficult or impossible. This requires that namespaced

--- a/pkg/controller/sync/updater.go
+++ b/pkg/controller/sync/updater.go
@@ -19,7 +19,7 @@ package sync
 import (
 	"fmt"
 	"strings"
-	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/pkg/errors"
@@ -47,14 +47,12 @@ type updaterResult struct {
 }
 
 type federatedUpdaterImpl struct {
-	sync.RWMutex
-
 	fedView util.FederationView
 
 	fedResource FederatedResource
 
 	resultChan     chan updaterResult
-	operationCount int
+	operationCount int32
 
 	timeout time.Duration
 }
@@ -69,7 +67,7 @@ func NewFederatedUpdater(fedView util.FederationView, fedResource FederatedResou
 }
 
 func (u *federatedUpdaterImpl) NoChanges() bool {
-	return u.operationCount == 0
+	return atomic.LoadInt32(&u.operationCount) == 0
 }
 
 func (u *federatedUpdaterImpl) Wait() (map[string]string, bool) {
@@ -78,7 +76,7 @@ func (u *federatedUpdaterImpl) Wait() (map[string]string, bool) {
 
 	timedOut := false
 	start := time.Now()
-	for i := 0; i < u.operationCount; i++ {
+	for i := int32(0); i < atomic.LoadInt32(&u.operationCount); i++ {
 		now := time.Now()
 		if !now.Before(start.Add(u.timeout)) {
 			timedOut = true
@@ -107,7 +105,7 @@ func (u *federatedUpdaterImpl) Wait() (map[string]string, bool) {
 }
 
 func (u *federatedUpdaterImpl) Create(clusterName string) {
-	u.operationCount += 1
+	u.incrementOperationCount()
 	const op = "create"
 	go u.clusterOperation(clusterName, op, func(client util.ResourceClient) (string, error) {
 		u.recordEvent(clusterName, op, "Creating")
@@ -117,15 +115,29 @@ func (u *federatedUpdaterImpl) Create(clusterName string) {
 			return "", err
 		}
 		createdObj, err := client.Resources(obj.GetNamespace()).Create(obj, metav1.CreateOptions{})
-		if err != nil {
+		if err == nil {
+			return util.ObjectVersion(createdObj), nil
+		}
+		// TODO(marun) Figure out why attempting to create a namespace that
+		// already exists indicates ServerTimeout instead of AlreadyExists.
+		alreadyExists := apierrors.IsAlreadyExists(err) || u.fedResource.TargetKind() == util.NamespaceKind && apierrors.IsServerTimeout(err)
+		if !alreadyExists {
 			return "", err
 		}
-		return util.ObjectVersion(createdObj), err
+
+		// Attempt to update the existing resource to ensure that it
+		// is labeled as a managed resource.
+		clusterObj, err := client.Resources(obj.GetNamespace()).Get(obj.GetName(), metav1.GetOptions{})
+		if err != nil {
+			return "", errors.Wrapf(err, "Failed to retrieve object potentially requiring adoption for cluster %q", clusterName)
+		}
+		u.Update(clusterName, clusterObj)
+		return "", errors.Errorf("An update will be attempted instead of a creation due to an existing resource in cluster %q", clusterName)
 	})
 }
 
 func (u *federatedUpdaterImpl) Update(clusterName string, clusterObj *unstructured.Unstructured) {
-	u.operationCount += 1
+	u.incrementOperationCount()
 	const op = "update"
 	go u.clusterOperation(clusterName, op, func(client util.ResourceClient) (string, error) {
 		obj, err := u.fedResource.ObjectForCluster(clusterName)
@@ -160,7 +172,7 @@ func (u *federatedUpdaterImpl) Update(clusterName string, clusterObj *unstructur
 }
 
 func (u *federatedUpdaterImpl) Delete(clusterName string) {
-	u.operationCount += 1
+	u.incrementOperationCount()
 	const op = "delete"
 	go u.clusterOperation(clusterName, op, func(client util.ResourceClient) (string, error) {
 		u.recordEvent(clusterName, op, "Deleting")
@@ -172,6 +184,10 @@ func (u *federatedUpdaterImpl) Delete(clusterName string) {
 		}
 		return "", err
 	})
+}
+
+func (u *federatedUpdaterImpl) incrementOperationCount() {
+	atomic.AddInt32(&u.operationCount, 1)
 }
 
 func (u *federatedUpdaterImpl) clusterOperation(clusterName, op string, opFunc func(util.ResourceClient) (string, error)) {

--- a/pkg/controller/sync/version/manager.go
+++ b/pkg/controller/sync/version/manager.go
@@ -311,6 +311,12 @@ func (m *VersionManager) writeVersion(obj pkgruntime.Object, qualifiedName util.
 				refreshVersion = true
 				return false, nil
 			}
+			// Forbidden is likely to be a permanent failure and
+			// likely the result of the containing namespace being
+			// deleted.
+			if apierrors.IsForbidden(err) {
+				return false, err
+			}
 			if err != nil {
 				runtime.HandleError(errors.Wrapf(err, "Failed to create %s %q", adapterType, key))
 				return false, nil
@@ -368,7 +374,7 @@ func (m *VersionManager) writeVersion(obj pkgruntime.Object, qualifiedName util.
 		return true, nil
 	})
 	if err != nil {
-		return errors.Wrapf(err, "Failed to write the version map for %s %q to the API within %v", adapterType, key, waitDuration)
+		return errors.Wrapf(err, "Failed to write the version map for %s %q to the API", adapterType, key)
 	}
 	return nil
 }

--- a/pkg/controller/util/federated_informer.go
+++ b/pkg/controller/util/federated_informer.go
@@ -140,7 +140,7 @@ func NewFederatedInformer(
 	clusterLifecycle *ClusterLifecycleHandlerFuncs) (FederatedInformer, error) {
 
 	targetInformerFactory := func(cluster *fedv1a1.FederatedCluster, client ResourceClient) (cache.Store, cache.Controller) {
-		return NewResourceInformer(client, config.TargetNamespace, triggerFunc)
+		return NewManagedResourceInformer(client, config.TargetNamespace, triggerFunc)
 	}
 
 	federatedInformer := &federatedInformerImpl{

--- a/test/common/dns.go
+++ b/test/common/dns.go
@@ -64,6 +64,9 @@ func NewServiceObject(name, namespace string) *apiv1.Service {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
+			Labels: map[string]string{
+				util.ManagedByFederationLabelKey: util.ManagedByFederationLabelValue,
+			},
 		},
 		Spec: apiv1.ServiceSpec{
 			Type: apiv1.ServiceTypeLoadBalancer,
@@ -80,6 +83,9 @@ func NewEndpointObject(name, namespace string) *apiv1.Endpoints {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
+			Labels: map[string]string{
+				util.ManagedByFederationLabelKey: util.ManagedByFederationLabelValue,
+			},
 		},
 		Subsets: []apiv1.EndpointSubset{{
 			Addresses: []apiv1.EndpointAddress{{IP: "1.2.3.4"}},
@@ -93,6 +99,9 @@ func NewIngressObject(name, namespace string) *extv1b1.Ingress {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
+			Labels: map[string]string{
+				util.ManagedByFederationLabelKey: util.ManagedByFederationLabelValue,
+			},
 		},
 		Spec: extv1b1.IngressSpec{
 			Rules: []extv1b1.IngressRule{{

--- a/test/e2e/crud.go
+++ b/test/e2e/crud.go
@@ -17,14 +17,20 @@ limitations under the License.
 package e2e
 
 import (
+	"context"
 	"fmt"
 	"strings"
+	"time"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/wait"
+	kubeclientset "k8s.io/client-go/kubernetes"
 
 	"github.com/kubernetes-sigs/federation-v2/pkg/apis/core/typeconfig"
 	genericclient "github.com/kubernetes-sigs/federation-v2/pkg/client/generic"
 	"github.com/kubernetes-sigs/federation-v2/pkg/controller/util"
+	"github.com/kubernetes-sigs/federation-v2/pkg/kubefed2/federate"
 	"github.com/kubernetes-sigs/federation-v2/test/common"
 	"github.com/kubernetes-sigs/federation-v2/test/e2e/framework"
 
@@ -49,43 +55,119 @@ var _ = Describe("Federated", func() {
 		fixture := typeConfigFixtures[key]
 		Describe(fmt.Sprintf("%q", typeConfigName), func() {
 			It("should be created, read, updated and deleted successfully", func() {
-				// Lookup the type config from the api
-				client, err := genericclient.New(f.KubeConfig())
-				if err != nil {
-					tl.Fatalf("Error initializing dynamic client: %v", err)
-				}
-				typeConfig, err := common.GetTypeConfig(client, typeConfigName, f.FederationSystemNamespace())
-				if err != nil {
-					tl.Fatalf("Error retrieving federatedtypeconfig %q: %v", typeConfigName, err)
-				}
-
-				if framework.TestContext.LimitedScope && !typeConfig.GetNamespaced() {
-					framework.Skipf("Federation of cluster-scoped type %s is not supported by a namespaced control plane.", typeConfigName)
-				}
-
-				testObjectsFunc := func(namespace string, clusterNames []string) (*unstructured.Unstructured, []interface{}, error) {
-					targetObject, err := common.NewTestTargetObject(typeConfig, namespace, fixture)
-					if err != nil {
-						return nil, nil, err
-					}
-					if typeConfig.GetTarget().Kind == util.NamespaceKind {
-						// Namespace crud testing needs to have the same name as its namespace.
-						targetObject.SetName(namespace)
-						targetObject.SetNamespace(namespace)
-					}
-					overrides, err := common.OverridesFromFixture(clusterNames, fixture)
-					if err != nil {
-						return nil, nil, err
-					}
-					return targetObject, overrides, err
-				}
-
+				typeConfig, testObjectsFunc := getCrudTestInput(f, tl, typeConfigName, fixture)
 				crudTester, targetObject, overrides := initCrudTest(f, tl, typeConfig, testObjectsFunc)
 				crudTester.CheckLifecycle(targetObject, overrides)
+			})
+
+			// Unlabeled resource handling behavior should not vary between
+			// types, so testing a single type is sufficient.  Picking a
+			// namespaced type minimizes the impact of teardown failure.
+			if typeConfigName != "configmaps" {
+				return
+			}
+
+			It("should not be deleted if unlabeled", func() {
+				typeConfig, testObjectsFunc := getCrudTestInput(f, tl, typeConfigName, fixture)
+				crudTester, targetObject, _ := initCrudTest(f, tl, typeConfig, testObjectsFunc)
+
+				testClusters := crudTester.TestClusters()
+
+				By("Selecting a member cluster to create an unlabeled resource in")
+				clusterName := ""
+				for key := range testClusters {
+					clusterName = key
+					break
+				}
+				clusterConfig := testClusters[clusterName].Config
+
+				By("Waiting for the test namespace to be created in the selected cluster")
+				kubeClient := kubeclientset.NewForConfigOrDie(clusterConfig)
+				common.WaitForNamespaceOrDie(tl, kubeClient, clusterName, targetObject.GetNamespace(),
+					framework.PollInterval, framework.TestContext.SingleCallTimeout)
+
+				By("Creating an unlabeled resource in the selected cluster")
+				unlabeledObj, err := common.CreateResource(clusterConfig, typeConfig.GetTarget(), targetObject)
+				if err != nil {
+					tl.Fatalf("Failed to create unlabeled resource in cluster %q: %v", clusterName, err)
+				}
+				clusterClient := genericclient.NewForConfigOrDie(clusterConfig)
+				defer clusterClient.Delete(context.TODO(), unlabeledObj, unlabeledObj.GetNamespace(), unlabeledObj.GetName())
+
+				By("Intitializing a federated resource with placement excluding all clusters")
+				fedObject, err := federate.FederatedResourceFromTargetResource(typeConfig, unlabeledObj)
+				if err != nil {
+					tl.Fatalf("Error generating federated resource: %v", err)
+				}
+				err = util.SetClusterNames(fedObject, []string{})
+				if err != nil {
+					tl.Fatalf("Error setting cluster names for federated resource: %v", err)
+				}
+				fedObject.SetGenerateName("")
+
+				By("Creating the federated resource")
+				createdObj, err := common.CreateResource(f.KubeConfig(), typeConfig.GetFederatedType(), fedObject)
+				if err != nil {
+					tl.Fatalf("Error creating federated resource: %v", err)
+				}
+				hostClient := genericclient.NewForConfigOrDie(f.KubeConfig())
+				defer hostClient.Delete(context.TODO(), createdObj, createdObj.GetNamespace(), createdObj.GetName())
+
+				waitDuration := 10 * time.Second // Arbitrary amount of time to wait for deletion
+				By(fmt.Sprintf("Checking that the unlabeled resource is not deleted within %v", waitDuration))
+				wait.PollImmediate(framework.PollInterval, waitDuration, func() (bool, error) {
+					obj := &unstructured.Unstructured{}
+					obj.SetGroupVersionKind(unlabeledObj.GroupVersionKind())
+					err := clusterClient.Get(context.TODO(), obj, unlabeledObj.GetNamespace(), unlabeledObj.GetName())
+					if apierrors.IsNotFound(err) {
+						tl.Fatalf("Unlabeled resource %s %q was deleted", typeConfig.GetTarget().Kind, util.NewQualifiedName(unlabeledObj))
+					}
+					if err != nil {
+						tl.Errorf("Error retrieving unlabeled resource: %v", err)
+					}
+					return false, nil
+				})
 			})
 		})
 	}
 })
+
+func getCrudTestInput(f framework.FederationFramework, tl common.TestLogger,
+	typeConfigName string, fixture *unstructured.Unstructured) (
+	typeconfig.Interface, testObjectsAccessor) {
+
+	// Lookup the type config from the api
+	client, err := genericclient.New(f.KubeConfig())
+	if err != nil {
+		tl.Fatalf("Error initializing dynamic client: %v", err)
+	}
+	typeConfig, err := common.GetTypeConfig(client, typeConfigName, f.FederationSystemNamespace())
+	if err != nil {
+		tl.Fatalf("Error retrieving federatedtypeconfig %q: %v", typeConfigName, err)
+	}
+
+	if framework.TestContext.LimitedScope && !typeConfig.GetNamespaced() {
+		framework.Skipf("Federation of cluster-scoped type %s is not supported by a namespaced control plane.", typeConfigName)
+	}
+
+	testObjectsFunc := func(namespace string, clusterNames []string) (*unstructured.Unstructured, []interface{}, error) {
+		targetObject, err := common.NewTestTargetObject(typeConfig, namespace, fixture)
+		if err != nil {
+			return nil, nil, err
+		}
+		if typeConfig.GetTarget().Kind == util.NamespaceKind {
+			// Namespace crud testing needs to have the same name as its namespace.
+			targetObject.SetName(namespace)
+			targetObject.SetNamespace(namespace)
+		}
+		overrides, err := common.OverridesFromFixture(clusterNames, fixture)
+		if err != nil {
+			return nil, nil, err
+		}
+		return targetObject, overrides, err
+	}
+	return typeConfig, testObjectsFunc
+}
 
 func initCrudTest(f framework.FederationFramework, tl common.TestLogger,
 	typeConfig typeconfig.Interface, testObjectsFunc testObjectsAccessor) (


### PR DESCRIPTION
This PR labels managed resources with `federation.k8s.io/managed: true` and the federated informer will only watch resources so labeled.  Existing resources will be updated to include the label, and this is implicitly tested by the crud test for namespaces (since the namespace in the host cluster exists and will be adopted).

The label will be removed from namespaces in the host cluster in the event of a propagation change resulting in the host cluster not existing in the selected set.  The label is not yet removed from a namespace in the host cluster when a FederatedNamespace is deleted.  The label is also not yet removed from an orphaned resource.  Both of these changes will be made in a subsequent PR that rewrites the deletion helper.

Fixes #549

TODO:
 - [x] - Add test that federated resource without placement for a member cluster does not delete an unlabeled resource in that cluster. 

5th in a series targeting #612 