### PR TITLE
Add chart index to support installing the released chart

### DIFF
--- a/charts/index.yaml
+++ b/charts/index.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+entries:
+  federation-v2:
+  - apiVersion: v1
+    created: 2019-04-10T22:19:18.130342567-07:00
+    description: Kubernetes Federation V2 helm chart
+    digest: 99e3236f43ac81dbdf04e9ad47914e5782dbb6a97a5bb2bf9d2d6ec3d73d9afc
+    name: federation-v2
+    urls:
+    - https://github.com/kubernetes-sigs/federation-v2/releases/download/v0.0.8/federation-v2-0.0.8.tgz
+    version: 0.0.8
+generated: 2019-04-10T22:19:18.127937045-07:00


### PR DESCRIPTION
The addition of a chart index detailing released versions of federation will allow the following installation workflow:

```
helm repo add fedv2-charts https://raw.githubusercontent.com/marun/federation-v2/add-chart-repo-index/charts/
helm install fedv2-charts/federation-v2 --name=federation-v2 --version=0.0.8 --namespace federation-system
```

This PR is intended to merge ahead of the update to the helm instructions proposed in #751.
