### PR TITLE
kubefed2 disable should delete the FTC rather than set propagationEnabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Unreleased
+ - [#721](https://github.com/kubernetes-sigs/federation-v2/issues/721) -
+   kubefed2 disable now deletes the FederatedTypeConfig rather than set
+   propagationEnabled, waits for the sync controller to shut down, and
+   optionally removes the federated type CRD.
 
 # v0.0.9
 -  [#776](https://github.com/kubernetes-sigs/federation-v2/pull/776) -

--- a/pkg/kubefed2/disable.go
+++ b/pkg/kubefed2/disable.go
@@ -168,11 +168,11 @@ func (j *disableType) Run(cmdOut io.Writer, config util.FedConfig) error {
 		Name:      name,
 	}
 	j.enableTypeDirective.Name = typeConfigName.Name
-	return DisableFederation(cmdOut, hostConfig, j.enableTypeDirective, typeConfigName, j.deleteCRD, j.DryRun)
+	return DisableFederation(cmdOut, hostConfig, j.enableTypeDirective, typeConfigName, j.deleteCRD, j.DryRun, true)
 }
 
 func DisableFederation(cmdOut io.Writer, config *rest.Config, enableTypeDirective *enable.EnableTypeDirective,
-	typeConfigName ctlutil.QualifiedName, deleteCRD, dryRun bool) error {
+	typeConfigName ctlutil.QualifiedName, deleteCRD, dryRun, verifyStopped bool) error {
 	client, err := genericclient.New(config)
 	if err != nil {
 		return errors.Wrap(err, "Failed to get federation clientset")
@@ -215,9 +215,11 @@ func DisableFederation(cmdOut io.Writer, config *rest.Config, enableTypeDirectiv
 				return err
 			}
 		}
-		err = verifyPropagationControllerStopped(client, typeConfigName, write)
-		if err != nil {
-			return err
+		if verifyStopped {
+			err = verifyPropagationControllerStopped(client, typeConfigName, write)
+			if err != nil {
+				return err
+			}
 		}
 	}
 

--- a/pkg/kubefed2/enable/directive.go
+++ b/pkg/kubefed2/enable/directive.go
@@ -20,6 +20,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/kubernetes-sigs/federation-v2/pkg/apis/core/common"
+	"github.com/kubernetes-sigs/federation-v2/pkg/kubefed2/options"
 )
 
 // EnableTypeDirectiveSpec defines the desired state of EnableTypeDirective.
@@ -52,8 +53,8 @@ type EnableTypeDirective struct {
 }
 
 func (ft *EnableTypeDirective) SetDefaults() {
-	ft.Spec.FederationGroup = DefaultFederationGroup
-	ft.Spec.FederationVersion = DefaultFederationVersion
+	ft.Spec.FederationGroup = options.DefaultFederationGroup
+	ft.Spec.FederationVersion = options.DefaultFederationVersion
 }
 
 func NewEnableTypeDirective() *EnableTypeDirective {

--- a/pkg/kubefed2/enable/enable.go
+++ b/pkg/kubefed2/enable/enable.go
@@ -43,8 +43,8 @@ import (
 )
 
 const (
-	DefaultFederationGroup   = "types.federation.k8s.io"
-	DefaultFederationVersion = "v1alpha1"
+	federationGroupUsage = "The name of the API group to use for the generated federation type."
+	targetVersionUsage   = "Optional, the API version of the target type."
 )
 
 var (
@@ -69,14 +69,12 @@ var (
 
 type enableType struct {
 	options.GlobalSubcommandOptions
+	options.CommonEnableOptions
 	enableTypeOptions
 }
 
 type enableTypeOptions struct {
-	targetName          string
-	targetVersion       string
 	federationVersion   string
-	federationGroup     string
 	output              string
 	outputYAML          bool
 	filename            string
@@ -86,9 +84,7 @@ type enableTypeOptions struct {
 // Bind adds the join specific arguments to the flagset passed in as an
 // argument.
 func (o *enableTypeOptions) Bind(flags *pflag.FlagSet) {
-	flags.StringVar(&o.targetVersion, "version", "", "Optional, the API version of the target type.")
-	flags.StringVar(&o.federationGroup, "federation-group", DefaultFederationGroup, "The name of the API group to use for the generated federation type.")
-	flags.StringVar(&o.federationVersion, "federation-version", DefaultFederationVersion, "The API version to use for the generated federation type.")
+	flags.StringVar(&o.federationVersion, "federation-version", options.DefaultFederationVersion, "The API version to use for the generated federation type.")
 	flags.StringVarP(&o.output, "output", "o", "", "If provided, the resources that would be created in the API by the command are instead output to stdout in the provided format.  Valid values are ['yaml'].")
 	flags.StringVarP(&o.filename, "filename", "f", "", "If provided, the command will be configured from the provided yaml file.  Only --output will be accepted from the command line")
 }
@@ -118,6 +114,7 @@ func NewCmdTypeEnable(cmdOut io.Writer, config util.FedConfig) *cobra.Command {
 
 	flags := cmd.Flags()
 	opts.GlobalSubcommandBind(flags)
+	opts.CommonSubcommandBind(flags, federationGroupUsage, targetVersionUsage)
 	opts.Bind(flags)
 
 	return cmd
@@ -142,16 +139,17 @@ func (j *enableType) Complete(args []string) error {
 		return nil
 	}
 
-	if len(args) == 0 {
-		return errors.New("NAME is required")
+	if err := j.SetName(args); err != nil {
+		return err
 	}
-	fd.Name = args[0]
 
-	if len(j.targetVersion) > 0 {
-		fd.Spec.TargetVersion = j.targetVersion
+	fd.Name = j.TargetName
+
+	if len(j.TargetVersion) > 0 {
+		fd.Spec.TargetVersion = j.TargetVersion
 	}
-	if len(j.federationGroup) > 0 {
-		fd.Spec.FederationGroup = j.federationGroup
+	if len(j.FederationGroup) > 0 {
+		fd.Spec.FederationGroup = j.FederationGroup
 	}
 	if len(j.federationVersion) > 0 {
 		fd.Spec.FederationVersion = j.federationVersion

--- a/pkg/kubefed2/join.go
+++ b/pkg/kubefed2/join.go
@@ -84,7 +84,7 @@ var (
 
 type joinFederation struct {
 	options.GlobalSubcommandOptions
-	options.CommonSubcommandOptions
+	options.CommonJoinOptions
 	options.FederationConfigOptions
 	joinFederationOptions
 }

--- a/pkg/kubefed2/options/options.go
+++ b/pkg/kubefed2/options/options.go
@@ -99,3 +99,35 @@ func GetOptionsFromFederationConfig(hostConfig *rest.Config, namespace string) (
 
 	return fedConfig.Spec.Scope, fedConfig.Spec.RegistryNamespace, nil
 }
+
+// CommonEnableOptions holds the common configuration required by the enable
+// and disable subcommands of `kubefed2`.
+type CommonEnableOptions struct {
+	TargetName      string
+	FederationGroup string
+	TargetVersion   string
+}
+
+// Default value for shared Federation group across enable and
+// disable subcommands of `kubefed2`.
+const (
+	DefaultFederationGroup   = "types.federation.k8s.io"
+	DefaultFederationVersion = "v1alpha1"
+)
+
+// CommonSubcommandBind adds the common subcommand flags to the flagset passed in.
+func (o *CommonEnableOptions) CommonSubcommandBind(flags *pflag.FlagSet, federationGroupUsage, targetVersionUsage string) {
+	flags.StringVar(&o.FederationGroup, "federation-group", DefaultFederationGroup, federationGroupUsage)
+	flags.StringVar(&o.TargetVersion, "version", "", targetVersionUsage)
+}
+
+// SetName sets the name from the args passed in for the required positional
+// argument.
+func (o *CommonEnableOptions) SetName(args []string) error {
+	if len(args) == 0 {
+		return errors.New("NAME is required")
+	}
+
+	o.TargetName = args[0]
+	return nil
+}

--- a/pkg/kubefed2/options/options.go
+++ b/pkg/kubefed2/options/options.go
@@ -48,16 +48,16 @@ func (o *GlobalSubcommandOptions) GlobalSubcommandBind(flags *pflag.FlagSet) {
 		"Run the command in dry-run mode, without making any server requests.")
 }
 
-// CommonSubcommandOptions holds the common configuration required by some of
-// the subcommands of `kubefed2`.
-type CommonSubcommandOptions struct {
+// CommonJoinOptions holds the common configuration required by the join and
+// unjoin subcommands of `kubefed2`.
+type CommonJoinOptions struct {
 	ClusterName     string
 	ClusterContext  string
 	HostClusterName string
 }
 
 // CommonSubcommandBind adds the common subcommand flags to the flagset passed in.
-func (o *CommonSubcommandOptions) CommonSubcommandBind(flags *pflag.FlagSet) {
+func (o *CommonJoinOptions) CommonSubcommandBind(flags *pflag.FlagSet) {
 	flags.StringVar(&o.ClusterContext, "cluster-context", "",
 		"Name of the cluster's context in the local kubeconfig. Defaults to cluster name if unspecified.")
 	flags.StringVar(&o.HostClusterName, "host-cluster-name", "",
@@ -66,7 +66,7 @@ func (o *CommonSubcommandOptions) CommonSubcommandBind(flags *pflag.FlagSet) {
 
 // SetName sets the name from the args passed in for the required positional
 // argument.
-func (o *CommonSubcommandOptions) SetName(args []string) error {
+func (o *CommonJoinOptions) SetName(args []string) error {
 	if len(args) == 0 {
 		return errors.New("NAME is required")
 	}

--- a/pkg/kubefed2/unjoin.go
+++ b/pkg/kubefed2/unjoin.go
@@ -57,7 +57,7 @@ var (
 
 type unjoinFederation struct {
 	options.GlobalSubcommandOptions
-	options.CommonSubcommandOptions
+	options.CommonJoinOptions
 	options.FederationConfigOptions
 	unjoinFederationOptions
 }

--- a/test/e2e/crd.go
+++ b/test/e2e/crd.go
@@ -162,7 +162,7 @@ func validateCrdCrud(f framework.FederationFramework, targetCrdKind string, name
 		// CRDs is attempted even if the removal of any one CRD fails.
 		objectMeta := typeConfig.GetObjectMeta()
 		qualifiedName := util.QualifiedName{Namespace: f.FederationSystemNamespace(), Name: objectMeta.Name}
-		err := kubefed2.DisableFederation(nil, hostConfig, enableTypeDirective, qualifiedName, delete, dryRun)
+		err := kubefed2.DisableFederation(nil, hostConfig, enableTypeDirective, qualifiedName, delete, dryRun, false)
 		if err != nil {
 			tl.Fatalf("Error disabling federation of target type %q: %v", targetAPIResource.Kind, err)
 		}

--- a/test/e2e/crd.go
+++ b/test/e2e/crd.go
@@ -37,6 +37,7 @@ import (
 
 	"github.com/kubernetes-sigs/federation-v2/pkg/kubefed2"
 	kfenable "github.com/kubernetes-sigs/federation-v2/pkg/kubefed2/enable"
+	kfenableopts "github.com/kubernetes-sigs/federation-v2/pkg/kubefed2/options"
 	"github.com/kubernetes-sigs/federation-v2/test/common"
 	"github.com/kubernetes-sigs/federation-v2/test/e2e/framework"
 
@@ -85,8 +86,8 @@ func validateCrdCrud(f framework.FederationFramework, targetCrdKind string, name
 		// Need to reuse a group and version for which the helm chart
 		// is granted rbac permissions for.  The default group and
 		// version used by `kubefed2 enable` meets this criteria.
-		Group:   kfenable.DefaultFederationGroup,
-		Version: kfenable.DefaultFederationVersion,
+		Group:   kfenableopts.DefaultFederationGroup,
+		Version: kfenableopts.DefaultFederationVersion,
 
 		Kind:       targetCrdKind,
 		Name:       fedv1a1.PluralName(targetCrdKind),
@@ -161,7 +162,7 @@ func validateCrdCrud(f framework.FederationFramework, targetCrdKind string, name
 		// CRDs is attempted even if the removal of any one CRD fails.
 		objectMeta := typeConfig.GetObjectMeta()
 		qualifiedName := util.QualifiedName{Namespace: f.FederationSystemNamespace(), Name: objectMeta.Name}
-		err := kubefed2.DisableFederation(nil, hostConfig, qualifiedName, delete, dryRun)
+		err := kubefed2.DisableFederation(nil, hostConfig, enableTypeDirective, qualifiedName, delete, dryRun)
 		if err != nil {
 			tl.Fatalf("Error disabling federation of target type %q: %v", targetAPIResource.Kind, err)
 		}

--- a/test/e2e/scheduling.go
+++ b/test/e2e/scheduling.go
@@ -389,7 +389,7 @@ func enableTypeConfigResource(name, namespace string, config *restclient.Config,
 
 func deleteTypeConfigResource(name, namespace string, config *restclient.Config, tl common.TestLogger) {
 	qualifiedName := util.QualifiedName{Namespace: namespace, Name: name}
-	err := kubefed2.DisableFederation(nil, config, nil, qualifiedName, true, false)
+	err := kubefed2.DisableFederation(nil, config, nil, qualifiedName, true, false, false)
 	if err != nil {
 		tl.Fatalf("Error disabling federation of target type %q: %v", qualifiedName, err)
 	}

--- a/test/e2e/scheduling.go
+++ b/test/e2e/scheduling.go
@@ -389,7 +389,7 @@ func enableTypeConfigResource(name, namespace string, config *restclient.Config,
 
 func deleteTypeConfigResource(name, namespace string, config *restclient.Config, tl common.TestLogger) {
 	qualifiedName := util.QualifiedName{Namespace: namespace, Name: name}
-	err := kubefed2.DisableFederation(nil, config, qualifiedName, true, false)
+	err := kubefed2.DisableFederation(nil, config, nil, qualifiedName, true, false)
 	if err != nil {
 		tl.Fatalf("Error disabling federation of target type %q: %v", qualifiedName, err)
 	}


### PR DESCRIPTION
With this change `kubefed2 disable` now deletes the `FederatedTypeConfig` instead of just setting `propagationEnabled` to `false`. It will also wait for the sync controller to shut down before deleting it, and optionally delete the federated type CRD as well.

Partial fix for #721.