### PR TITLE
Add script to automate build of release artifacts

### DIFF
--- a/charts/federation-v2/Chart.yaml
+++ b/charts/federation-v2/Chart.yaml
@@ -1,5 +1,4 @@
 apiVersion: v1
-appVersion: 0.0.2
 description: Kubernetes Federation V2 helm chart
 name: federation-v2
 version: 0.0.2

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -18,25 +18,15 @@ Creating a federation v2 release involves the following steps:
      annotated tag through the github web interface.
 2. Push the tag to master
    - `git push origin <tag>` (this requires write access to the repo)
-3. Build `kubefedctl` for release
-   1. `make kubefedctl`
-   2. `cd bin` (from repo root)
-   3. `kubefedctl version` (check that the output is as expected)
-   4. `tar cvzf kubefedctl.tgz kubefedctl`
-   5. `sha256sum kubefedctl.tgz > kubefedctl.tgz.sha`
-4. Package the helm chart for release
-   1. Update the default image tag in values.yaml (Change the version to match the release)
-   2. Update the chart version in Chart.yaml (Format should be `x.x.x`)
-   3. `cd charts` (from repo root)
-   4. `helm package federation-v2`
-   5. `sha256sum federation-v2-<x.x.x>.tgz > federation-v2-<x.x.x>.tgz.sha`
-   6. `helm repo index . --merge index.yaml --url=https://github.com/kubernetes-sigs/federation-v2/releases/download/v<x.x.x>` (Add the new version to the chart index)
-   7. Check that index.yaml contains the added release
+3. Build the release artifacts (will output to root of repo)
+   - `./scripts/build-release-artifacts.sh <tag>`
 4. Create github release
    1. Copy text from old release and replace old tag references
    2. Add a synopsis of the `Unreleased` section of `CHANGELOG.md`
-   3. Add `kubefedctl.tgz` and `kubefedctl.tgz.sha`
-   4. Add `federation-v2-<x.x.x>.tgz` and `federation-v2-<x.x.x>.tgz.sha`
+   3. Add `kubefedctl-<x.x.x>-linux-amd64.tgz` and `kubefedctl-<x.x.x>-linux-amd64.tgz.sha`
+   4. Add `kubefedctl-<x.x.x>-darwin-amd64.tgz` and `kubefedctl-<x.x.x>-darwin-amd64.tgz.sha`
+   5. Add `federation-v2-<x.x.x>.tgz` and `federation-v2-<x.x.x>.tgz.sha`
 5. Update master
    1. Move the contents of the `Unreleased` section of `CHANGELOG.md` to `v<x.x.x>`
-   2. Propose a PR that includes changes to `charts/index.yaml` (from `4.6`) and `CHANGELOG.md`
+   2. Propose a PR that includes changes to `charts/index.yaml`
+      (updated by the build script) and `CHANGELOG.md`

--- a/scripts/build-release-artifacts.sh
+++ b/scripts/build-release-artifacts.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script automates the building of artifacts for a release.
+#
+# Reference:  docs/releasing.md
+
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+RELEASE_TAG="${1-}"
+if [[ ! "${RELEASE_TAG}" ]]; then
+  >&2 echo "usage: $0 <release tag of the form v[0-9]+.[0-9]+.[0-9]+>"
+  exit 1
+fi
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." ; pwd)"
+RELEASE_VERSION="${RELEASE_TAG:1:${#RELEASE_TAG}-1}"
+
+pushd "${ROOT_DIR}"
+  # Build release artifacts for kubefedctl
+  make bin/kubefedctl-linux
+  make bin/kubefedctl-darwin
+  pushd "${ROOT_DIR}/bin"
+    for host_os in linux darwin; do
+      TAR_FILENAME="kubefedctl-${RELEASE_VERSION}-${host_os}-amd64.tgz"
+      BINARY_FILENAME="kubefedctl-${host_os}"
+      # The binary is built with a platform suffix, but should be archived without it.
+      tar cvzf "${TAR_FILENAME}" --transform="flags=r;s|${BINARY_FILENAME}|kubefedctl|" "${BINARY_FILENAME}"
+      sha256sum "${TAR_FILENAME}" > "${TAR_FILENAME}.sha"
+      mv "${TAR_FILENAME}" "${TAR_FILENAME}.sha" "${ROOT_DIR}/"
+    done
+  popd
+
+  # Build release artifacts for the helm chart
+  pushd "${ROOT_DIR}/charts"
+    # Update the image tag for the chart
+    sed -i.backup "s+\(  tag: \)canary+\1${RELEASE_TAG}+" federation-v2/values.yaml
+
+    # Update the chart version
+    sed -i.backup "s+\(version: \).*+\1${RELEASE_VERSION}+" federation-v2/Chart.yaml
+
+    helm package federation-v2
+
+    # Update the repo index (will need to be committed)
+    helm repo index . --merge index.yaml --url="https://github.com/kubernetes-sigs/federation-v2/releases/download/${RELEASE_TAG}"
+
+    sha256sum "federation-v2-${RELEASE_VERSION}.tgz" > "federation-v2-${RELEASE_VERSION}.tgz.sha"
+    mv federation-v2-${RELEASE_VERSION}.tgz* "${ROOT_DIR}/"
+
+    # Revert the chart changes (should not be committed)
+    mv federation-v2/values.yaml.backup federation-v2/values.yaml
+    mv federation-v2/Chart.yaml.backup federation-v2/Chart.yaml
+  popd
+popd


### PR DESCRIPTION
 - Add script to build release artifacts

 - Remove documentation of artifact build (replaced by script)

 - Remove appVersion from chart yaml to avoid having to maintain it

Partial fix for #813.   I tried automating the tag creation/push and it ended up being more trouble than it was worth.