### PR TITLE
Give controller cluster role ability to patch

### DIFF
--- a/charts/federation-v2/charts/controllermanager/templates/clusterrole.yaml
+++ b/charts/federation-v2/charts/controllermanager/templates/clusterrole.yaml
@@ -66,4 +66,5 @@ rules:
   - list
   - create
   - update
+  - patch
 {{- end }}

--- a/charts/federation-v2/charts/controllermanager/templates/role.yaml
+++ b/charts/federation-v2/charts/controllermanager/templates/role.yaml
@@ -63,4 +63,5 @@ rules:
   - get
   - create
   - update
+  - patch
 {{- end }}


### PR DESCRIPTION
The controller currently lacks the permission to patch events which causes some errors. To rectify this I've added patch to the cluster role
```
'events "test-deployment.1595eea7da7b10cc" is forbidden: User "system:serviceaccount:federation-system:default" cannot patch resource "events" in API group "" in the namespace "test-namespace"' (will not retry!)
```