### PR TITLE
clean obsolete script to delete clusterrolebinding federation-admin

### DIFF
--- a/scripts/delete-federation.sh
+++ b/scripts/delete-federation.sh
@@ -77,11 +77,6 @@ delete-helm-deployment
 
 ${KCD} ns "${NS}"
 
-# Remove permissive rolebinding that allows federation controllers to run.
-if [[ ! "${NAMESPACED}" ]]; then
-  ${KCD} clusterrolebinding federation-admin
-fi
-
 # Wait for the namespaces to be removed
 function ns-deleted() {
   kubectl get ns "${1}" &> /dev/null


### PR DESCRIPTION
After use exact RBAC for controller and remove script based installation, the clusterrolebinding federation-admin no longer needed. Just clean it.