### PR TITLE
Cleanup ci script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,6 @@ install:
 
 script:
   - test $DOC_ONLY && echo "Skipped!" || DOWNLOAD_BINARIES=y bash -x ./scripts/pre-commit.sh
-  - test $DOC_ONLY && echo "Skipped!" || vendor/github.com/kubernetes/repo-infra/verify/verify-boilerplate.sh --rootdir="$GOPATH/src/github.com/kubernetes-sigs/federation-v2" -v
 
 after_success:
   - test $DOC_ONLY && echo "Skipped!" || ./scripts/imagebuild.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,11 +20,9 @@ before_install:
 # The dependencies have already been vendored by `dep` so
 # we don't need to fetch them.
 install:
-  - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.16.0
-  - golangci-lint --version
+  -
 
 script:
-  - test $DOC_ONLY && echo "Skipped!" || golangci-lint run
   - test $DOC_ONLY && echo "Skipped!" || DOWNLOAD_BINARIES=y bash -x ./scripts/pre-commit.sh
   - test $DOC_ONLY && echo "Skipped!" || vendor/github.com/kubernetes/repo-infra/verify/verify-boilerplate.sh --rootdir="$GOPATH/src/github.com/kubernetes-sigs/federation-v2" -v
 

--- a/scripts/download-binaries.sh
+++ b/scripts/download-binaries.sh
@@ -49,7 +49,7 @@ curl "${curl_args}O" "${kb_url}" \
   && tar xzfP "${kb_tgz}" -C "${dest_dir}" --strip-components=2 \
   && rm "${kb_tgz}"
 
-helm_version="2.11.0"
+helm_version="2.13.1"
 helm_tgz="helm-v${helm_version}-${platform}-amd64.tar.gz"
 helm_url="https://storage.googleapis.com/kubernetes-helm/$helm_tgz"
 curl "${curl_args}O" "${helm_url}" \

--- a/scripts/download-binaries.sh
+++ b/scripts/download-binaries.sh
@@ -67,8 +67,6 @@ curl "${curl_args}O" "${golint_url}" \
 echo    "# destination:"
 echo    "#   ${dest_dir}"
 echo    "# versions:"
-echo -n "#   etcd:           "; ("${dest_dir}/etcd" --version || :) | grep "etcd Version:"
-echo -n "#   kube-apiserver: "; "${dest_dir}/kube-apiserver" --version
 echo -n "#   kubectl:        "; "${dest_dir}/kubectl" version --client --short
 echo -n "#   kubebuilder:    "; "${dest_dir}/kubebuilder" version
 echo -n "#   helm:           "; "${dest_dir}/helm" version --client --short

--- a/scripts/download-binaries.sh
+++ b/scripts/download-binaries.sh
@@ -56,6 +56,14 @@ curl "${curl_args}O" "${helm_url}" \
     && tar xzfp "${helm_tgz}" -C "${dest_dir}" --strip-components=1 "${platform}-amd64/helm" \
     && rm "${helm_tgz}"
 
+golint_version="1.16.0"
+golint_dir="golangci-lint-${golint_version}-${platform}-amd64"
+golint_tgz="${golint_dir}.tar.gz"
+golint_url="https://github.com/golangci/golangci-lint/releases/download/v1.16.0/${golint_tgz}"
+curl "${curl_args}O" "${golint_url}" \
+    && tar xzfP "${golint_tgz}" -C "${dest_dir}" "${golint_dir}/golangci-lint" --strip-components=1 \
+    && rm "${golint_tgz}"
+
 echo    "# destination:"
 echo    "#   ${dest_dir}"
 echo    "# versions:"
@@ -64,3 +72,4 @@ echo -n "#   kube-apiserver: "; "${dest_dir}/kube-apiserver" --version
 echo -n "#   kubectl:        "; "${dest_dir}/kubectl" version --client --short
 echo -n "#   kubebuilder:    "; "${dest_dir}/kubebuilder" version
 echo -n "#   helm:           "; "${dest_dir}/helm" version --client --short
+echo -n "#   golangci-lint:  "; "${dest_dir}/golangci-lint" --version

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -113,6 +113,9 @@ check-git-state
 echo "Verifying Gofmt"
 ./hack/go-tools/verify-gofmt.sh
 
+echo "Checking boilerplate text"
+./vendor/github.com/kubernetes/repo-infra/verify/verify-boilerplate.sh --rootdir="${ROOT_DIR}" -v
+
 echo "Linting"
 golangci-lint run
 

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -113,6 +113,9 @@ check-git-state
 echo "Verifying Gofmt"
 ./hack/go-tools/verify-gofmt.sh
 
+echo "Linting"
+golangci-lint run
+
 echo "Checking that correct Error Package is used."
 ./hack/verify-errpkg.sh
 


### PR DESCRIPTION
Recently I saw a CI job that the linter failed but that still ran all the tests.  I realized that travis runs script entries in parallel, which isn't the behavior we want, and also that instructions included in `.travis.yml` aren't easy for developers to reuse.  That prompted me to make the following changes to ensure our ci job fails fast on low-cost tests and is easier to reproduce locally:

 - moved the download and execution of `golangci-lint` to the `pre-commit.sh` script
 - moved the execution of the boilerplate check to `pre-commit.sh`

I also updated the version of helm to the latest and removed some unnecessary log output.