### PR TITLE
Ensure managed label is removed from unmanaged resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Unreleased
+ - [#612](https://github.com/kubernetes-sigs/federation-v2/pull/612) -
+   Label managed resources in member clusters and only watch resources
+   so labeled to minimize the memory usage of the federated control
+   plane.
  - [#721](https://github.com/kubernetes-sigs/federation-v2/issues/721) -
    kubefed2 disable now deletes the FederatedTypeConfig rather than set
    propagationEnabled, waits for the sync controller to shut down, and

--- a/pkg/controller/sync/controller.go
+++ b/pkg/controller/sync/controller.go
@@ -240,14 +240,22 @@ func (s *FederationSyncController) reconcile(qualifiedName util.QualifiedName) u
 
 	kind := s.typeConfig.GetFederatedType().Kind
 
-	// TODO(marun) Handle the case where the resource has the managed
-	// label but does not have a managing resource.  Strip the label
-	// or remove the resource?
-
-	fedResource, err := s.fedAccessor.FederatedResource(qualifiedName)
+	fedResource, possibleOrphan, err := s.fedAccessor.FederatedResource(qualifiedName)
 	if err != nil {
 		runtime.HandleError(errors.Wrapf(err, "Error creating FederatedResource helper for %s %q", kind, qualifiedName))
 		return util.StatusError
+	}
+	if possibleOrphan {
+		targetKind := s.typeConfig.GetTarget().Kind
+		glog.V(2).Infof("Ensuring the removal of the label %q from %s %q in member clusters.", util.ManagedByFederationLabelKey, targetKind, qualifiedName)
+		err = s.removeManagedLabel(targetKind, qualifiedName)
+		if err != nil {
+			wrappedErr := errors.Wrapf(err, "failed to remove the label %q from %s %q in member clusters", util.ManagedByFederationLabelKey, targetKind, qualifiedName)
+			runtime.HandleError(wrappedErr)
+			return util.StatusError
+		}
+
+		return util.StatusAllOK
 	}
 	if fedResource == nil {
 		return util.StatusAllOK

--- a/test/e2e/crud.go
+++ b/test/e2e/crud.go
@@ -60,12 +60,61 @@ var _ = Describe("Federated", func() {
 				crudTester.CheckLifecycle(targetObject, overrides)
 			})
 
-			// Unlabeled resource handling behavior should not vary between
-			// types, so testing a single type is sufficient.  Picking a
-			// namespaced type minimizes the impact of teardown failure.
+			// Labeling behavior should not vary between types, so testing a
+			// single type is sufficient.  Picking a namespaced type minimizes
+			// the impact of teardown failure.
 			if typeConfigName != "configmaps" {
 				return
 			}
+
+			It("should have the managed label removed if not managed", func() {
+				typeConfig, testObjectsFunc := getCrudTestInput(f, tl, typeConfigName, fixture)
+				crudTester, targetObject, _ := initCrudTest(f, tl, typeConfig, testObjectsFunc)
+
+				testClusters := crudTester.TestClusters()
+
+				By("Selecting a member cluster to create an unlabeled resource in")
+				clusterName := ""
+				for key := range testClusters {
+					clusterName = key
+					break
+				}
+				clusterConfig := testClusters[clusterName].Config
+
+				By("Waiting for the test namespace to be created in the selected cluster")
+				kubeClient := kubeclientset.NewForConfigOrDie(clusterConfig)
+				common.WaitForNamespaceOrDie(tl, kubeClient, clusterName, targetObject.GetNamespace(),
+					framework.PollInterval, framework.TestContext.SingleCallTimeout)
+
+				By("Creating a labeled resource in the selected cluster")
+				util.AddManagedLabel(targetObject)
+				labeledObj, err := common.CreateResource(clusterConfig, typeConfig.GetTarget(), targetObject)
+				if err != nil {
+					tl.Fatalf("Failed to create labeled resource in cluster %q: %v", clusterName, err)
+				}
+				clusterClient := genericclient.NewForConfigOrDie(clusterConfig)
+				defer func() {
+					err := clusterClient.Delete(context.TODO(), labeledObj, labeledObj.GetNamespace(), labeledObj.GetName())
+					if err != nil {
+						tl.Fatalf("Unexpected error: %v", err)
+					}
+				}()
+
+				By("Checking that the labeled resource is unlabeled by the sync controller")
+				err = wait.PollImmediate(framework.PollInterval, wait.ForeverTestTimeout, func() (bool, error) {
+					obj := &unstructured.Unstructured{}
+					obj.SetGroupVersionKind(labeledObj.GroupVersionKind())
+					err := clusterClient.Get(context.TODO(), obj, labeledObj.GetNamespace(), labeledObj.GetName())
+					if err != nil {
+						tl.Errorf("Error retrieving labeled resource: %v", err)
+						return false, nil
+					}
+					return !util.HasManagedLabel(obj), nil
+				})
+				if err != nil {
+					tl.Fatal("Timed out waiting for the managed label to be removed")
+				}
+			})
 
 			It("should not be deleted if unlabeled", func() {
 				typeConfig, testObjectsFunc := getCrudTestInput(f, tl, typeConfigName, fixture)


### PR DESCRIPTION
This PR ensures that the managed label (`federation.k8s.io/managed: true`) is removed from orphaned resources or namespaces in the host cluster or when a managed resource is seen without a corresponding federated resource. 

Fixes #612 