### PR TITLE
Removal of the FederatedTypeConfig for namespaces disables all namespaced sync controllers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Unreleased
+-  [#722](https://github.com/kubernetes-sigs/federation-v2/issues/722) -
+   Removal of the FederatedTypeConfig for namespaces now disables all
+   namespaced sync controllers. Additionally, the namespace FederatedTypeConfig
+   must always exist prior to starting any namespaced sync controller.
  - [#612](https://github.com/kubernetes-sigs/federation-v2/pull/612) -
    Label managed resources in member clusters and only watch resources
    so labeled to minimize the memory usage of the federated control

--- a/pkg/apis/core/typeconfig/interface.go
+++ b/pkg/apis/core/typeconfig/interface.go
@@ -30,4 +30,5 @@ type Interface interface {
 	GetStatus() *metav1.APIResource
 	GetEnableStatus() bool
 	GetFederatedNamespaced() bool
+	IsNamespace() bool
 }

--- a/pkg/apis/core/v1alpha1/federatedtypeconfig_types.go
+++ b/pkg/apis/core/v1alpha1/federatedtypeconfig_types.go
@@ -212,12 +212,16 @@ func (f *FederatedTypeConfig) GetFederatedNamespaced() bool {
 	// type differing from the scope of its target.
 
 	// TODO(marun) Use the constant in pkg/controller/util
-	if f.Name == "namespaces" {
+	if f.IsNamespace() {
 		// Namespace placement is namespaced to allow the control
 		// plane to run with only namespace-scoped permissions.
 		return true
 	}
 	return f.Spec.Namespaced
+}
+
+func (f *FederatedTypeConfig) IsNamespace() bool {
+	return f.Name == "namespaces"
 }
 
 func apiResourceToMeta(apiResource APIResource, namespaced bool) metav1.APIResource {

--- a/pkg/controller/federatedtypeconfig/controller.go
+++ b/pkg/controller/federatedtypeconfig/controller.go
@@ -46,12 +46,6 @@ type Controller struct {
 	// Arguments to use when starting new controllers
 	controllerConfig *util.ControllerConfig
 
-	// The federated namespace api resource will be needed to start
-	// sync controllers for namespaced federated types.  The placement
-	// for a federated namespace is used in determining the placement
-	// of resources contained by that namespace.
-	fedNamespaceAPIResource *metav1.APIResource
-
 	client genericclient.Client
 
 	// Map of running sync controllers keyed by qualified target type
@@ -371,15 +365,8 @@ func (c *Controller) namespaceFTCExists() bool {
 }
 
 func (c *Controller) getFederatedNamespaceAPIResource() (*metav1.APIResource, error) {
-	// TODO(marun) Document the requirement to restart the controller
-	// manager if the federated namespace resource changes.
-
 	c.lock.Lock()
 	defer c.lock.Unlock()
-
-	if c.fedNamespaceAPIResource != nil {
-		return c.fedNamespaceAPIResource, nil
-	}
 
 	qualifiedName := util.QualifiedName{
 		Namespace: c.controllerConfig.FederationNamespace,
@@ -395,8 +382,7 @@ func (c *Controller) getFederatedNamespaceAPIResource() (*metav1.APIResource, er
 	}
 	namespaceTypeConfig := cachedObj.(*corev1a1.FederatedTypeConfig)
 	apiResource := namespaceTypeConfig.GetFederatedType()
-	c.fedNamespaceAPIResource = &apiResource
-	return c.fedNamespaceAPIResource, nil
+	return &apiResource, nil
 }
 
 func (c *Controller) reconcileOnNamespaceFTCDelete() {

--- a/pkg/controller/federatedtypeconfig/controller.go
+++ b/pkg/controller/federatedtypeconfig/controller.go
@@ -289,11 +289,11 @@ func (c *Controller) startSyncController(tc *corev1a1.FederatedTypeConfig) error
 	// cluster-scoped federation control plane.  A namespace-scoped
 	// control plane would still have to use a non-shared informer due
 	// to it not being possible to limit its scope.
+	kind := tc.Spec.FederatedType.Kind
 	fedNamespaceAPIResource, err := c.getFederatedNamespaceAPIResource()
 	if err != nil {
-		return err
+		return errors.Wrapf(err, "Unable to start sync controller for %q due to missing FederatedTypeConfig for namespaces", kind)
 	}
-	kind := tc.Spec.FederatedType.Kind
 	stopChan := make(chan struct{})
 	err = synccontroller.StartFederationSyncController(c.controllerConfig, stopChan, tc, fedNamespaceAPIResource)
 	if err != nil {


### PR DESCRIPTION
~~**NOTE**: This PR is not reviewable until #821 merges.~~

This change modifies the `FederatedTypeConfig` controller to start/stop all enabled namespaced sync controllers if the namespace `FederatedTypeConfig` resource is created/deleted. It will also fail to start any namespaced sync controller if the namespaced `FederatedTypeConfig` resource does not exist.

This also reverts a change to add and remove a finalizer for the FTC, requiring some E2E test changes, and discovering a couple race conditions along the way.

As a future follow-up soon, I will refactor the FTC controller, particularly the `reconcile` method.

Fixes #722

Edited:
I think we should add E2E tests for the FTC controller in the near future.