### PR TITLE
Packaged and updates charts. 

### DIFF
--- a/charts/federation-v2/README.md
+++ b/charts/federation-v2/README.md
@@ -36,17 +36,30 @@ cluster registry:
 $ kubectl create ns kube-multicluster-public
 ```
 
-Install the chart with the release name `federation-v2`:
-
+Next, add the chart to your local repository.
 ```bash
-$ helm install charts/federation-v2 --name federation-v2 --namespace federation-system
+$ helm repo add federation-v2 https://raw.githubusercontent.com/kubernetes-sigs/federation-v2/add-chart-repo-index/charts/
+
+$ helm repo list
+NAME            URL                                        
+federation-v2   https://raw.githubusercontent.com/kubernetes-sigs/federation-v2/add-chart-repo-index/charts/
+```
+
+With the repo added, available charts and versions can be viewed.
+```bash
+$ helm search federation-v2
+```
+
+Install the chart and append the version you would like using the `--version` tag. Here, we specify version 0.0.7 and name it federation-v2.
+```bash
+$ helm install fedv2-charts/federation-v2 --name=federation-v2 --version=0.0.7 v2 --namespace federation-system
 ```
 
 If you already have clusterregistry installed, skip installing it during federation-v2 installation
 as follows:
 
 ```bash
-$ helm install charts/federation-v2 --name federation-v2 --namespace federation-system --set clusterregistry.enabled=false
+$ helm install fedv2-charts/federation-v2 --name federation-v2 --namespace federation-system --set clusterregistry.enabled=false
 ```
 
 ## Uninstalling the Chart

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -22,8 +22,17 @@ Creating a federation v2 release involves the following steps:
    1. `make kubefed2`
    2. `cd bin`
    3. `kubefed2 version` (check that the output is as expected)
-   4. `tar cvzf kubefed2.tar.gz kubefed2`
-   5. `sha256sum kubefed2.tar.gz > kubefed2.tar.gz.sha`
+   4. `tar cvzf kubefed2.tgz kubefed2`
+   5. `sha256sum kubefed2.tgz > kubefed2.tgz.sha`
+4. Package the helm chart for release
+   1.  Adjust the default image tag in values.yaml
+   2.  Update the chart version in Chart.yaml
+   3.  `helm package federation-v2` (Package the chart)
+   4.  `sha256sum federation-v2-<x.x.x>.tgz > federation-v2-<x.x.x>.tgz` (Name and checksum the packaged chart accordingly)
+   5.  `helm repo index federation-v2/ --url=https://raw.githubusercontent.com/kubernetes-sigs/federation-v2/add-chart-repo-index/charts/` (Add the new version to the chart index)
+   6.  Ensure index.yaml containes the latest release within the entries array
+   7.  Create PR that captures index.yaml for branch "add-chart-repo-index"
 4. Create github release
    - Copy text from old release and replace old tag references
-   - Add `kubefed2.tar.gz` and `kubefed2.tar.gz.sha`
+   - Add `kubefed2.tgz` and `kubefed2.tgz.sha`
+   - Add `federation-v2-<x.x.x>.tgz` and `federation-v2-<x.x.x>.tgz.sha`


### PR DESCRIPTION
Resolves https://github.com/kubernetes-sigs/federation-v2/issues/701

Currently uses repo as a base. Consider using Github pages or an existing bucket to host the chart? If so, before the merge, the chart would need to be updated with the new endpoint.