### PR TITLE
Federate resources from input yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Unreleased
+-  [#832](https://github.com/kubernetes-sigs/federation-v2/issues/832)
+   `kubefedctl federate` can take input from a file via `--filename`
+   option and stdin via `--filename -` option.
 -  [#868](https://github.com/kubernetes-sigs/federation-v2/issues/868)
    The default kubefed system namespace has been changed from
    `federation-system` to `kube-federation-system`.  The `kube-`
@@ -6,7 +9,7 @@
    having the kubefed namespace conflict with a user namespace.
 -  [#740](https://github.com/kubernetes-sigs/federation-v2/issues/740)
    Propagation status is now recorded for all federated resources.
-- [#844](https://github.com/kubernetes-sigs/federation-v2/pull/844)
+-  [#844](https://github.com/kubernetes-sigs/federation-v2/pull/844)
    `kubefedctl federate` namespace with its content gets an option to
    skip API Resources via `--skip-api-resources`.
 

--- a/pkg/kubefedctl/federate/federate.go
+++ b/pkg/kubefedctl/federate/federate.go
@@ -168,16 +168,16 @@ func (j *federateResource) Run(cmdOut io.Writer, config util.FedConfig) error {
 	}
 
 	if len(j.filename) > 0 {
-		resources, err := decodeUnstructuredFromFile(j.filename)
+		resources, err := DecodeUnstructuredFromFile(j.filename)
 		if err != nil {
 			return errors.Wrapf(err, "Failed to load yaml from file %q", j.filename)
 		}
-		federatedResources, err := federateResources(resources)
+		federatedResources, err := FederateResources(resources)
 		if err != nil {
 			return err
 		}
 
-		err = writeUnstructuredObjsToYaml(federatedResources, cmdOut)
+		err = WriteUnstructuredObjsToYaml(federatedResources, cmdOut)
 		if err != nil {
 			return errors.Wrap(err, "Failed to write federated resources to YAML")
 		}
@@ -211,7 +211,7 @@ func (j *federateResource) Run(cmdOut io.Writer, config util.FedConfig) error {
 
 	if j.outputYAML {
 		for _, artifacts := range artifactsList {
-			err := writeUnstructuredObjsToYaml(artifacts.federatedResources, cmdOut)
+			err := WriteUnstructuredObjsToYaml(artifacts.federatedResources, cmdOut)
 			if err != nil {
 				return errors.Wrap(err, "Failed to write federated resource to YAML")
 			}
@@ -222,7 +222,7 @@ func (j *federateResource) Run(cmdOut io.Writer, config util.FedConfig) error {
 	return CreateResources(cmdOut, hostConfig, artifactsList, j.FederationNamespace, j.enableType, j.DryRun)
 }
 
-func federateResources(resources []*unstructured.Unstructured) ([]*unstructured.Unstructured, error) {
+func FederateResources(resources []*unstructured.Unstructured) ([]*unstructured.Unstructured, error) {
 	var federatedResources []*unstructured.Unstructured
 	for _, targetResource := range resources {
 		// A Group, a Version and a Kind is sufficient for API Resource definition.
@@ -514,7 +514,7 @@ func GetContainedArtifactsList(hostConfig *rest.Config, containerNamespace, fede
 	return artifactsList, nil
 }
 
-func writeUnstructuredObjsToYaml(unstructuredObjs []*unstructured.Unstructured, w io.Writer) error {
+func WriteUnstructuredObjsToYaml(unstructuredObjs []*unstructured.Unstructured, w io.Writer) error {
 	for _, unstructuredObj := range unstructuredObjs {
 		if _, err := w.Write([]byte("---\n")); err != nil {
 			return errors.Wrap(err, "Error encoding object to yaml")

--- a/pkg/kubefedctl/federate/util.go
+++ b/pkg/kubefedctl/federate/util.go
@@ -212,9 +212,16 @@ func getResourcesInNamespace(config *rest.Config, namespace string, skipAPIResou
 
 // decodeUnstructuredFromFile reads a list of yamls into a slice of unstructured objects
 func decodeUnstructuredFromFile(filename string) ([]*unstructured.Unstructured, error) {
-	f, err := os.Open(filename)
-	if err != nil {
-		return nil, err
+	var f *os.File
+	if filename == "-" {
+		f = os.Stdin
+	} else {
+		var err error
+		f, err = os.Open(filename)
+
+		if err != nil {
+			return nil, err
+		}
 	}
 	defer f.Close()
 

--- a/pkg/kubefedctl/federate/util.go
+++ b/pkg/kubefedctl/federate/util.go
@@ -211,7 +211,7 @@ func getResourcesInNamespace(config *rest.Config, namespace string, skipAPIResou
 }
 
 // decodeUnstructuredFromFile reads a list of yamls into a slice of unstructured objects
-func decodeUnstructuredFromFile(filename string) ([]*unstructured.Unstructured, error) {
+func DecodeUnstructuredFromFile(filename string) ([]*unstructured.Unstructured, error) {
 	var f *os.File
 	if filename == "-" {
 		f = os.Stdin


### PR DESCRIPTION
- Federates resources given in input yaml (emits yaml output).
- Takes input from `stdin` if `-` is specified for file name.