### PR TITLE
Remove host-only docker daemon config file check

### DIFF
--- a/scripts/create-clusters.sh
+++ b/scripts/create-clusters.sh
@@ -75,16 +75,12 @@ function configure-insecure-registry-and-reload() {
 }
 
 function insecure-registry-config-cmd() {
-  if test -f "${docker_daemon_config}"; then
-    sed -i "1a \    \"insecure-registries\": [\"${CONTAINER_REGISTRY_HOST}\"]" ${docker_daemon_config}
-  else
-    echo "cat <<EOF > ${docker_daemon_config}
+  echo "cat <<EOF > ${docker_daemon_config}
 {
     \"insecure-registries\": [\"${CONTAINER_REGISTRY_HOST}\"]
 }
 EOF
 "
-  fi
 }
 
 function reload-docker-daemon-cmd() {


### PR DESCRIPTION
This reverts a check for the docker daemon config file that was performed only on the host. Currently this breaks local testing as well as CI whenever the host's docker daemon config file already exists since this code is called from 2 different contexts: the host and the cluster. We'll need to address it differently per https://github.com/kubernetes-sigs/federation-v2/pull/764#discussion_r276029510.