### PR TITLE
Fix issues with FederatedTypeConfig controller

### DIFF
--- a/pkg/controller/federatedtypeconfig/controller.go
+++ b/pkg/controller/federatedtypeconfig/controller.go
@@ -79,7 +79,7 @@ func StartController(config *util.ControllerConfig, stopChan <-chan struct{}) er
 // newController returns a new controller to manage FederatedTypeConfig objects.
 func newController(config *util.ControllerConfig) (*Controller, error) {
 	userAgent := "FederatedTypeConfig"
-	kubeConfig := config.KubeConfig
+	kubeConfig := restclient.CopyConfig(config.KubeConfig)
 	restclient.AddUserAgent(kubeConfig, userAgent)
 	genericclient, err := genericclient.New(kubeConfig)
 	if err != nil {
@@ -98,7 +98,7 @@ func newController(config *util.ControllerConfig) (*Controller, error) {
 	// restrictive authz can be applied to a namespaced
 	// control plane.
 	c.store, c.controller, err = util.NewGenericInformer(
-		config.KubeConfig,
+		kubeConfig,
 		config.FederationNamespace,
 		&corev1a1.FederatedTypeConfig{},
 		util.NoResyncPeriod,

--- a/pkg/controller/federatedtypeconfig/controller.go
+++ b/pkg/controller/federatedtypeconfig/controller.go
@@ -230,12 +230,15 @@ func (c *Controller) reconcile(qualifiedName util.QualifiedName) util.Reconcilia
 	}
 
 	typeConfig.Status.ObservedGeneration = typeConfig.Generation
-	if syncRunning {
+	syncControllerRunning := startNewSyncController || (syncRunning && !stopSyncController)
+	if syncControllerRunning {
 		typeConfig.Status.PropagationController = corev1a1.ControllerStatusRunning
 	} else {
 		typeConfig.Status.PropagationController = corev1a1.ControllerStatusNotRunning
 	}
-	if statusRunning {
+
+	statusControllerRunning := startNewStatusController || (statusRunning && !stopStatusController)
+	if statusControllerRunning {
 		typeConfig.Status.StatusController = corev1a1.ControllerStatusRunning
 	} else {
 		typeConfig.Status.StatusController = corev1a1.ControllerStatusNotRunning

--- a/pkg/controller/federatedtypeconfig/controller.go
+++ b/pkg/controller/federatedtypeconfig/controller.go
@@ -324,6 +324,7 @@ func (c *Controller) ensureFinalizer(tc *corev1a1.FederatedTypeConfig) error {
 	}
 	finalizers.Insert(finalizer)
 	accessor.SetFinalizers(finalizers.List())
+	err = c.client.Update(context.TODO(), tc)
 	return err
 }
 
@@ -338,7 +339,7 @@ func (c *Controller) removeFinalizer(tc *corev1a1.FederatedTypeConfig) error {
 	}
 	finalizers.Delete(finalizer)
 	accessor.SetFinalizers(finalizers.List())
-	err = c.client.UpdateStatus(context.TODO(), tc)
+	err = c.client.Update(context.TODO(), tc)
 	return err
 }
 

--- a/pkg/controller/schedulingmanager/controller.go
+++ b/pkg/controller/schedulingmanager/controller.go
@@ -63,10 +63,6 @@ func (s *SchedulerWrapper) HasPlugin(typeConfigName string) bool {
 }
 
 func StartSchedulingManager(config *util.ControllerConfig, stopChan <-chan struct{}) (*SchedulingManager, error) {
-	userAgent := "SchedulingManager"
-	kubeConfig := config.KubeConfig
-	restclient.AddUserAgent(kubeConfig, userAgent)
-
 	manager, err := newSchedulingManager(config)
 	if err != nil {
 		return nil, err
@@ -86,6 +82,10 @@ func newSchedulerWrapper(schedulerInterface schedulingtypes.Scheduler, stopChan 
 }
 
 func newSchedulingManager(config *util.ControllerConfig) (*SchedulingManager, error) {
+	userAgent := "SchedulingManager"
+	kubeConfig := restclient.CopyConfig(config.KubeConfig)
+	restclient.AddUserAgent(kubeConfig, userAgent)
+
 	c := &SchedulingManager{
 		config:     config,
 		schedulers: util.NewSafeMap(),
@@ -95,7 +95,7 @@ func newSchedulingManager(config *util.ControllerConfig) (*SchedulingManager, er
 
 	var err error
 	c.store, c.controller, err = util.NewGenericInformer(
-		config.KubeConfig,
+		kubeConfig,
 		config.FederationNamespace,
 		&corev1a1.FederatedTypeConfig{},
 		util.NoResyncPeriod,

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -155,6 +155,12 @@ kubectl scale deployments federation-controller-manager -n federation-system --r
 echo "Running e2e tests with race detector against cluster-scoped federation-v2 with in-memory controllers"
 run-e2e-tests-with-in-memory-controllers
 
+# FederatedTypeConfig controller is needed to remove finalizers from
+# FederatedTypeConfigs in order to successfully delete federation in the next
+# step.
+echo "Scaling back up cluster-scoped controller manager prior to deletion"
+kubectl scale deployments federation-controller-manager -n federation-system --replicas=1
+
 echo "Deleting cluster-scoped federation-v2"
 ./scripts/delete-federation.sh
 

--- a/test/e2e/framework/controller.go
+++ b/test/e2e/framework/controller.go
@@ -22,6 +22,7 @@ import (
 	"github.com/kubernetes-sigs/federation-v2/pkg/apis/core/typeconfig"
 	"github.com/kubernetes-sigs/federation-v2/pkg/controller/dnsendpoint"
 	"github.com/kubernetes-sigs/federation-v2/pkg/controller/federatedcluster"
+	"github.com/kubernetes-sigs/federation-v2/pkg/controller/federatedtypeconfig"
 	"github.com/kubernetes-sigs/federation-v2/pkg/controller/ingressdns"
 	"github.com/kubernetes-sigs/federation-v2/pkg/controller/schedulingmanager"
 	"github.com/kubernetes-sigs/federation-v2/pkg/controller/servicedns"
@@ -50,6 +51,20 @@ func NewSyncControllerFixture(tl common.TestLogger, controllerConfig *util.Contr
 		if err != nil {
 			tl.Fatalf("Error starting status controller: %v", err)
 		}
+	}
+	return f
+}
+
+// NewFederatedTypeConfigControllerFixure initializes a new federatedtypeconfig
+// controller fixure.
+func NewFederatedTypeConfigControllerFixture(tl common.TestLogger, config *util.ControllerConfig) *ControllerFixture {
+	f := &ControllerFixture{
+		stopChan: make(chan struct{}),
+	}
+
+	err := federatedtypeconfig.StartController(config, f.stopChan)
+	if err != nil {
+		tl.Fatalf("Error starting federatedtypeconfig controller: %v", err)
 	}
 	return f
 }

--- a/test/e2e/scheduling.go
+++ b/test/e2e/scheduling.go
@@ -100,6 +100,12 @@ var _ = Describe("Scheduling", func() {
 					framework.Skipf("The scheduling manager can only be tested when controllers are running in-process.")
 				}
 
+				// The deletion of FederatedTypeConfigs performed by this test
+				// requires the FederatedTypeConfig controller in order to
+				// remove its finalizer for proper deletion.
+				controllerFixture = framework.NewFederatedTypeConfigControllerFixture(tl, f.ControllerConfig())
+				f.RegisterFixture(controllerFixture)
+
 				// make sure scheduler/plugin initialization are done before our test
 				By("Waiting for scheduler/plugin controllers are initialized in scheduling manager")
 				waitForSchedulerStarted(tl, controller, schedulingTypes)


### PR DESCRIPTION
This PR has the following changes:
- Reverts a change to add/remove finalizers when a `FederatedTypeConfig` is created/deleted.
- Fixes `FederatedTypeConfig` status to set the correct current status.
- Fixes E2E tests associated with `FederatedTypeConfig` finalizer changes.
- Fixes race conditions associated with the `FederatedTypeConfig` controller.