### PR TITLE
Make deploy-federation.sh more robust

### DIFF
--- a/scripts/deploy-federation.sh
+++ b/scripts/deploy-federation.sh
@@ -53,7 +53,7 @@ function deploy-with-helm() {
   # Don't install tiller if we already have a working install.
   if ! helm version --server 2>/dev/null; then
     # RBAC should be enabled to avoid CI fail because CI K8s uses RBAC for Tiller
-    cat <<EOF | cat # kubectl apply -f -
+    cat <<EOF | kubectl apply -f -
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/scripts/deploy-federation.sh
+++ b/scripts/deploy-federation.sh
@@ -51,7 +51,7 @@ source "$(dirname "${BASH_SOURCE}")/util.sh"
 
 function deploy-with-helm() {
   # Don't install tiller if we already have a working install.
-  if ! helm version --server; then
+  if ! helm version --server 2>/dev/null; then
     # RBAC should be enabled to avoid CI fail because CI K8s uses RBAC for Tiller
     cat <<EOF | cat # kubectl apply -f -
 apiVersion: v1


### PR DESCRIPTION
Allow running deploy-federation.sh when:
* There is already a working tiller installation, and the user doesn't have the ability to create cluster-wide roles.
* There are no additional specified JOIN_CLUSTERS.
