### PR TITLE
Extend service discovery for multi-zone clusters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Unreleased
+-  [#797](https://github.com/kubernetes-sigs/federation-v2/pull/797) -
+   Cross-cluster service discovery now works for multi-zone clusters.
+   There is an update to FederatedClusters and ServiceDNSRecord API
+   types wherein the zone field is changed to zones.
 -  [#720](https://github.com/kubernetes-sigs/federation-v2/issues/720) -
    `kubefed2 enable` now succeeds if federation of the type is already
    enabled.

--- a/charts/federation-v2/charts/controllermanager/templates/crds.yaml
+++ b/charts/federation-v2/charts/controllermanager/templates/crds.yaml
@@ -157,10 +157,12 @@ spec:
               description: Region is the name of the region in which all of the nodes
                 in the cluster exist.  e.g. 'us-east1'.
               type: string
-            zone:
-              description: Zone is the name of availability zone in which the nodes
-                of the cluster exist, e.g. 'us-east1-a'.
-              type: string
+            zones:
+              description: Zones are the names of availability zones in which the
+                nodes of the cluster exist, e.g. 'us-east1-a'.
+              items:
+                type: string
+              type: array
           type: object
   version: v1alpha1
 status:
@@ -725,9 +727,11 @@ spec:
                   region:
                     description: Region to which the cluster belongs
                     type: string
-                  zone:
-                    description: Zone to which the cluster belongs
-                    type: string
+                  zones:
+                    description: Zones to which the cluster belongs
+                    items:
+                      type: string
+                    type: array
                 type: object
               type: array
             domain:

--- a/pkg/apis/core/v1alpha1/federatedcluster_types.go
+++ b/pkg/apis/core/v1alpha1/federatedcluster_types.go
@@ -52,9 +52,9 @@ type FederatedClusterStatus struct {
 	// Conditions is an array of current cluster conditions.
 	// +optional
 	Conditions []ClusterCondition `json:"conditions,omitempty"`
-	// Zone is the name of availability zone in which the nodes of the cluster exist, e.g. 'us-east1-a'.
+	// Zones are the names of availability zones in which the nodes of the cluster exist, e.g. 'us-east1-a'.
 	// +optional
-	Zone string `json:"zone,omitempty"`
+	Zones []string `json:"zones,omitempty"`
 	// Region is the name of the region in which all of the nodes in the cluster exist.  e.g. 'us-east1'.
 	// +optional
 	Region string `json:"region,omitempty"`

--- a/pkg/apis/core/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/core/v1alpha1/zz_generated.deepcopy.go
@@ -295,6 +295,11 @@ func (in *FederatedClusterStatus) DeepCopyInto(out *FederatedClusterStatus) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.Zones != nil {
+		in, out := &in.Zones, &out.Zones
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/apis/multiclusterdns/v1alpha1/servicednsrecord_types.go
+++ b/pkg/apis/multiclusterdns/v1alpha1/servicednsrecord_types.go
@@ -49,8 +49,8 @@ type ClusterDNS struct {
 	Cluster string `json:"cluster,omitempty"`
 	// LoadBalancer for the corresponding service
 	LoadBalancer corev1.LoadBalancerStatus `json:"loadBalancer,omitempty"`
-	// Zone to which the cluster belongs
-	Zone string `json:"zone,omitempty"`
+	// Zones to which the cluster belongs
+	Zones []string `json:"zones,omitempty"`
 	// Region to which the cluster belongs
 	Region string `json:"region,omitempty"`
 }

--- a/pkg/apis/multiclusterdns/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/multiclusterdns/v1alpha1/zz_generated.deepcopy.go
@@ -28,6 +28,11 @@ import (
 func (in *ClusterDNS) DeepCopyInto(out *ClusterDNS) {
 	*out = *in
 	in.LoadBalancer.DeepCopyInto(&out.LoadBalancer)
+	if in.Zones != nil {
+		in, out := &in.Zones, &out.Zones
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/controller/servicedns/controller.go
+++ b/pkg/controller/servicedns/controller.go
@@ -299,10 +299,14 @@ func (c *Controller) reconcile(qualifiedName util.QualifiedName) util.Reconcilia
 	var fedDNSStatus []dnsv1a1.ClusterDNS
 	// Iterate through all ready clusters and aggregate the service status for the key
 	for _, cluster := range clusters {
+		if cluster.Status.Region == "" || len(cluster.Status.Zones) == 0 {
+			runtime.HandleError(errors.Wrapf(err, "Cluster %q does not have Region or Zones Attributes", cluster.Name))
+			return util.StatusError
+		}
 		clusterDNS := dnsv1a1.ClusterDNS{
 			Cluster: cluster.Name,
 			Region:  cluster.Status.Region,
-			Zone:    cluster.Status.Zone,
+			Zones:   cluster.Status.Zones,
 		}
 
 		// If there are no endpoints for the service, the service is not backed by pods


### PR DESCRIPTION
Fixes: https://github.com/kubernetes-sigs/federation-v2/issues/678

This PR adds additional zone level DNS record to take care of cross-cluster service discovery in case of multi-zone clusters