### PR TITLE
Release v0.0.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Unreleased
+
+# v0.0.9
 -  [#776](https://github.com/kubernetes-sigs/federation-v2/pull/776) -
    Switch to use `scope` instead of `limitedScope` to specify if it is
    `Namespaced` or `Cluster` scoped federation deployment.

--- a/charts/index.yaml
+++ b/charts/index.yaml
@@ -2,6 +2,14 @@ apiVersion: v1
 entries:
   federation-v2:
   - apiVersion: v1
+    created: 2019-04-29T22:11:58.917695043-07:00
+    description: Kubernetes Federation V2 helm chart
+    digest: b0dc5f35ef7b5fcc8604881d97a033af2cbdb5ea221b4702ca098bc4ef1c7dc5
+    name: federation-v2
+    urls:
+    - https://github.com/kubernetes-sigs/federation-v2/releases/download/v0.0.9/federation-v2-0.0.9.tgz
+    version: 0.0.9
+  - apiVersion: v1
     created: 2019-04-10T22:19:18.130342567-07:00
     description: Kubernetes Federation V2 helm chart
     digest: 99e3236f43ac81dbdf04e9ad47914e5782dbb6a97a5bb2bf9d2d6ec3d73d9afc
@@ -9,4 +17,4 @@ entries:
     urls:
     - https://github.com/kubernetes-sigs/federation-v2/releases/download/v0.0.8/federation-v2-0.0.8.tgz
     version: 0.0.8
-generated: 2019-04-10T22:19:18.127937045-07:00
+generated: 2019-04-29T22:11:58.915072178-07:00

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -30,10 +30,13 @@ Creating a federation v2 release involves the following steps:
    3. `cd charts` (from repo root)
    4. `helm package federation-v2`
    5. `sha256sum federation-v2-<x.x.x>.tgz > federation-v2-<x.x.x>.tgz.sha`
-   6. `helm repo index . --merge index.yaml --url=https://github.com/kubernetes-sigs/federation-v2/releases/download/v<x.x.x>/federation-v2-<x.x.x>.tgz` (Add the new version to the chart index)
-   7. Ensure index.yaml contains the added release
-   8. Propose a PR that updates index.yaml
+   6. `helm repo index . --merge index.yaml --url=https://github.com/kubernetes-sigs/federation-v2/releases/download/v<x.x.x>` (Add the new version to the chart index)
+   7. Check that index.yaml contains the added release
 4. Create github release
-   - Copy text from old release and replace old tag references
-   - Add `kubefed2.tgz` and `kubefed2.tgz.sha`
-   - Add `federation-v2-<x.x.x>.tgz` and `federation-v2-<x.x.x>.tgz.sha`
+   1. Copy text from old release and replace old tag references
+   2. Add a synopsis of the `Unreleased` section of `CHANGELOG.md`
+   3. Add `kubefed2.tgz` and `kubefed2.tgz.sha`
+   4. Add `federation-v2-<x.x.x>.tgz` and `federation-v2-<x.x.x>.tgz.sha`
+5. Update master
+   1. Move the contents of the `Unreleased` section of `CHANGELOG.md` to `v<x.x.x>`
+   2. Propose a PR that includes changes to `charts/index.yaml` (from `4.6`) and `CHANGELOG.md`


### PR DESCRIPTION
v0.0.9 has been [released](https://github.com/kubernetes-sigs/federation-v2/releases/tag/v0.0.9).  This PR includes the supporting updates to the chart index and changelog.  I've also done a bit of cleanup on the releasing instructions and added some steps that were missing.

Please merge asap to ensure the updated chart index is available for use.