### PR TITLE
Write propagation status to reconciled federated resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Unreleased
+-  [#740](https://github.com/kubernetes-sigs/federation-v2/issues/740)
+   Propagation status is now recorded for all federated resources.
 - [#844](https://github.com/kubernetes-sigs/federation-v2/pull/844)
    `kubefedctl federate` namespace with its content gets an option to
    skip API Resources via `--skip-api-resources`.
-
 
 # v0.0.10
 -  [#722](https://github.com/kubernetes-sigs/federation-v2/issues/722) -
@@ -20,7 +21,7 @@
  - [#825](https://github.com/kubernetes-sigs/federation-v2/pull/825) -
    kubefed2 tool is renamed to kubefedctl.
  - [#741](https://github.com/kubernetes-sigs/federation-v2/pull/741) -
-   Added conversion of a namespace and its contents to federated 
+   Added conversion of a namespace and its contents to federated
    equivalents via `kubefedctl federate ns <namespace> --contents`.
 
 # v0.0.9
@@ -43,7 +44,7 @@
  - [#549](https://github.com/kubernetes-sigs/federation-v2/pull/549) -
    As a result of watching only labled resources, unlabled resources
    in unselected clusters will no longer be deleted.
- - [#663](https://github.com/kubernetes-sigs/federation-v2/pull/663) 
+ - [#663](https://github.com/kubernetes-sigs/federation-v2/pull/663)
    `kubefed2 federate` now supports the `--enable-type` flag to optionally
    enable the given `type` for propagation.
 
@@ -76,11 +77,10 @@
    `retainReplicas` of type `boolean` rather than the invalid type
    `bool`.
 - [#662](https://github.com/kubernetes-sigs/federation-v2/pull/662)
-   Federating a resource could now function without a federation API. 
+   Federating a resource could now function without a federation API.
 - [#661](https://github.com/kubernetes-sigs/federation-v2/pull/661)
    Accept group qualified type name for type in federate resource.
 - [#660](https://github.com/kubernetes-sigs/federation-v2/pull/660)
-   `kubefed2 federate` has been updated to support output to yaml via 
+   `kubefed2 federate` has been updated to support output to yaml via
    `-o yaml`. YAML output would still require a Kubernetes API endpoint
-    to function. 
-   
+    to function.

--- a/charts/federation-v2/templates/crds.yaml
+++ b/charts/federation-v2/templates/crds.yaml
@@ -12,6 +12,8 @@ spec:
     kind: FederatedClusterRole
     plural: federatedclusterroles
   scope: Cluster
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       properties:
@@ -262,6 +264,40 @@ spec:
                   type: array
               type: object
           type: object
+        status:
+          properties:
+            clusters:
+              items:
+                properties:
+                  name:
+                    type: string
+                  status:
+                    type: string
+                required:
+                - name
+                type: object
+              type: array
+            conditions:
+              items:
+                properties:
+                  lastProbeTime:
+                    format: date-time
+                    type: string
+                  lastTransitionTime:
+                    format: date-time
+                    type: string
+                  reason:
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    type: string
+                required:
+                - type
+                - status
+                type: object
+              type: array
+          type: object
   version: v1alpha1
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -278,6 +314,8 @@ spec:
     shortNames:
     - fcm
   scope: Namespaced
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       properties:
@@ -482,6 +520,40 @@ spec:
                   type: object
               type: object
           type: object
+        status:
+          properties:
+            clusters:
+              items:
+                properties:
+                  name:
+                    type: string
+                  status:
+                    type: string
+                required:
+                - name
+                type: object
+              type: array
+            conditions:
+              items:
+                properties:
+                  lastProbeTime:
+                    format: date-time
+                    type: string
+                  lastTransitionTime:
+                    format: date-time
+                    type: string
+                  reason:
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    type: string
+                required:
+                - type
+                - status
+                type: object
+              type: array
+          type: object
   version: v1alpha1
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -498,6 +570,8 @@ spec:
     shortNames:
     - fdeploy
   scope: Namespaced
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       properties:
@@ -2748,6 +2822,40 @@ spec:
                   type: object
               type: object
           type: object
+        status:
+          properties:
+            clusters:
+              items:
+                properties:
+                  name:
+                    type: string
+                  status:
+                    type: string
+                required:
+                - name
+                type: object
+              type: array
+            conditions:
+              items:
+                properties:
+                  lastProbeTime:
+                    format: date-time
+                    type: string
+                  lastTransitionTime:
+                    format: date-time
+                    type: string
+                  reason:
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    type: string
+                required:
+                - type
+                - status
+                type: object
+              type: array
+          type: object
   version: v1alpha1
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -2764,6 +2872,8 @@ spec:
     shortNames:
     - fing
   scope: Namespaced
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       properties:
@@ -3020,6 +3130,40 @@ spec:
                   type: object
               type: object
           type: object
+        status:
+          properties:
+            clusters:
+              items:
+                properties:
+                  name:
+                    type: string
+                  status:
+                    type: string
+                required:
+                - name
+                type: object
+              type: array
+            conditions:
+              items:
+                properties:
+                  lastProbeTime:
+                    format: date-time
+                    type: string
+                  lastTransitionTime:
+                    format: date-time
+                    type: string
+                  reason:
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    type: string
+                required:
+                - type
+                - status
+                type: object
+              type: array
+          type: object
   version: v1alpha1
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -3034,6 +3178,8 @@ spec:
     kind: FederatedJob
     plural: federatedjobs
   scope: Namespaced
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       properties:
@@ -5266,6 +5412,40 @@ spec:
                   type: object
               type: object
           type: object
+        status:
+          properties:
+            clusters:
+              items:
+                properties:
+                  name:
+                    type: string
+                  status:
+                    type: string
+                required:
+                - name
+                type: object
+              type: array
+            conditions:
+              items:
+                properties:
+                  lastProbeTime:
+                    format: date-time
+                    type: string
+                  lastTransitionTime:
+                    format: date-time
+                    type: string
+                  reason:
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    type: string
+                required:
+                - type
+                - status
+                type: object
+              type: array
+          type: object
   version: v1alpha1
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -5282,6 +5462,8 @@ spec:
     shortNames:
     - fns
   scope: Namespaced
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       properties:
@@ -5484,6 +5666,40 @@ spec:
                   type: object
               type: object
           type: object
+        status:
+          properties:
+            clusters:
+              items:
+                properties:
+                  name:
+                    type: string
+                  status:
+                    type: string
+                required:
+                - name
+                type: object
+              type: array
+            conditions:
+              items:
+                properties:
+                  lastProbeTime:
+                    format: date-time
+                    type: string
+                  lastTransitionTime:
+                    format: date-time
+                    type: string
+                  reason:
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    type: string
+                required:
+                - type
+                - status
+                type: object
+              type: array
+          type: object
   version: v1alpha1
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -5500,6 +5716,8 @@ spec:
     shortNames:
     - frs
   scope: Namespaced
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       properties:
@@ -7723,6 +7941,40 @@ spec:
                   type: object
               type: object
           type: object
+        status:
+          properties:
+            clusters:
+              items:
+                properties:
+                  name:
+                    type: string
+                  status:
+                    type: string
+                required:
+                - name
+                type: object
+              type: array
+            conditions:
+              items:
+                properties:
+                  lastProbeTime:
+                    format: date-time
+                    type: string
+                  lastTransitionTime:
+                    format: date-time
+                    type: string
+                  reason:
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    type: string
+                required:
+                - type
+                - status
+                type: object
+              type: array
+          type: object
   version: v1alpha1
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -7737,6 +7989,8 @@ spec:
     kind: FederatedSecret
     plural: federatedsecrets
   scope: Namespaced
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       properties:
@@ -7943,6 +8197,40 @@ spec:
                   type: string
               type: object
           type: object
+        status:
+          properties:
+            clusters:
+              items:
+                properties:
+                  name:
+                    type: string
+                  status:
+                    type: string
+                required:
+                - name
+                type: object
+              type: array
+            conditions:
+              items:
+                properties:
+                  lastProbeTime:
+                    format: date-time
+                    type: string
+                  lastTransitionTime:
+                    format: date-time
+                    type: string
+                  reason:
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    type: string
+                required:
+                - type
+                - status
+                type: object
+              type: array
+          type: object
   version: v1alpha1
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -7959,6 +8247,8 @@ spec:
     shortNames:
     - fsa
   scope: Namespaced
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       properties:
@@ -8182,6 +8472,40 @@ spec:
                   type: array
               type: object
           type: object
+        status:
+          properties:
+            clusters:
+              items:
+                properties:
+                  name:
+                    type: string
+                  status:
+                    type: string
+                required:
+                - name
+                type: object
+              type: array
+            conditions:
+              items:
+                properties:
+                  lastProbeTime:
+                    format: date-time
+                    type: string
+                  lastTransitionTime:
+                    format: date-time
+                    type: string
+                  reason:
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    type: string
+                required:
+                - type
+                - status
+                type: object
+              type: array
+          type: object
   version: v1alpha1
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -8198,6 +8522,8 @@ spec:
     shortNames:
     - fsvc
   scope: Namespaced
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       properties:
@@ -8455,6 +8781,40 @@ spec:
                       type: string
                   type: object
               type: object
+          type: object
+        status:
+          properties:
+            clusters:
+              items:
+                properties:
+                  name:
+                    type: string
+                  status:
+                    type: string
+                required:
+                - name
+                type: object
+              type: array
+            conditions:
+              items:
+                properties:
+                  lastProbeTime:
+                    format: date-time
+                    type: string
+                  lastTransitionTime:
+                    format: date-time
+                    type: string
+                  reason:
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    type: string
+                required:
+                - type
+                - status
+                type: object
+              type: array
           type: object
   version: v1alpha1
 {{ end }}

--- a/pkg/controller/sync/dispatch/checkunmanaged.go
+++ b/pkg/controller/sync/dispatch/checkunmanaged.go
@@ -17,13 +17,13 @@ limitations under the License.
 package dispatch
 
 import (
-	"github.com/golang/glog"
 	"github.com/pkg/errors"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	pkgruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/klog"
 
 	"github.com/kubernetes-sigs/federation-v2/pkg/controller/util"
 )
@@ -64,7 +64,7 @@ func (d *checkUnmanagedDispatcherImpl) CheckRemovedOrUnlabeled(clusterName strin
 	const op = "check for deletion of resource or removal of managed label from"
 	const opContinuous = "Checking for deletion of resource or removal of managed label from"
 	go d.dispatcher.clusterOperation(clusterName, op, func(client util.ResourceClient) util.ReconciliationStatus {
-		glog.V(2).Infof(eventTemplate, opContinuous, d.targetKind, d.targetName, clusterName)
+		klog.V(2).Infof(eventTemplate, opContinuous, d.targetKind, d.targetName, clusterName)
 
 		clusterObj, err := client.Resources(d.targetName.Namespace).Get(d.targetName.Name, metav1.GetOptions{})
 		if apierrors.IsNotFound(err) {

--- a/pkg/controller/sync/status/status.go
+++ b/pkg/controller/sync/status/status.go
@@ -1,0 +1,203 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package status
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/pkg/errors"
+
+	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/kubernetes-sigs/federation-v2/pkg/controller/util"
+)
+
+type PropagationStatus string
+
+type AggregateStatus string
+
+type AggregateReason string
+
+type ConditionType string
+
+const (
+	ClusterPropagationOK PropagationStatus = ""
+	WaitingForRemoval    PropagationStatus = "WaitingForRemoval"
+
+	// Cluster-specific errors
+	ClusterNotReady        PropagationStatus = "ClusterNotReady"
+	CachedRetrievalFailed  PropagationStatus = "CachedRetrievalFailed"
+	ComputeResourceFailed  PropagationStatus = "ComputeResourceFailed"
+	CreationFailed         PropagationStatus = "CreationFailed"
+	UpdateFailed           PropagationStatus = "UpdateFailed"
+	DeletionFailed         PropagationStatus = "DeletionFailed"
+	LabelRemovalFailed     PropagationStatus = "LabelRemovalFailed"
+	RetrievalFailed        PropagationStatus = "RetrievalFailed"
+	AlreadyExists          PropagationStatus = "AlreadyExists"
+	FieldRetentionFailed   PropagationStatus = "FieldRetentionFailed"
+	VersionRetrievalFailed PropagationStatus = "VersionRetrievalFailed"
+	ClientRetrievalFailed  PropagationStatus = "ClientRetrievalFailed"
+
+	// Operation timeout errors
+	CreationTimedOut     PropagationStatus = "CreationTimedOut"
+	UpdateTimedOut       PropagationStatus = "UpdateTimedOut"
+	DeletionTimedOut     PropagationStatus = "DeletionTimedOut"
+	LabelRemovalTimedOut PropagationStatus = "LabelRemovalTimedOut"
+
+	AggregateSuccess       AggregateReason = ""
+	ClusterRetrievalFailed AggregateReason = "ClusterRetrievalFailed"
+	ComputePlacementFailed AggregateReason = "ComputePlacementFailed"
+	CheckClusters          AggregateReason = "CheckClusters"
+
+	PropagationConditionType ConditionType = "Propagation"
+)
+
+type GenericClusterStatus struct {
+	Name   string            `json:"name"`
+	Status PropagationStatus `json:"status,omitempty"`
+}
+
+type GenericCondition struct {
+	// Type of cluster condition
+	Type ConditionType `json:"type"`
+	// Status of the condition, one of True, False, Unknown.
+	Status apiv1.ConditionStatus `json:"status"`
+	// Last time the condition was checked.
+	// +optional
+	LastProbeTime string `json:"lastProbeTime,omitempty"`
+	// Last time the condition transit from one status to another.
+	// +optional
+	LastTransitionTime string `json:"lastTransitionTime,omitempty"`
+	// (brief) reason for the condition's last transition.
+	// +optional
+	Reason AggregateReason `json:"reason,omitempty"`
+}
+
+type GenericPropagationStatus struct {
+	Conditions []*GenericCondition    `json:"conditions,omitempty"`
+	Clusters   []GenericClusterStatus `json:"clusters,omitempty"`
+}
+
+type GenericFederatedStatus struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	Status *GenericPropagationStatus `json:"status,omitempty"`
+}
+
+type PropagationStatusMap map[string]PropagationStatus
+
+// SetPropagationStatus sets the conditions and clusters fields of the
+// federated resource's object map from the provided reason and
+// cluster status map.
+func SetPropagationStatus(fedObject *unstructured.Unstructured, reason AggregateReason, statusMap PropagationStatusMap) error {
+	status := &GenericFederatedStatus{}
+	err := util.UnstructuredToInterface(fedObject, status)
+	if err != nil {
+		return errors.Wrapf(err, "Failed to unmarshall to generic status")
+	}
+	if status.Status == nil {
+		status.Status = &GenericPropagationStatus{}
+	}
+	propStatus := status.Status
+
+	// Identify whether one or more clusters could not be reconciled
+	// successfully.
+	if reason == AggregateSuccess && statusMap != nil {
+		for _, value := range statusMap {
+			if value != ClusterPropagationOK {
+				reason = CheckClusters
+				break
+			}
+		}
+	}
+	propStatus.setPropagationCondition(reason)
+	propStatus.setClusterStatus(statusMap)
+
+	statusJSON, err := json.Marshal(status)
+	if err != nil {
+		return errors.Wrapf(err, "Failed to marshall generic status to json")
+	}
+	statusObj := &unstructured.Unstructured{}
+	err = statusObj.UnmarshalJSON(statusJSON)
+	if err != nil {
+		return errors.Wrapf(err, "Failed to marshall generic status json to unstructured")
+	}
+	fedObject.Object[util.StatusField] = statusObj.Object[util.StatusField]
+
+	return nil
+}
+
+// setPropagationCondition ensures that the Propagation condition is
+// updated to reflect the given reason.  The type of the condition is
+// derived from the reason (empty -> True, not empty -> False).
+func (s *GenericPropagationStatus) setPropagationCondition(reason AggregateReason) {
+	// Determine the appropriate status from the reason.
+	var newStatus apiv1.ConditionStatus
+	if reason == AggregateSuccess {
+		newStatus = apiv1.ConditionTrue
+	} else {
+		newStatus = apiv1.ConditionFalse
+	}
+
+	if s.Conditions == nil {
+		s.Conditions = []*GenericCondition{}
+	}
+	var propCondition *GenericCondition
+	for _, condition := range s.Conditions {
+		if condition.Type == PropagationConditionType {
+			propCondition = condition
+			break
+		}
+	}
+
+	newCondition := propCondition == nil
+	if newCondition {
+		propCondition = &GenericCondition{
+			Type: PropagationConditionType,
+		}
+		s.Conditions = append(s.Conditions, propCondition)
+	}
+
+	// Determine whether the latest status represents a change from
+	// the old that requires updating the transition time.
+	transition := newCondition || propCondition.Status != newStatus
+	if transition {
+		propCondition.Status = newStatus
+		propCondition.LastTransitionTime = time.Now().UTC().Format(time.RFC3339)
+
+	}
+
+	propCondition.Reason = reason
+	propCondition.LastProbeTime = time.Now().UTC().Format(time.RFC3339)
+
+}
+
+// setClusterStatus sets the cluster status slice from a propagation
+// status map.
+func (s *GenericPropagationStatus) setClusterStatus(statusMap PropagationStatusMap) {
+	s.Clusters = []GenericClusterStatus{}
+	for clusterName, status := range statusMap {
+		s.Clusters = append(s.Clusters, GenericClusterStatus{
+			Name:   clusterName,
+			Status: status,
+		})
+	}
+}

--- a/pkg/controller/sync/version/manager.go
+++ b/pkg/controller/sync/version/manager.go
@@ -351,6 +351,12 @@ func (m *VersionManager) writeVersion(obj pkgruntime.Object, qualifiedName util.
 			resourceVersion = ""
 			return false, nil
 		}
+		// Forbidden is likely to be a permanent failure and
+		// likely the result of the containing namespace being
+		// deleted.
+		if apierrors.IsForbidden(err) {
+			return false, err
+		}
 		if err != nil {
 			runtime.HandleError(errors.Wrapf(err, "Failed to update the status of %s %q", adapterType, key))
 			return false, nil

--- a/pkg/controller/util/constants.go
+++ b/pkg/controller/util/constants.go
@@ -36,6 +36,7 @@ const (
 
 	// Common fields
 	SpecField     = "spec"
+	StatusField   = "status"
 	MetadataField = "metadata"
 
 	// ServiceAccount fields
@@ -60,6 +61,15 @@ const (
 	ClusterOverridesField = "clusterOverrides"
 	PathField             = "path"
 	ValueField            = "value"
+
+	// Propagation status fields
+	ClustersField           = "clusters"
+	NameField               = "name"
+	ConditionsField         = "conditions"
+	TypeField               = "type"
+	ReasonField             = "reason"
+	LastProbeTimeField      = "lastProbeTime"
+	LastTransitionTimeField = "lastTransitionTime"
 )
 
 type ReconciliationStatus int

--- a/pkg/kubefedctl/enable/util.go
+++ b/pkg/kubefedctl/enable/util.go
@@ -74,6 +74,9 @@ func CrdForAPIResource(apiResource metav1.APIResource, validation *apiextv1b1.Cu
 				ShortNames: shortNames,
 			},
 			Validation: validation,
+			Subresources: &apiextv1b1.CustomResourceSubresources{
+				Status: &apiextv1b1.CustomResourceSubresourceStatus{},
+			},
 		},
 	}
 }

--- a/pkg/kubefedctl/enable/validation.go
+++ b/pkg/kubefedctl/enable/validation.go
@@ -171,6 +171,61 @@ func ValidationSchema(specProps v1beta1.JSONSchemaProps) *v1beta1.CustomResource
 					Type: "object",
 				},
 				"spec": specProps,
+				"status": {
+					Type: "object",
+					Properties: map[string]v1beta1.JSONSchemaProps{
+						"conditions": {
+							Type: "array",
+							Items: &v1beta1.JSONSchemaPropsOrArray{
+								Schema: &v1beta1.JSONSchemaProps{
+									Type: "object",
+									Properties: map[string]v1beta1.JSONSchemaProps{
+										"type": {
+											Type: "string",
+										},
+										"status": {
+											Type: "string",
+										},
+										"reason": {
+											Type: "string",
+										},
+										"lastProbeTime": {
+											Format: "date-time",
+											Type:   "string",
+										},
+										"lastTransitionTime": {
+											Format: "date-time",
+											Type:   "string",
+										},
+									},
+									Required: []string{
+										"type",
+										"status",
+									},
+								},
+							},
+						},
+						"clusters": {
+							Type: "array",
+							Items: &v1beta1.JSONSchemaPropsOrArray{
+								Schema: &v1beta1.JSONSchemaProps{
+									Type: "object",
+									Properties: map[string]v1beta1.JSONSchemaProps{
+										"name": {
+											Type: "string",
+										},
+										"status": {
+											Type: "string",
+										},
+									},
+									Required: []string{
+										"name",
+									},
+								},
+							},
+						},
+					},
+				},
 			},
 		},
 	}


### PR DESCRIPTION
This PR ensures that propagation status is written for federated resources.   The PR looks large but the bulk of it is actually generated crd yaml.

TODO

 - [x] Update the user documentation
 - [x] Add checks for status to the crudtester
 - [x]  Truncate `lastProbeTime` and `lastTransitionTime` to the second


Fixes #740
Fixes #588