### PR TITLE
Don't fail without cluster scope.

### DIFF
--- a/pkg/kubefedctl/join.go
+++ b/pkg/kubefedctl/join.go
@@ -455,7 +455,19 @@ func createFederationNamespace(clusterClientset kubeclient.Interface, federation
 		return federationNS, nil
 	}
 
-	_, err := clusterClientset.CoreV1().Namespaces().Create(federationNS)
+	_, err := clusterClientset.CoreV1().Namespaces().Get(federationNamespace, metav1.GetOptions{})
+	if err != nil && !apierrors.IsNotFound(err) {
+		glog.V(2).Infof("Could not get %s namespace: %v", federationNamespace, err)
+		return nil, err
+	}
+
+	if err == nil {
+		glog.V(2).Infof("Already existing %s namespace", federationNamespace)
+		return federationNS, nil
+	}
+
+	// Not found, so create.
+	_, err = clusterClientset.CoreV1().Namespaces().Create(federationNS)
 	if err != nil && !apierrors.IsAlreadyExists(err) {
 		glog.V(2).Infof("Could not create %s namespace: %v", federationNamespace, err)
 		return nil, err


### PR DESCRIPTION
Fixes #733.

This PR allows the user to have RBAC permissions to the namespaced installation host, but not clusterwide access.  Clusterwide access is still required to join other clusters.

I use this successfully to create federations between my local, namespace-only role, and remote clusterwide roles.
