### PR TITLE
namespaced leader elector RBAC for cluster scope federation

### DIFF
--- a/charts/federation-v2/charts/controllermanager/templates/clusterrole.yaml
+++ b/charts/federation-v2/charts/controllermanager/templates/clusterrole.yaml
@@ -64,20 +64,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - configmaps
-  verbs:
-  - get
-  - create
-  - update
-- apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - get
-- apiGroups:
-  - ""
-  resources:
   - events
   verbs:
   - get

--- a/charts/federation-v2/charts/controllermanager/templates/role.yaml
+++ b/charts/federation-v2/charts/controllermanager/templates/role.yaml
@@ -56,6 +56,26 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - events
+  verbs:
+  - get
+  - create
+  - update
+  - patch
+{{- end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    api: federation
+    kubebuilder.k8s.io: 1.0.0
+  name: federation-config-role
+  namespace: {{ .Release.Namespace }}
+rules:
+- apiGroups:
+  - ""
+  resources:
   - configmaps
   verbs:
   - get
@@ -67,13 +87,3 @@ rules:
   - secrets
   verbs:
   - get
-- apiGroups:
-  - ""
-  resources:
-  - events
-  verbs:
-  - get
-  - create
-  - update
-  - patch
-{{- end }}

--- a/charts/federation-v2/charts/controllermanager/templates/rolebindings.yaml
+++ b/charts/federation-v2/charts/controllermanager/templates/rolebindings.yaml
@@ -1,5 +1,4 @@
 {{- if and .Values.global.scope (eq .Values.global.scope "Namespaced") }}
----
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -14,3 +13,17 @@ subjects:
   name: federation-controller
   namespace: {{ .Release.Namespace }}
 {{- end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: federation-config-rolebinding
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: federation-config-role
+subjects:
+- kind: ServiceAccount
+  name: federation-controller
+  namespace: {{ .Release.Namespace }}


### PR DESCRIPTION
A new role for leader elector is created in federation controller namespace for bindings.
`secret` and `configmap` has minimum privilege

Fixes #687
