### PR TITLE
Fix race conditions detected with in-memory execution of controllers

### DIFF
--- a/pkg/controller/schedulingpreference/controller.go
+++ b/pkg/controller/schedulingpreference/controller.go
@@ -87,8 +87,9 @@ func StartSchedulingPreferenceController(config *util.ControllerConfig, scheduli
 // newSchedulingPreferenceController returns a new SchedulingPreference Controller for the given type
 func newSchedulingPreferenceController(config *util.ControllerConfig, schedulingType schedulingtypes.SchedulingType) (*SchedulingPreferenceController, error) {
 	userAgent := fmt.Sprintf("%s-controller", schedulingType.Kind)
-	restclient.AddUserAgent(config.KubeConfig, userAgent)
-	kubeClient, err := kubeclientset.NewForConfig(config.KubeConfig)
+	kubeConfig := restclient.CopyConfig(config.KubeConfig)
+	restclient.AddUserAgent(kubeConfig, userAgent)
+	kubeClient, err := kubeclientset.NewForConfig(kubeConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/test/e2e/framework/unmanaged.go
+++ b/test/e2e/framework/unmanaged.go
@@ -182,8 +182,9 @@ func (f *UnmanagedFramework) KubeConfig() *restclient.Config {
 }
 
 func (f *UnmanagedFramework) KubeClient(userAgent string) kubeclientset.Interface {
-	restclient.AddUserAgent(f.Config, userAgent)
-	return kubeclientset.NewForConfigOrDie(f.Config)
+	config := restclient.CopyConfig(f.Config)
+	restclient.AddUserAgent(config, userAgent)
+	return kubeclientset.NewForConfigOrDie(config)
 }
 
 func (f *UnmanagedFramework) Client(userAgent string) genericclient.Client {


### PR DESCRIPTION
I noticed these when testing in hybrid mode (unmanaged + in-memory controllers), prompting me to file #718.   