### PR TITLE
[Makefile] fix `make` compilation error on macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ vet:
 fmt:
 	$(shell ./hack/update-gofmt.sh)
 
-container: hyperfed
+container: $(HYPERFED_TARGET)-linux
 	cp -f $(HYPERFED_TARGET)-linux images/federation-v2/hyperfed
 	$(DOCKER) build images/federation-v2 -t $(IMAGE_NAME)
 	rm -f images/federation-v2/hyperfed


### PR DESCRIPTION
`make` will result into below below error without fix on macOS

```
cp -f bin/hyperfed-linux images/federation-v2/hyperfed
cp: bin/hyperfed-linux: No such file or directory
make: *** [container] Error 1
```