### PR TITLE
support optional values in FederationConfig 

### DIFF
--- a/cmd/controller-manager/app/options/options.go
+++ b/cmd/controller-manager/app/options/options.go
@@ -34,26 +34,6 @@ type Options struct {
 // AddFlags adds flags to fs and binds them to options.
 func (o *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&o.Config.FederationNamespace, "federation-namespace", util.DefaultFederationSystemNamespace, "The namespace the federation control plane is deployed in.")
-	o.setDefaults()
-}
-
-func (o *Options) setDefaults() {
-	o.FeatureGates = make(map[string]bool)
-	o.LimitedScope = false
-
-	o.Config.ClusterNamespace = util.MulticlusterPublicNamespace
-	o.Config.ClusterAvailableDelay = util.DefaultClusterAvailableDelay
-	o.Config.ClusterUnavailableDelay = util.DefaultClusterUnavailableDelay
-
-	o.LeaderElection.LeaseDuration = util.DefaultLeaderElectionLeaseDuration
-	o.LeaderElection.RenewDeadline = util.DefaultLeaderElectionRenewDeadline
-	o.LeaderElection.RetryPeriod = util.DefaultLeaderElectionRetryPeriod
-	o.LeaderElection.ResourceLock = "configmaps"
-
-	o.ClusterHealthCheckConfig.PeriodSeconds = util.DefaultClusterHealthCheckPeriod
-	o.ClusterHealthCheckConfig.FailureThreshold = util.DefaultClusterHealthCheckFailureThreshold
-	o.ClusterHealthCheckConfig.SuccessThreshold = util.DefaultClusterHealthCheckSuccessThreshold
-	o.ClusterHealthCheckConfig.TimeoutSeconds = util.DefaultClusterHealthCheckTimeout
 }
 
 func NewOptions() *Options {

--- a/config/federationconfig.yaml
+++ b/config/federationconfig.yaml
@@ -4,24 +4,7 @@ metadata:
   name: federation-v2
   namespace: federation-system
 spec:
-  limited-scope: false
-  registry-namespace: kube-multicluster-public
-  controller-duration:
-    available-delay: 20s
-    unavailable-delay: 60s
-    cluster-monitor-period: 40s
   leader-elect:
     lease-duration: 1500ms
     renew-deadline: 1000ms
     retry-period: 500ms
-    resource-lock: configmaps
-  feature-gates:
-  - name: PushReconciler
-    enabled: true
-  - name: SchedulerPreferences
-    enabled: true
-  - name: CrossClusterServiceDiscovery
-    enabled: true
-  - name: FederatedIngress
-    enabled: true
-

--- a/pkg/controller/util/cluster_util.go
+++ b/pkg/controller/util/cluster_util.go
@@ -49,6 +49,7 @@ const (
 	DefaultLeaderElectionLeaseDuration = 15 * time.Second
 	DefaultLeaderElectionRenewDeadline = 10 * time.Second
 	DefaultLeaderElectionRetryPeriod   = 5 * time.Second
+	DefaultLeaderElectionResourceLock  = "configmaps"
 
 	DefaultClusterHealthCheckPeriod           = 10
 	DefaultClusterHealthCheckFailureThreshold = 3


### PR DESCRIPTION
Use default values in controller manager if the `FederationConfig` yaml file not specified the field.

As mentioned in #770, the configuration value used by controller will be updated to `FederationConfig`


Fixes #770