### PR TITLE
adding Age column while listing the cluster status

### DIFF
--- a/charts/federation-v2/charts/controllermanager/templates/crds.yaml
+++ b/charts/federation-v2/charts/controllermanager/templates/crds.yaml
@@ -78,6 +78,9 @@ spec:
   - JSONPath: .status.conditions[?(@.type=='Ready')].status
     name: ready
     type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: age
+    type: date
   group: core.federation.k8s.io
   names:
     kind: FederatedCluster

--- a/pkg/apis/core/v1alpha1/federatedcluster_types.go
+++ b/pkg/apis/core/v1alpha1/federatedcluster_types.go
@@ -71,6 +71,7 @@ type FederatedClusterStatus struct {
 // +kubebuilder:resource:path=federatedclusters
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name=ready,type=string,JSONPath=.status.conditions[?(@.type=='Ready')].status
+// +kubebuilder:printcolumn:name=age,type=date,JSONPath=.metadata.creationTimestamp
 type FederatedCluster struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`


### PR DESCRIPTION
Presently if you run `kubectl get federatedcluster -n federation-system`, it will display the following o/p:
```
NAME       READY  
cluster1     True    
cluster2     True
```   
however, it should display:  
```
NAME       READY   AGE
cluster1   True    1m
cluster2   True    1m
```
The workaround here would be adding the following line 
`// +kubebuilder:printcolumn:name=age,type=date,JSONPath=.metadata.creationTimestamp` in the federatedcluster_types.go
It looks like the `printercolumn` definition is replacing the existing server-side columns(in this case it was `Age`). 