### PR TITLE
Kubefed2 Federate fixes

### DIFF
--- a/pkg/kubefed2/disable.go
+++ b/pkg/kubefed2/disable.go
@@ -89,12 +89,12 @@ func NewCmdTypeDisable(cmdOut io.Writer, config util.FedConfig) *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			err := opts.Complete(args)
 			if err != nil {
-				glog.Fatalf("error: %v", err)
+				glog.Fatalf("Error: %v", err)
 			}
 
 			err = opts.Run(cmdOut, config)
 			if err != nil {
-				glog.Fatalf("error: %v", err)
+				glog.Fatalf("Error: %v", err)
 			}
 		},
 	}

--- a/pkg/kubefed2/enable/enable.go
+++ b/pkg/kubefed2/enable/enable.go
@@ -102,12 +102,12 @@ func NewCmdTypeEnable(cmdOut io.Writer, config util.FedConfig) *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			err := opts.Complete(args)
 			if err != nil {
-				glog.Fatalf("error: %v", err)
+				glog.Fatalf("Error: %v", err)
 			}
 
 			err = opts.Run(cmdOut, config)
 			if err != nil {
-				glog.Fatalf("error: %v", err)
+				glog.Fatalf("Error: %v", err)
 			}
 		},
 	}

--- a/pkg/kubefed2/federate/federate.go
+++ b/pkg/kubefed2/federate/federate.go
@@ -106,12 +106,12 @@ func NewCmdFederateResource(cmdOut io.Writer, config util.FedConfig) *cobra.Comm
 		Run: func(cmd *cobra.Command, args []string) {
 			err := opts.Complete(args)
 			if err != nil {
-				glog.Fatalf("error: %v", err)
+				glog.Fatalf("Error: %v", err)
 			}
 
 			err = opts.Run(cmdOut, config)
 			if err != nil {
-				glog.Fatalf("error: %v", err)
+				glog.Fatalf("Error: %v", err)
 			}
 		},
 	}

--- a/pkg/kubefed2/federate/federate.go
+++ b/pkg/kubefed2/federate/federate.go
@@ -225,8 +225,9 @@ func getTargetResource(hostConfig *rest.Config, typeConfig *fedv1a1.FederatedTyp
 	return resource, nil
 }
 
-func FederatedResourceFromTargetResource(typeConfig typeconfig.Interface, targetResource *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+func FederatedResourceFromTargetResource(typeConfig typeconfig.Interface, resource *unstructured.Unstructured) (*unstructured.Unstructured, error) {
 	fedAPIResource := typeConfig.GetFederatedType()
+	targetResource := resource.DeepCopy()
 
 	// Special handling is needed for some controller set fields.
 	switch typeConfig.GetTarget().Kind {

--- a/pkg/kubefed2/federate/federate.go
+++ b/pkg/kubefed2/federate/federate.go
@@ -53,8 +53,8 @@ var (
 		flag otherwise.`
 
 	federate_example = `
-		# Federate resource named "my-dep" in namespace "my-ns" of kubernetes type "deploy"
-		kubefed2 federate deploy my-dep -n "my-ns" --host-cluster-context=cluster1`
+		# Federate resource named "my-cm" in namespace "my-ns" of kubernetes type "configmaps" (identified by short name "cm")
+		kubefed2 federate cm "my-cm" -n "my-ns" --host-cluster-context=cluster1`
 	// TODO(irfanurrehman): implement —contents flag applicable to namespaces
 )
 

--- a/pkg/kubefed2/federate/util.go
+++ b/pkg/kubefed2/federate/util.go
@@ -25,7 +25,6 @@ import (
 var systemMetadataFields = []string{"selfLink", "uid", "resourceVersion", "generation", "creationTimestamp", "deletionTimestamp", "deletionGracePeriodSeconds"}
 
 func RemoveUnwantedFields(resource *unstructured.Unstructured) {
-	unstructured.RemoveNestedField(resource.Object, "status")
 	for _, field := range systemMetadataFields {
 		unstructured.RemoveNestedField(resource.Object, "metadata", field)
 		// For resources with pod template subresource (jobs, deployments, replicasets)
@@ -33,6 +32,9 @@ func RemoveUnwantedFields(resource *unstructured.Unstructured) {
 	}
 	unstructured.RemoveNestedField(resource.Object, "metadata", "name")
 	unstructured.RemoveNestedField(resource.Object, "metadata", "namespace")
+	unstructured.RemoveNestedField(resource.Object, "apiVersion")
+	unstructured.RemoveNestedField(resource.Object, "kind")
+	unstructured.RemoveNestedField(resource.Object, "status")
 }
 
 func SetBasicMetaFields(resource *unstructured.Unstructured, apiResource metav1.APIResource, name, namespace, generateName string) {

--- a/pkg/kubefed2/join.go
+++ b/pkg/kubefed2/join.go
@@ -125,12 +125,12 @@ func NewCmdJoin(cmdOut io.Writer, config util.FedConfig) *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			err := opts.Complete(args)
 			if err != nil {
-				glog.Fatalf("error: %v", err)
+				glog.Fatalf("Error: %v", err)
 			}
 
 			err = opts.Run(cmdOut, config)
 			if err != nil {
-				glog.Fatalf("error: %v", err)
+				glog.Fatalf("Error: %v", err)
 			}
 		},
 	}

--- a/pkg/kubefed2/unjoin.go
+++ b/pkg/kubefed2/unjoin.go
@@ -93,12 +93,12 @@ func NewCmdUnjoin(cmdOut io.Writer, config util.FedConfig) *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			err := opts.Complete(args)
 			if err != nil {
-				glog.Fatalf("error: %v", err)
+				glog.Fatalf("Error: %v", err)
 			}
 
 			err = opts.Run(cmdOut, config)
 			if err != nil {
-				glog.Fatalf("error: %v", err)
+				glog.Fatalf("Error: %v", err)
 			}
 		},
 	}


### PR DESCRIPTION
Follow up fixes pending from older PRs

Follow ups from :
1. [comment](https://github.com/kubernetes-sigs/federation-v2/pull/660#issuecomment-478092485).
2. [comment](https://github.com/kubernetes-sigs/federation-v2/pull/661#discussion_r270703867)

Additionally:
1. Error message in the base commands started with small  alphabet, which looked out of sync. All other messages start in caps.
2. `FederatedResourceFromTargetResource()` should not modify input.

cc @marun


