### PR TITLE
Switch from glog to klog

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1054,7 +1054,6 @@
   analyzer-version = 1
   input-imports = [
     "github.com/ghodss/yaml",
-    "github.com/golang/glog",
     "github.com/json-iterator/go",
     "github.com/kubernetes/repo-infra/verify/boilerplate/test",
     "github.com/onsi/ginkgo",
@@ -1084,6 +1083,7 @@
     "k8s.io/apimachinery/pkg/util/uuid",
     "k8s.io/apimachinery/pkg/util/wait",
     "k8s.io/apimachinery/pkg/util/yaml",
+    "k8s.io/apimachinery/pkg/version",
     "k8s.io/apimachinery/pkg/watch",
     "k8s.io/apiserver/pkg/util/feature",
     "k8s.io/apiserver/pkg/util/flag",
@@ -1106,6 +1106,7 @@
     "k8s.io/cluster-registry/pkg/apis/clusterregistry/v1alpha1",
     "k8s.io/code-generator/cmd/client-gen",
     "k8s.io/code-generator/cmd/deepcopy-gen",
+    "k8s.io/klog",
     "k8s.io/kube-openapi/pkg/util/proto",
     "k8s.io/kubectl/pkg/framework/openapi",
     "sigs.k8s.io/controller-runtime/pkg/client",

--- a/cmd/controller-manager/app/controller-manager.go
+++ b/cmd/controller-manager/app/controller-manager.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+
 	apiextv1b1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/cmd/controller-manager/app/leaderelection/leaderelection.go
+++ b/cmd/controller-manager/app/leaderelection/leaderelection.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"os"
 
-	"github.com/golang/glog"
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	kubeclient "k8s.io/client-go/kubernetes"
@@ -30,6 +29,7 @@ import (
 	"k8s.io/client-go/tools/leaderelection"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/klog"
 
 	"github.com/kubernetes-sigs/federation-v2/cmd/controller-manager/app/options"
 )
@@ -41,7 +41,7 @@ func NewFederationLeaderElector(opts *options.Options, fnStartControllers func(*
 
 	hostname, err := os.Hostname()
 	if err != nil {
-		glog.Infof("unable to get hostname: %v", err)
+		klog.Infof("unable to get hostname: %v", err)
 		return nil, err
 	}
 
@@ -61,7 +61,7 @@ func NewFederationLeaderElector(opts *options.Options, fnStartControllers func(*
 			EventRecorder: eventRecorder,
 		})
 	if err != nil {
-		glog.Infof("couldn't create resource lock: %v", err)
+		klog.Infof("couldn't create resource lock: %v", err)
 		return nil, err
 	}
 
@@ -72,13 +72,13 @@ func NewFederationLeaderElector(opts *options.Options, fnStartControllers func(*
 		RetryPeriod:   opts.LeaderElection.RetryPeriod,
 		Callbacks: leaderelection.LeaderCallbacks{
 			OnStartedLeading: func(ctx context.Context) {
-				glog.Info("promoted as leader")
+				klog.Info("promoted as leader")
 				stopChan := ctx.Done()
 				fnStartControllers(opts, stopChan)
 				<-stopChan
 			},
 			OnStoppedLeading: func() {
-				glog.Info("leader election lost")
+				klog.Info("leader election lost")
 			},
 		},
 	})

--- a/cmd/controller-manager/app/options/options.go
+++ b/cmd/controller-manager/app/options/options.go
@@ -18,9 +18,11 @@ limitations under the License.
 package options
 
 import (
-	"github.com/kubernetes-sigs/federation-v2/pkg/controller/util"
 	"github.com/spf13/pflag"
+
 	apiextv1b1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+
+	"github.com/kubernetes-sigs/federation-v2/pkg/controller/util"
 )
 
 // Options contains everything necessary to create and run controller-manager.

--- a/cmd/hyperfed/main.go
+++ b/cmd/hyperfed/main.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+
 	utilflag "k8s.io/apiserver/pkg/util/flag"
 	"k8s.io/apiserver/pkg/util/logs"
 	_ "k8s.io/client-go/plugin/pkg/client/auth" // Load all client auth plugins for GCP, Azure, Openstack, etc

--- a/pkg/client/generic/scheme/register.go
+++ b/pkg/client/generic/scheme/register.go
@@ -17,7 +17,6 @@ limitations under the License.
 package scheme
 
 import (
-	fedapis "github.com/kubernetes-sigs/federation-v2/pkg/apis"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
@@ -25,6 +24,8 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	k8sscheme "k8s.io/client-go/kubernetes/scheme"
 	crapis "k8s.io/cluster-registry/pkg/apis/clusterregistry/v1alpha1"
+
+	fedapis "github.com/kubernetes-sigs/federation-v2/pkg/apis"
 )
 
 var Scheme = runtime.NewScheme()

--- a/pkg/controller/dnsendpoint/common.go
+++ b/pkg/controller/dnsendpoint/common.go
@@ -20,7 +20,7 @@ import (
 	"net"
 	"sort"
 
-	"github.com/golang/glog"
+	"k8s.io/klog"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -64,7 +64,7 @@ func getResolvedTargets(targets feddnsv1a1.Targets, netWrapper NetWrapper) (fedd
 			// through an interface abstracting the internet
 			ipAddrs, err := netWrapper.LookupHost(target)
 			if err != nil {
-				glog.Errorf("Failed to resolve %s, err: %v", target, err)
+				klog.Errorf("Failed to resolve %s, err: %v", target, err)
 				return resolvedTargets.List(), err
 			}
 			for _, ip := range ipAddrs {

--- a/pkg/controller/dnsendpoint/common.go
+++ b/pkg/controller/dnsendpoint/common.go
@@ -20,10 +20,9 @@ import (
 	"net"
 	"sort"
 
-	"k8s.io/klog"
-
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/klog"
 
 	feddnsv1a1 "github.com/kubernetes-sigs/federation-v2/pkg/apis/multiclusterdns/v1alpha1"
 )

--- a/pkg/controller/dnsendpoint/controller.go
+++ b/pkg/controller/dnsendpoint/controller.go
@@ -21,8 +21,8 @@ import (
 	"reflect"
 	"time"
 
-	"github.com/golang/glog"
 	"github.com/pkg/errors"
+	"k8s.io/klog"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -110,8 +110,8 @@ func (d *controller) Run(stopCh <-chan struct{}) {
 	defer runtime.HandleCrash()
 	defer d.queue.ShutDown()
 
-	glog.Infof("Starting %q DNSEndpoint controller", d.dnsObjectKind)
-	defer glog.Infof("Shutting down %q DNSEndpoint controller", d.dnsObjectKind)
+	klog.Infof("Starting %q DNSEndpoint controller", d.dnsObjectKind)
+	defer klog.Infof("Shutting down %q DNSEndpoint controller", d.dnsObjectKind)
 
 	go d.dnsObjectController.Run(stopCh)
 
@@ -121,7 +121,7 @@ func (d *controller) Run(stopCh <-chan struct{}) {
 		return
 	}
 
-	glog.Infof("%q DNSEndpoint controller synced and ready", d.dnsObjectKind)
+	klog.Infof("%q DNSEndpoint controller synced and ready", d.dnsObjectKind)
 
 	for i := 0; i < numWorkers; i++ {
 		go wait.Until(d.worker, time.Second, stopCh)
@@ -133,7 +133,7 @@ func (d *controller) Run(stopCh <-chan struct{}) {
 func (d *controller) enqueueObject(obj pkgruntime.Object) {
 	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
 	if err != nil {
-		glog.Errorf("Couldn't get key for object %#v: %v", obj, err)
+		klog.Errorf("Couldn't get key for object %#v: %v", obj, err)
 		return
 	}
 	d.queue.Add(key)
@@ -159,12 +159,12 @@ func (d *controller) processNextItem() bool {
 		// No error, tell the queue to stop tracking history
 		d.queue.Forget(key)
 	} else if d.queue.NumRequeues(key) < maxRetries {
-		glog.Errorf("Error processing %s (will retry): %v", key, err)
+		klog.Errorf("Error processing %s (will retry): %v", key, err)
 		// requeue the item to work on later
 		d.queue.AddRateLimited(key)
 	} else {
 		// err != nil and too many retries
-		glog.Errorf("Error processing %s (giving up): %v", key, err)
+		klog.Errorf("Error processing %s (giving up): %v", key, err)
 		d.queue.Forget(key)
 		runtime.HandleError(err)
 	}
@@ -174,9 +174,9 @@ func (d *controller) processNextItem() bool {
 
 func (d *controller) processItem(key string) error {
 	startTime := time.Now()
-	glog.V(4).Infof("Processing change to %q DNSEndpoint %s", d.dnsObjectKind, key)
+	klog.V(4).Infof("Processing change to %q DNSEndpoint %s", d.dnsObjectKind, key)
 	defer func() {
-		glog.V(4).Infof("Finished processing %q DNSEndpoint %q (%v)", d.dnsObjectKind, key, time.Since(startTime))
+		klog.V(4).Infof("Finished processing %q DNSEndpoint %q (%v)", d.dnsObjectKind, key, time.Since(startTime))
 	}()
 
 	namespace, name, err := cache.SplitMetaNamespaceKey(key)

--- a/pkg/controller/federatedcluster/clusterclient.go
+++ b/pkg/controller/federatedcluster/clusterclient.go
@@ -19,8 +19,8 @@ package federatedcluster
 import (
 	"strings"
 
-	"github.com/golang/glog"
 	"github.com/pkg/errors"
+	"k8s.io/klog"
 
 	fedcommon "github.com/kubernetes-sigs/federation-v2/pkg/apis/core/common"
 	fedv1a1 "github.com/kubernetes-sigs/federation-v2/pkg/apis/core/v1alpha1"
@@ -123,7 +123,7 @@ func (self *ClusterClient) GetClusterHealthStatus() *fedv1a1.FederatedClusterSta
 func (self *ClusterClient) GetClusterZones() ([]string, string, error) {
 	nodes, err := self.kubeClient.CoreV1().Nodes().List(metav1.ListOptions{})
 	if err != nil {
-		glog.Errorf("Failed to list nodes while getting zone names: %v", err)
+		klog.Errorf("Failed to list nodes while getting zone names: %v", err)
 		return nil, "", err
 	}
 

--- a/pkg/controller/federatedcluster/clusterclient.go
+++ b/pkg/controller/federatedcluster/clusterclient.go
@@ -20,18 +20,19 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
-	"k8s.io/klog"
 
-	fedcommon "github.com/kubernetes-sigs/federation-v2/pkg/apis/core/common"
-	fedv1a1 "github.com/kubernetes-sigs/federation-v2/pkg/apis/core/v1alpha1"
-	"github.com/kubernetes-sigs/federation-v2/pkg/client/generic"
-	"github.com/kubernetes-sigs/federation-v2/pkg/controller/util"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	kubeclientset "k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
+	"k8s.io/klog"
+
+	fedcommon "github.com/kubernetes-sigs/federation-v2/pkg/apis/core/common"
+	fedv1a1 "github.com/kubernetes-sigs/federation-v2/pkg/apis/core/v1alpha1"
+	"github.com/kubernetes-sigs/federation-v2/pkg/client/generic"
+	"github.com/kubernetes-sigs/federation-v2/pkg/controller/util"
 )
 
 const (

--- a/pkg/controller/federatedcluster/controller.go
+++ b/pkg/controller/federatedcluster/controller.go
@@ -21,14 +21,13 @@ import (
 	"sync"
 	"time"
 
-	"k8s.io/klog"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog"
 
 	fedv1a1 "github.com/kubernetes-sigs/federation-v2/pkg/apis/core/v1alpha1"
 	genericclient "github.com/kubernetes-sigs/federation-v2/pkg/client/generic"

--- a/pkg/controller/federatedtypeconfig/controller.go
+++ b/pkg/controller/federatedtypeconfig/controller.go
@@ -21,7 +21,6 @@ import (
 	"sync"
 
 	"github.com/pkg/errors"
-	"k8s.io/klog"
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -30,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog"
 
 	"github.com/kubernetes-sigs/federation-v2/pkg/apis/core/typeconfig"
 	corev1a1 "github.com/kubernetes-sigs/federation-v2/pkg/apis/core/v1alpha1"

--- a/pkg/controller/federatedtypeconfig/controller.go
+++ b/pkg/controller/federatedtypeconfig/controller.go
@@ -20,8 +20,8 @@ import (
 	"context"
 	"sync"
 
-	"github.com/golang/glog"
 	"github.com/pkg/errors"
+	"k8s.io/klog"
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -66,7 +66,7 @@ func StartController(config *util.ControllerConfig, stopChan <-chan struct{}) er
 	if err != nil {
 		return err
 	}
-	glog.Infof("Starting FederatedTypeConfig controller")
+	klog.Infof("Starting FederatedTypeConfig controller")
 	controller.Run(stopChan)
 	return nil
 }
@@ -128,7 +128,7 @@ func (c *Controller) Run(stopChan <-chan struct{}) {
 func (c *Controller) reconcile(qualifiedName util.QualifiedName) util.ReconciliationStatus {
 	key := qualifiedName.String()
 
-	glog.V(3).Infof("Running reconcile FederatedTypeConfig for %q", key)
+	klog.V(3).Infof("Running reconcile FederatedTypeConfig for %q", key)
 
 	cachedObj, err := c.objCopyFromCache(key)
 	if err != nil {
@@ -161,7 +161,7 @@ func (c *Controller) reconcile(qualifiedName util.QualifiedName) util.Reconcilia
 			c.lock.Lock()
 			c.stopChannels[typeConfig.Name] = holderChan
 			c.lock.Unlock()
-			glog.Infof("Skipping start of sync & status controller for cluster-scoped resource %q. It is not required for a namespaced federation control plane.", typeConfig.GetFederatedType().Kind)
+			klog.Infof("Skipping start of sync & status controller for cluster-scoped resource %q. It is not required for a namespaced federation control plane.", typeConfig.GetFederatedType().Kind)
 		}
 
 		typeConfig.Status.ObservedGeneration = typeConfig.Generation
@@ -189,7 +189,7 @@ func (c *Controller) reconcile(qualifiedName util.QualifiedName) util.Reconcilia
 		}
 
 		if typeConfig.IsNamespace() {
-			glog.Infof("Reconciling all namespaced FederatedTypeConfig resources on deletion of %q", key)
+			klog.Infof("Reconciling all namespaced FederatedTypeConfig resources on deletion of %q", key)
 			c.reconcileOnNamespaceFTCUpdate()
 		}
 
@@ -209,7 +209,7 @@ func (c *Controller) reconcile(qualifiedName util.QualifiedName) util.Reconcilia
 		// Detected creation of the namespace FTC. If there are existing FTCs
 		// which did not start their sync controllers due to the lack of a
 		// namespace FTC, then reconcile them now so they can start.
-		glog.Infof("Reconciling all namespaced FederatedTypeConfig resources on finalizer update for %q", key)
+		klog.Infof("Reconciling all namespaced FederatedTypeConfig resources on finalizer update for %q", key)
 		c.reconcileOnNamespaceFTCUpdate()
 	}
 
@@ -305,7 +305,7 @@ func (c *Controller) startSyncController(tc *corev1a1.FederatedTypeConfig) error
 		close(stopChan)
 		return errors.Wrapf(err, "Error starting sync controller for %q", kind)
 	}
-	glog.Infof("Started sync controller for %q", kind)
+	klog.Infof("Started sync controller for %q", kind)
 	c.lock.Lock()
 	defer c.lock.Unlock()
 	c.stopChannels[tc.Name] = stopChan
@@ -320,7 +320,7 @@ func (c *Controller) startStatusController(statusKey string, tc *corev1a1.Federa
 		close(stopChan)
 		return errors.Wrapf(err, "Error starting status controller for %q", kind)
 	}
-	glog.Infof("Started status controller for %q", kind)
+	klog.Infof("Started status controller for %q", kind)
 	c.lock.Lock()
 	defer c.lock.Unlock()
 	c.stopChannels[statusKey] = stopChan
@@ -328,7 +328,7 @@ func (c *Controller) startStatusController(statusKey string, tc *corev1a1.Federa
 }
 
 func (c *Controller) stopController(key string, stopChan chan struct{}) {
-	glog.Infof("Stopping controller for %q", key)
+	klog.Infof("Stopping controller for %q", key)
 	close(stopChan)
 	c.lock.Lock()
 	defer c.lock.Unlock()

--- a/pkg/controller/ingressdns/controller.go
+++ b/pkg/controller/ingressdns/controller.go
@@ -23,8 +23,8 @@ import (
 	"sort"
 	"time"
 
-	"github.com/golang/glog"
 	"github.com/pkg/errors"
+	"k8s.io/klog"
 
 	corev1 "k8s.io/api/core/v1"
 	extv1b1 "k8s.io/api/extensions/v1beta1"
@@ -76,7 +76,7 @@ func StartController(config *util.ControllerConfig, stopChan <-chan struct{}) er
 	if config.MinimizeLatency {
 		controller.minimizeLatency()
 	}
-	glog.Infof("Starting IngressDNS controller")
+	klog.Infof("Starting IngressDNS controller")
 	controller.Run(stopChan)
 	return nil
 }
@@ -174,7 +174,7 @@ func (c *Controller) Run(stopChan <-chan struct{}) {
 // synced with the corresponding api server.
 func (c *Controller) isSynced() bool {
 	if !c.ingressFederatedInformer.ClustersSynced() {
-		glog.V(2).Infof("Cluster list not synced")
+		klog.V(2).Infof("Cluster list not synced")
 		return false
 	}
 	clusters, err := c.ingressFederatedInformer.GetReadyClusters()
@@ -207,9 +207,9 @@ func (c *Controller) reconcile(qualifiedName util.QualifiedName) util.Reconcilia
 
 	key := qualifiedName.String()
 
-	glog.V(2).Infof("Starting to reconcile IngressDNS resource: %v", key)
+	klog.V(2).Infof("Starting to reconcile IngressDNS resource: %v", key)
 	startTime := time.Now()
-	defer glog.V(2).Infof("Finished reconciling IngressDNS resource %v (duration: %v)", key, time.Since(startTime))
+	defer klog.V(2).Infof("Finished reconciling IngressDNS resource %v (duration: %v)", key, time.Since(startTime))
 
 	cachedIngressDNSObj, exist, err := c.ingressDNSStore.GetByKey(key)
 	if err != nil {

--- a/pkg/controller/ingressdns/controller.go
+++ b/pkg/controller/ingressdns/controller.go
@@ -24,7 +24,6 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"k8s.io/klog"
 
 	corev1 "k8s.io/api/core/v1"
 	extv1b1 "k8s.io/api/extensions/v1beta1"
@@ -33,6 +32,7 @@ import (
 	pkgruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog"
 
 	fedv1a1 "github.com/kubernetes-sigs/federation-v2/pkg/apis/core/v1alpha1"
 	dnsv1a1 "github.com/kubernetes-sigs/federation-v2/pkg/apis/multiclusterdns/v1alpha1"

--- a/pkg/controller/schedulingmanager/controller.go
+++ b/pkg/controller/schedulingmanager/controller.go
@@ -18,11 +18,11 @@ package schedulingmanager
 
 import (
 	"github.com/pkg/errors"
-	"k8s.io/klog"
 
 	"k8s.io/apimachinery/pkg/util/runtime"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog"
 
 	"github.com/kubernetes-sigs/federation-v2/pkg/apis/core/typeconfig"
 	corev1a1 "github.com/kubernetes-sigs/federation-v2/pkg/apis/core/v1alpha1"

--- a/pkg/controller/schedulingpreference/controller.go
+++ b/pkg/controller/schedulingpreference/controller.go
@@ -21,11 +21,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"k8s.io/klog"
 
-	fedv1a1 "github.com/kubernetes-sigs/federation-v2/pkg/apis/core/v1alpha1"
-	"github.com/kubernetes-sigs/federation-v2/pkg/controller/util"
-	"github.com/kubernetes-sigs/federation-v2/pkg/schedulingtypes"
 	corev1 "k8s.io/api/core/v1"
 	pkgruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/runtime"
@@ -35,6 +31,11 @@ import (
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/klog"
+
+	fedv1a1 "github.com/kubernetes-sigs/federation-v2/pkg/apis/core/v1alpha1"
+	"github.com/kubernetes-sigs/federation-v2/pkg/controller/util"
+	"github.com/kubernetes-sigs/federation-v2/pkg/schedulingtypes"
 )
 
 const (

--- a/pkg/controller/schedulingpreference/controller.go
+++ b/pkg/controller/schedulingpreference/controller.go
@@ -20,8 +20,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/golang/glog"
 	"github.com/pkg/errors"
+	"k8s.io/klog"
 
 	fedv1a1 "github.com/kubernetes-sigs/federation-v2/pkg/apis/core/v1alpha1"
 	"github.com/kubernetes-sigs/federation-v2/pkg/controller/util"
@@ -77,7 +77,7 @@ func StartSchedulingPreferenceController(config *util.ControllerConfig, scheduli
 	if config.MinimizeLatency {
 		controller.minimizeLatency()
 	}
-	glog.Infof(fmt.Sprintf("Starting replicaschedulingpreferences controller"))
+	klog.Infof(fmt.Sprintf("Starting replicaschedulingpreferences controller"))
 	controller.Run(stopChannel)
 	return controller.scheduler, nil
 }
@@ -200,9 +200,9 @@ func (s *SchedulingPreferenceController) reconcile(qualifiedName util.QualifiedN
 	kind := s.scheduler.SchedulingKind()
 	key := qualifiedName.String()
 
-	glog.V(4).Infof("Starting to reconcile %s controller triggered key named %v", kind, key)
+	klog.V(4).Infof("Starting to reconcile %s controller triggered key named %v", kind, key)
 	startTime := time.Now()
-	defer glog.V(4).Infof("Finished reconciling %s controller triggered key named %v (duration: %v)", kind, key, time.Since(startTime))
+	defer klog.V(4).Infof("Finished reconciling %s controller triggered key named %v (duration: %v)", kind, key, time.Since(startTime))
 
 	obj, err := s.objFromCache(s.store, kind, key)
 	if err != nil {

--- a/pkg/controller/servicedns/controller.go
+++ b/pkg/controller/servicedns/controller.go
@@ -24,7 +24,6 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"k8s.io/klog"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -32,6 +31,7 @@ import (
 	pkgruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog"
 
 	fedv1a1 "github.com/kubernetes-sigs/federation-v2/pkg/apis/core/v1alpha1"
 	dnsv1a1 "github.com/kubernetes-sigs/federation-v2/pkg/apis/multiclusterdns/v1alpha1"

--- a/pkg/controller/servicedns/controller.go
+++ b/pkg/controller/servicedns/controller.go
@@ -23,8 +23,8 @@ import (
 	"sort"
 	"time"
 
-	"github.com/golang/glog"
 	"github.com/pkg/errors"
+	"k8s.io/klog"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -85,7 +85,7 @@ func StartController(config *util.ControllerConfig, stopChan <-chan struct{}) er
 	if config.MinimizeLatency {
 		controller.minimizeLatency()
 	}
-	glog.Infof("Starting ServiceDNS controller")
+	klog.Infof("Starting ServiceDNS controller")
 	controller.Run(stopChan)
 	return nil
 }
@@ -217,7 +217,7 @@ func (c *Controller) Run(stopChan <-chan struct{}) {
 // synced with the corresponding api server.
 func (c *Controller) isSynced() bool {
 	if !c.serviceInformer.ClustersSynced() {
-		glog.V(2).Infof("Cluster list not synced")
+		klog.V(2).Infof("Cluster list not synced")
 		return false
 	}
 	clusters, err := c.serviceInformer.GetReadyClusters()
@@ -230,7 +230,7 @@ func (c *Controller) isSynced() bool {
 	}
 
 	if !c.endpointInformer.ClustersSynced() {
-		glog.V(2).Infof("Cluster list not synced")
+		klog.V(2).Infof("Cluster list not synced")
 		return false
 	}
 	clusters, err = c.endpointInformer.GetReadyClusters()
@@ -263,9 +263,9 @@ func (c *Controller) reconcile(qualifiedName util.QualifiedName) util.Reconcilia
 
 	key := qualifiedName.String()
 
-	glog.V(4).Infof("Starting to reconcile ServiceDNS resource: %v", key)
+	klog.V(4).Infof("Starting to reconcile ServiceDNS resource: %v", key)
 	startTime := time.Now()
-	defer glog.V(4).Infof("Finished reconciling ServiceDNS resource %v (duration: %v)", key, time.Since(startTime))
+	defer klog.V(4).Infof("Finished reconciling ServiceDNS resource %v (duration: %v)", key, time.Since(startTime))
 
 	cachedObj, exist, err := c.serviceDNSStore.GetByKey(key)
 	if err != nil {
@@ -344,7 +344,7 @@ func (c *Controller) reconcile(qualifiedName util.QualifiedName) util.Reconcilia
 				offlineClusterDNS := clusterDNS
 				offlineClusterDNS.LoadBalancer = corev1.LoadBalancerStatus{}
 				fedDNSStatus = append(fedDNSStatus, offlineClusterDNS)
-				glog.V(5).Infof("Cluster %s is Offline, Preserving previously available status for Service %s", cluster.Name, key)
+				klog.V(5).Infof("Cluster %s is Offline, Preserving previously available status for Service %s", cluster.Name, key)
 				break
 			}
 		}

--- a/pkg/controller/status/controller.go
+++ b/pkg/controller/status/controller.go
@@ -24,18 +24,19 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"k8s.io/klog"
 
-	"github.com/kubernetes-sigs/federation-v2/pkg/apis/core/typeconfig"
-	fedv1a1 "github.com/kubernetes-sigs/federation-v2/pkg/apis/core/v1alpha1"
-	genericclient "github.com/kubernetes-sigs/federation-v2/pkg/client/generic"
-	"github.com/kubernetes-sigs/federation-v2/pkg/controller/util"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	pkgruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog"
+
+	"github.com/kubernetes-sigs/federation-v2/pkg/apis/core/typeconfig"
+	fedv1a1 "github.com/kubernetes-sigs/federation-v2/pkg/apis/core/v1alpha1"
+	genericclient "github.com/kubernetes-sigs/federation-v2/pkg/client/generic"
+	"github.com/kubernetes-sigs/federation-v2/pkg/controller/util"
 )
 
 const (

--- a/pkg/controller/status/controller.go
+++ b/pkg/controller/status/controller.go
@@ -23,8 +23,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/golang/glog"
 	"github.com/pkg/errors"
+	"k8s.io/klog"
 
 	"github.com/kubernetes-sigs/federation-v2/pkg/apis/core/typeconfig"
 	fedv1a1 "github.com/kubernetes-sigs/federation-v2/pkg/apis/core/v1alpha1"
@@ -85,7 +85,7 @@ func StartFederationStatusController(controllerConfig *util.ControllerConfig, st
 	if controllerConfig.MinimizeLatency {
 		controller.minimizeLatency()
 	}
-	glog.Infof(fmt.Sprintf("Starting status controller for %q", typeConfig.GetFederatedType().Kind))
+	klog.Infof(fmt.Sprintf("Starting status controller for %q", typeConfig.GetFederatedType().Kind))
 	controller.Run(stopChan)
 	return nil
 }
@@ -192,15 +192,15 @@ func (s *FederationStatusController) Run(stopChan <-chan struct{}) {
 // synced with the corresponding api server.
 func (s *FederationStatusController) isSynced() bool {
 	if !s.informer.ClustersSynced() {
-		glog.V(2).Infof("Cluster list not synced")
+		klog.V(2).Infof("Cluster list not synced")
 		return false
 	}
 	if !s.federatedController.HasSynced() {
-		glog.V(2).Infof("Federated type not synced")
+		klog.V(2).Infof("Federated type not synced")
 		return false
 	}
 	if !s.statusController.HasSynced() {
-		glog.V(2).Infof("Status not synced")
+		klog.V(2).Infof("Status not synced")
 		return false
 	}
 
@@ -235,9 +235,9 @@ func (s *FederationStatusController) reconcile(qualifiedName util.QualifiedName)
 	statusKind := s.typeConfig.GetStatus().Kind
 	key := qualifiedName.String()
 
-	glog.V(4).Infof("Starting to reconcile %v %v", statusKind, key)
+	klog.V(4).Infof("Starting to reconcile %v %v", statusKind, key)
 	startTime := time.Now()
-	defer glog.V(4).Infof("Finished reconciling %v %v (duration: %v)", statusKind, key, time.Since(startTime))
+	defer klog.V(4).Infof("Finished reconciling %v %v (duration: %v)", statusKind, key, time.Since(startTime))
 
 	fedObject, err := s.objFromCache(s.federatedStore, federatedKind, key)
 	if err != nil {
@@ -245,7 +245,7 @@ func (s *FederationStatusController) reconcile(qualifiedName util.QualifiedName)
 	}
 
 	if fedObject == nil || fedObject.GetDeletionTimestamp() != nil {
-		glog.V(4).Infof("No federated type for %v %v found", federatedKind, key)
+		klog.V(4).Infof("No federated type for %v %v found", federatedKind, key)
 		// Status object is removed by GC. So we don't have to do anything more here.
 		return util.StatusAllOK
 	}
@@ -289,7 +289,7 @@ func (s *FederationStatusController) reconcile(qualifiedName util.QualifiedName)
 	}
 	status, err := util.GetUnstructured(federatedResource)
 	if err != nil {
-		glog.Errorf("Failed to convert to Unstructured: %s %q: %v", statusKind, key, err)
+		klog.Errorf("Failed to convert to Unstructured: %s %q: %v", statusKind, key, err)
 		return util.StatusError
 	}
 

--- a/pkg/controller/sync/accessor.go
+++ b/pkg/controller/sync/accessor.go
@@ -17,7 +17,7 @@ limitations under the License.
 package sync
 
 import (
-	"github.com/golang/glog"
+	"k8s.io/klog"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -161,19 +161,19 @@ func (a *resourceAccessor) Run(stopChan <-chan struct{}) {
 func (a *resourceAccessor) HasSynced() bool {
 	kind := a.typeConfig.GetFederatedType().Kind
 	if !a.versionManager.HasSynced() {
-		glog.V(2).Infof("Version manager for %s not synced", kind)
+		klog.V(2).Infof("Version manager for %s not synced", kind)
 		return false
 	}
 	if !a.federatedController.HasSynced() {
-		glog.V(2).Infof("Informer for %s not synced", kind)
+		klog.V(2).Infof("Informer for %s not synced", kind)
 		return false
 	}
 	if a.namespaceController != nil && !a.namespaceController.HasSynced() {
-		glog.V(2).Infof("Namespace informer for %s not synced", kind)
+		klog.V(2).Infof("Namespace informer for %s not synced", kind)
 		return false
 	}
 	if a.fedNamespaceController != nil && !a.fedNamespaceController.HasSynced() {
-		glog.V(2).Infof("FederatedNamespace informer for %s not synced", kind)
+		klog.V(2).Infof("FederatedNamespace informer for %s not synced", kind)
 		return false
 	}
 	return true
@@ -181,7 +181,7 @@ func (a *resourceAccessor) HasSynced() bool {
 
 func (a *resourceAccessor) FederatedResource(eventSource util.QualifiedName) (FederatedResource, bool, error) {
 	if a.targetIsNamespace && a.isSystemNamespace(eventSource.Name) {
-		glog.V(7).Infof("Ignoring system namespace %q", eventSource.Name)
+		klog.V(7).Infof("Ignoring system namespace %q", eventSource.Name)
 		return nil, false, nil
 	}
 

--- a/pkg/controller/sync/accessor.go
+++ b/pkg/controller/sync/accessor.go
@@ -17,13 +17,12 @@ limitations under the License.
 package sync
 
 import (
-	"k8s.io/klog"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	pkgruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/klog"
 
 	"github.com/kubernetes-sigs/federation-v2/pkg/apis/core/typeconfig"
 	genericclient "github.com/kubernetes-sigs/federation-v2/pkg/client/generic"

--- a/pkg/controller/sync/controller.go
+++ b/pkg/controller/sync/controller.go
@@ -22,8 +22,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/golang/glog"
 	"github.com/pkg/errors"
+	"k8s.io/klog"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -98,7 +98,7 @@ func StartFederationSyncController(controllerConfig *util.ControllerConfig, stop
 	if controllerConfig.MinimizeLatency {
 		controller.minimizeLatency()
 	}
-	glog.Infof(fmt.Sprintf("Starting sync controller for %q", typeConfig.GetFederatedType().Kind))
+	klog.Infof(fmt.Sprintf("Starting sync controller for %q", typeConfig.GetFederatedType().Kind))
 	controller.Run(stopChan)
 	return nil
 }
@@ -201,7 +201,7 @@ func (s *FederationSyncController) Run(stopChan <-chan struct{}) {
 // synced with the corresponding api server.
 func (s *FederationSyncController) isSynced() bool {
 	if !s.informer.ClustersSynced() {
-		glog.V(2).Infof("Cluster list not synced")
+		klog.V(2).Infof("Cluster list not synced")
 		return false
 	}
 	if !s.fedAccessor.HasSynced() {
@@ -247,7 +247,7 @@ func (s *FederationSyncController) reconcile(qualifiedName util.QualifiedName) u
 	}
 	if possibleOrphan {
 		targetKind := s.typeConfig.GetTarget().Kind
-		glog.V(2).Infof("Ensuring the removal of the label %q from %s %q in member clusters.", util.ManagedByFederationLabelKey, targetKind, qualifiedName)
+		klog.V(2).Infof("Ensuring the removal of the label %q from %s %q in member clusters.", util.ManagedByFederationLabelKey, targetKind, qualifiedName)
 		err = s.removeManagedLabel(targetKind, qualifiedName)
 		if err != nil {
 			wrappedErr := errors.Wrapf(err, "failed to remove the label %q from %s %q in member clusters", util.ManagedByFederationLabelKey, targetKind, qualifiedName)
@@ -263,15 +263,15 @@ func (s *FederationSyncController) reconcile(qualifiedName util.QualifiedName) u
 
 	key := fedResource.FederatedName().String()
 
-	glog.V(4).Infof("Starting to reconcile %s %q", kind, key)
+	klog.V(4).Infof("Starting to reconcile %s %q", kind, key)
 	startTime := time.Now()
-	defer glog.V(4).Infof("Finished reconciling %s %q (duration: %v)", kind, key, time.Since(startTime))
+	defer klog.V(4).Infof("Finished reconciling %s %q (duration: %v)", kind, key, time.Since(startTime))
 
 	if fedResource.Object().GetDeletionTimestamp() != nil {
-		glog.V(3).Infof("Handling deletion of %s %q", kind, key)
+		klog.V(3).Infof("Handling deletion of %s %q", kind, key)
 		return s.ensureDeletion(fedResource)
 	}
-	glog.V(3).Infof("Ensuring finalizer exists on %s %q", kind, key)
+	klog.V(3).Infof("Ensuring finalizer exists on %s %q", kind, key)
 	err = s.ensureFinalizer(fedResource)
 	if err != nil {
 		fedResource.RecordError("EnsureFinalizerError", errors.Wrap(err, "Failed to ensure finalizer"))
@@ -298,7 +298,7 @@ func (s *FederationSyncController) syncToClusters(fedResource FederatedResource,
 
 	kind := fedResource.TargetKind()
 	key := fedResource.TargetName().String()
-	glog.V(4).Infof("Syncing %s %q in underlying clusters, selected clusters are: %s", kind, key, selectedClusterNames)
+	klog.V(4).Infof("Syncing %s %q in underlying clusters, selected clusters are: %s", kind, key, selectedClusterNames)
 
 	dispatcher := dispatch.NewManagedDispatcher(s.informer.GetClientForCluster, fedResource, s.skipAdoptingResources)
 
@@ -375,27 +375,27 @@ func (s *FederationSyncController) ensureDeletion(fedResource FederatedResource)
 	key := fedResource.FederatedName().String()
 	kind := fedResource.FederatedKind()
 
-	glog.V(2).Infof("Ensuring deletion of %s %q", kind, key)
+	klog.V(2).Infof("Ensuring deletion of %s %q", kind, key)
 
 	obj := fedResource.Object()
 
 	finalizers := sets.NewString(obj.GetFinalizers()...)
 	if !finalizers.Has(FinalizerSyncController) {
-		glog.V(2).Infof("%s %q does not have the %q finalizer. Nothing to do.", kind, key, FinalizerSyncController)
+		klog.V(2).Infof("%s %q does not have the %q finalizer. Nothing to do.", kind, key, FinalizerSyncController)
 		return util.StatusAllOK
 	}
 
 	annotations := obj.GetAnnotations()
 	orphanResources := annotations != nil && annotations[OrphanManagedResources] == "true"
 	if orphanResources {
-		glog.V(2).Infof("Found %q annotation on %s %q. Removing the finalizer.", OrphanManagedResources, kind, key)
+		klog.V(2).Infof("Found %q annotation on %s %q. Removing the finalizer.", OrphanManagedResources, kind, key)
 		err := s.removeFinalizer(fedResource)
 		if err != nil {
 			wrappedErr := errors.Wrapf(err, "failed to remove finalizer %q from %s %q", OrphanManagedResources, kind, key)
 			runtime.HandleError(wrappedErr)
 			return util.StatusError
 		}
-		glog.V(2).Infof("Initiating the removal of the label %q from resources previously managed by %s %q.", util.ManagedByFederationLabelKey, kind, key)
+		klog.V(2).Infof("Initiating the removal of the label %q from resources previously managed by %s %q.", util.ManagedByFederationLabelKey, kind, key)
 		err = s.removeManagedLabel(fedResource.TargetKind(), fedResource.TargetName())
 		if err != nil {
 			wrappedErr := errors.Wrapf(err, "failed to remove the label %q from all resources previously managed by %s %q", util.ManagedByFederationLabelKey, kind, key)
@@ -405,7 +405,7 @@ func (s *FederationSyncController) ensureDeletion(fedResource FederatedResource)
 		return util.StatusAllOK
 	}
 
-	glog.V(2).Infof("Deleting resources managed by %s %q from member clusters.", kind, key)
+	klog.V(2).Infof("Deleting resources managed by %s %q from member clusters.", kind, key)
 	recheckRequired, err := s.deleteFromClusters(fedResource)
 	if err != nil {
 		wrappedErr := errors.Wrapf(err, "failed to delete %s %q", kind, key)
@@ -470,7 +470,7 @@ func (s *FederationSyncController) deleteFromClusters(fedResource FederatedResou
 	if len(remainingClusters) > 0 {
 		fedKind := fedResource.FederatedKind()
 		fedName := fedResource.FederatedName()
-		glog.V(2).Infof("Waiting for resources managed by %s %q to be removed from the following clusters: %s", fedKind, fedName, strings.Join(remainingClusters, ", "))
+		klog.V(2).Infof("Waiting for resources managed by %s %q to be removed from the following clusters: %s", fedKind, fedName, strings.Join(remainingClusters, ", "))
 		return true, nil
 	}
 	// Managed resources no longer exist in any member cluster
@@ -531,7 +531,7 @@ func (s *FederationSyncController) ensureFinalizer(fedResource FederatedResource
 	if err != nil || !isUpdated {
 		return err
 	}
-	glog.V(2).Infof("Adding finalizer %s to %s %q", FinalizerSyncController, fedResource.FederatedKind(), fedResource.FederatedName())
+	klog.V(2).Infof("Adding finalizer %s to %s %q", FinalizerSyncController, fedResource.FederatedKind(), fedResource.FederatedName())
 	return s.hostClusterClient.Update(context.TODO(), obj)
 }
 
@@ -541,6 +541,6 @@ func (s *FederationSyncController) removeFinalizer(fedResource FederatedResource
 	if err != nil || !isUpdated {
 		return err
 	}
-	glog.V(2).Infof("Removing finalizer %s from %s %q", FinalizerSyncController, fedResource.FederatedKind(), fedResource.FederatedName())
+	klog.V(2).Infof("Removing finalizer %s from %s %q", FinalizerSyncController, fedResource.FederatedKind(), fedResource.FederatedName())
 	return s.hostClusterClient.Update(context.TODO(), obj)
 }

--- a/pkg/controller/sync/controller.go
+++ b/pkg/controller/sync/controller.go
@@ -23,7 +23,6 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"k8s.io/klog"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -35,6 +34,7 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/klog"
 
 	"github.com/kubernetes-sigs/federation-v2/pkg/apis/core/typeconfig"
 	fedv1a1 "github.com/kubernetes-sigs/federation-v2/pkg/apis/core/v1alpha1"

--- a/pkg/controller/sync/dispatch/unmanaged.go
+++ b/pkg/controller/sync/dispatch/unmanaged.go
@@ -18,12 +18,12 @@ package dispatch
 
 import (
 	"github.com/pkg/errors"
-	"k8s.io/klog"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/klog"
 
 	"github.com/kubernetes-sigs/federation-v2/pkg/controller/util"
 )

--- a/pkg/controller/sync/dispatch/unmanaged.go
+++ b/pkg/controller/sync/dispatch/unmanaged.go
@@ -17,8 +17,8 @@ limitations under the License.
 package dispatch
 
 import (
-	"github.com/golang/glog"
 	"github.com/pkg/errors"
+	"k8s.io/klog"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -72,7 +72,7 @@ func (d *unmanagedDispatcherImpl) Delete(clusterName string) {
 	const opContinuous = "Deleting"
 	go d.dispatcher.clusterOperation(clusterName, op, func(client util.ResourceClient) util.ReconciliationStatus {
 		if d.recorder == nil {
-			glog.V(2).Infof(eventTemplate, opContinuous, d.targetKind, d.targetName, clusterName)
+			klog.V(2).Infof(eventTemplate, opContinuous, d.targetKind, d.targetName, clusterName)
 		} else {
 			d.recorder.RecordEvent(clusterName, op, opContinuous)
 		}
@@ -100,7 +100,7 @@ func (d *unmanagedDispatcherImpl) RemoveManagedLabel(clusterName string, cluster
 	const opContinuous = "Removing managed label from"
 	go d.dispatcher.clusterOperation(clusterName, op, func(client util.ResourceClient) util.ReconciliationStatus {
 		if d.recorder == nil {
-			glog.V(2).Infof(eventTemplate, opContinuous, d.targetKind, d.targetName, clusterName)
+			klog.V(2).Infof(eventTemplate, opContinuous, d.targetKind, d.targetName, clusterName)
 		} else {
 			d.recorder.RecordEvent(clusterName, op, opContinuous)
 		}

--- a/pkg/controller/sync/resource_test.go
+++ b/pkg/controller/sync/resource_test.go
@@ -20,8 +20,9 @@ import (
 	"strings"
 	"testing"
 
-	kfenable "github.com/kubernetes-sigs/federation-v2/pkg/kubefedctl/enable"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	kfenable "github.com/kubernetes-sigs/federation-v2/pkg/kubefedctl/enable"
 )
 
 func TestGetTemplateHash(t *testing.T) {

--- a/pkg/controller/sync/version/manager.go
+++ b/pkg/controller/sync/version/manager.go
@@ -23,7 +23,6 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"k8s.io/klog"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -33,6 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/klog"
 
 	"github.com/kubernetes-sigs/federation-v2/pkg/apis/core/common"
 	fedv1a1 "github.com/kubernetes-sigs/federation-v2/pkg/apis/core/v1alpha1"

--- a/pkg/controller/sync/version/manager.go
+++ b/pkg/controller/sync/version/manager.go
@@ -22,8 +22,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/golang/glog"
 	"github.com/pkg/errors"
+	"k8s.io/klog"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -175,7 +175,7 @@ func (m *VersionManager) Update(resource VersionedResource,
 	}
 
 	if oldStatus != nil && util.PropagatedVersionStatusEquivalent(oldStatus, status) {
-		glog.V(4).Infof("No update necessary for %s %q", m.adapter.TypeName(), qualifiedName)
+		klog.V(4).Infof("No update necessary for %s %q", m.adapter.TypeName(), qualifiedName)
 	} else if obj == nil {
 		ownerReference := ownerReferenceForUnstructured(resource.Object())
 		obj = m.adapter.NewVersion(qualifiedName, ownerReference, status)
@@ -206,7 +206,7 @@ func (m *VersionManager) list(stopChan <-chan struct{}) (pkgruntime.Object, bool
 	err := wait.PollImmediateInfinite(1*time.Second, func() (bool, error) {
 		select {
 		case <-stopChan:
-			glog.V(4).Infof("Halting version manager list due to closed stop channel")
+			klog.V(4).Infof("Halting version manager list due to closed stop channel")
 			return false, errors.New("")
 		default:
 		}
@@ -238,7 +238,7 @@ func (m *VersionManager) load(versionList pkgruntime.Object, stopChan <-chan str
 	for _, obj := range items {
 		select {
 		case <-stopChan:
-			glog.V(4).Infof("Halting version manager load due to closed stop channel")
+			klog.V(4).Infof("Halting version manager load due to closed stop channel")
 			return false
 		default:
 		}
@@ -252,7 +252,7 @@ func (m *VersionManager) load(versionList pkgruntime.Object, stopChan <-chan str
 	m.Lock()
 	m.hasSynced = true
 	m.Unlock()
-	glog.V(4).Infof("Version manager for %q synced", m.federatedKind)
+	klog.V(4).Infof("Version manager for %q synced", m.federatedKind)
 	return true
 }
 
@@ -304,10 +304,10 @@ func (m *VersionManager) writeVersion(obj pkgruntime.Object, qualifiedName util.
 				return false, nil
 			}
 
-			glog.V(4).Infof("Creating %s %q", adapterType, qualifiedName)
+			klog.V(4).Infof("Creating %s %q", adapterType, qualifiedName)
 			err = m.client.Create(context.TODO(), createdObj)
 			if apierrors.IsAlreadyExists(err) {
-				glog.V(4).Infof("%s %q was created by another process. Will refresh the resourceVersion and attempt to update.", adapterType, qualifiedName)
+				klog.V(4).Infof("%s %q was created by another process. Will refresh the resourceVersion and attempt to update.", adapterType, qualifiedName)
 				refreshVersion = true
 				return false, nil
 			}
@@ -339,15 +339,15 @@ func (m *VersionManager) writeVersion(obj pkgruntime.Object, qualifiedName util.
 			return false, nil
 		}
 
-		glog.V(4).Infof("Updating the status of %s %q", adapterType, qualifiedName)
+		klog.V(4).Infof("Updating the status of %s %q", adapterType, qualifiedName)
 		err = m.client.UpdateStatus(context.TODO(), updatedObj)
 		if apierrors.IsConflict(err) {
-			glog.V(4).Infof("%s %q was updated by another process. Will refresh the resourceVersion and retry the update.", adapterType, qualifiedName)
+			klog.V(4).Infof("%s %q was updated by another process. Will refresh the resourceVersion and retry the update.", adapterType, qualifiedName)
 			refreshVersion = true
 			return false, nil
 		}
 		if apierrors.IsNotFound(err) {
-			glog.V(4).Infof("%s %q was deleted by another process. Will clear the resourceVersion and retry the update.", adapterType, qualifiedName)
+			klog.V(4).Infof("%s %q was deleted by another process. Will clear the resourceVersion and retry the update.", adapterType, qualifiedName)
 			resourceVersion = ""
 			return false, nil
 		}
@@ -380,7 +380,7 @@ func (m *VersionManager) writeVersion(obj pkgruntime.Object, qualifiedName util.
 }
 
 func (m *VersionManager) getResourceVersionFromAPI(qualifiedName util.QualifiedName) (string, error) {
-	glog.V(4).Infof("Retrieving resourceVersion for %s %q from the API", m.federatedKind, qualifiedName)
+	klog.V(4).Infof("Retrieving resourceVersion for %s %q from the API", m.federatedKind, qualifiedName)
 	obj := m.adapter.NewObject()
 	err := m.client.Get(context.TODO(), obj, qualifiedName.Namespace, qualifiedName.Name)
 	if err != nil {

--- a/pkg/controller/util/cluster_util.go
+++ b/pkg/controller/util/cluster_util.go
@@ -21,8 +21,8 @@ import (
 	"net"
 	"time"
 
-	"github.com/golang/glog"
 	"github.com/pkg/errors"
+	"k8s.io/klog"
 
 	fedv1a1 "github.com/kubernetes-sigs/federation-v2/pkg/apis/core/v1alpha1"
 	"github.com/kubernetes-sigs/federation-v2/pkg/client/generic"
@@ -98,7 +98,7 @@ func BuildClusterConfig(fedCluster *fedv1a1.FederatedCluster, client generic.Cli
 	secretRef := fedCluster.Spec.SecretRef
 
 	if secretRef == nil {
-		glog.Infof("didn't find secretRef for cluster %s. Trying insecure access", clusterName)
+		klog.Infof("didn't find secretRef for cluster %s. Trying insecure access", clusterName)
 		clusterConfig, err = clientcmd.BuildConfigFromFlags(serverAddress, "")
 		if err != nil {
 			return nil, err

--- a/pkg/controller/util/cluster_util.go
+++ b/pkg/controller/util/cluster_util.go
@@ -22,10 +22,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"k8s.io/klog"
 
-	fedv1a1 "github.com/kubernetes-sigs/federation-v2/pkg/apis/core/v1alpha1"
-	"github.com/kubernetes-sigs/federation-v2/pkg/client/generic"
 	apiv1 "k8s.io/api/core/v1"
 	pkgruntime "k8s.io/apimachinery/pkg/runtime"
 	utilnet "k8s.io/apimachinery/pkg/util/net"
@@ -33,6 +30,10 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	crcv1alpha1 "k8s.io/cluster-registry/pkg/apis/clusterregistry/v1alpha1"
+	"k8s.io/klog"
+
+	fedv1a1 "github.com/kubernetes-sigs/federation-v2/pkg/apis/core/v1alpha1"
+	"github.com/kubernetes-sigs/federation-v2/pkg/client/generic"
 )
 
 const (

--- a/pkg/controller/util/federated_informer.go
+++ b/pkg/controller/util/federated_informer.go
@@ -22,8 +22,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/golang/glog"
 	"github.com/pkg/errors"
+	"k8s.io/klog"
 
 	fedcommon "github.com/kubernetes-sigs/federation-v2/pkg/apis/core/common"
 	fedv1a1 "github.com/kubernetes-sigs/federation-v2/pkg/apis/core/v1alpha1"
@@ -167,7 +167,7 @@ func NewFederatedInformer(
 	getClusterData := func(name string) []interface{} {
 		data, err := federatedInformer.GetTargetStore().ListFromCluster(name)
 		if err != nil {
-			glog.Errorf("Failed to list %s content: %v", name, err)
+			klog.Errorf("Failed to list %s content: %v", name, err)
 			return make([]interface{}, 0)
 		}
 		return data
@@ -196,26 +196,26 @@ func NewFederatedInformer(
 			AddFunc: func(cur interface{}) {
 				curCluster, ok := cur.(*fedv1a1.FederatedCluster)
 				if !ok {
-					glog.Errorf("Cluster %v/%v not added; incorrect type", curCluster.Namespace, curCluster.Name)
+					klog.Errorf("Cluster %v/%v not added; incorrect type", curCluster.Namespace, curCluster.Name)
 				} else if IsClusterReady(&curCluster.Status) {
 					federatedInformer.addCluster(curCluster)
-					glog.Infof("Cluster %v/%v is ready", curCluster.Namespace, curCluster.Name)
+					klog.Infof("Cluster %v/%v is ready", curCluster.Namespace, curCluster.Name)
 					if clusterLifecycle.ClusterAvailable != nil {
 						clusterLifecycle.ClusterAvailable(curCluster)
 					}
 				} else {
-					glog.Infof("Cluster %v/%v not added; it is not ready.", curCluster.Namespace, curCluster.Name)
+					klog.Infof("Cluster %v/%v not added; it is not ready.", curCluster.Namespace, curCluster.Name)
 				}
 			},
 			UpdateFunc: func(old, cur interface{}) {
 				oldCluster, ok := old.(*fedv1a1.FederatedCluster)
 				if !ok {
-					glog.Errorf("Internal error: Cluster %v not updated.  Old cluster not of correct type.", old)
+					klog.Errorf("Internal error: Cluster %v not updated.  Old cluster not of correct type.", old)
 					return
 				}
 				curCluster, ok := cur.(*fedv1a1.FederatedCluster)
 				if !ok {
-					glog.Errorf("Internal error: Cluster %v not updated.  New cluster not of correct type.", cur)
+					klog.Errorf("Internal error: Cluster %v not updated.  New cluster not of correct type.", cur)
 					return
 				}
 				if IsClusterReady(&oldCluster.Status) != IsClusterReady(&curCluster.Status) || !reflect.DeepEqual(oldCluster.Spec, curCluster.Spec) || !reflect.DeepEqual(oldCluster.ObjectMeta.Annotations, curCluster.ObjectMeta.Annotations) {
@@ -235,7 +235,7 @@ func NewFederatedInformer(
 						}
 					}
 				} else {
-					glog.V(7).Infof("Cluster %v not updated to %v as ready status and specs are identical", oldCluster, curCluster)
+					klog.V(7).Infof("Cluster %v not updated to %v as ready status and specs are identical", oldCluster, curCluster)
 				}
 			},
 		},
@@ -287,14 +287,14 @@ type federatedStoreImpl struct {
 }
 
 func (f *federatedInformerImpl) Stop() {
-	glog.V(4).Infof("Stopping federated informer.")
+	klog.V(4).Infof("Stopping federated informer.")
 	f.Lock()
 	defer f.Unlock()
 
-	glog.V(4).Infof("... Closing cluster informer channel.")
+	klog.V(4).Infof("... Closing cluster informer channel.")
 	close(f.clusterInformer.stopChan)
 	for key, informer := range f.targetInformers {
-		glog.V(4).Infof("... Closing informer channel for %q.", key)
+		klog.V(4).Infof("... Closing informer channel for %q.", key)
 		close(informer.stopChan)
 		// Remove each informer after it has been stopped to prevent
 		// subsequent cluster deletion from attempting to double close
@@ -327,9 +327,9 @@ func (f *federatedInformerImpl) GetClientForCluster(clusterName string) (Resourc
 
 func (f *federatedInformerImpl) getClientForClusterUnlocked(clusterName string) (ResourceClient, error) {
 	// No locking needed. Will happen in f.GetCluster.
-	glog.V(4).Infof("Getting clientset for cluster %q", clusterName)
+	klog.V(4).Infof("Getting clientset for cluster %q", clusterName)
 	if cluster, found, err := f.getReadyClusterUnlocked(clusterName); found && err == nil {
-		glog.V(4).Infof("Got clientset for cluster %q", clusterName)
+		klog.V(4).Infof("Got clientset for cluster %q", clusterName)
 		return f.clientFactory(cluster)
 	} else {
 		if err != nil {
@@ -431,7 +431,7 @@ func (f *federatedInformerImpl) addCluster(cluster *fedv1a1.FederatedCluster) {
 		go targetInformer.controller.Run(targetInformer.stopChan)
 	} else {
 		// TODO: create also an event for cluster.
-		glog.Errorf("Failed to create a client for cluster: %v", err)
+		klog.Errorf("Failed to create a client for cluster: %v", err)
 	}
 }
 

--- a/pkg/controller/util/federated_informer.go
+++ b/pkg/controller/util/federated_informer.go
@@ -23,16 +23,17 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"k8s.io/klog"
 
-	fedcommon "github.com/kubernetes-sigs/federation-v2/pkg/apis/core/common"
-	fedv1a1 "github.com/kubernetes-sigs/federation-v2/pkg/apis/core/v1alpha1"
-	"github.com/kubernetes-sigs/federation-v2/pkg/client/generic"
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	pkgruntime "k8s.io/apimachinery/pkg/runtime"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog"
+
+	fedcommon "github.com/kubernetes-sigs/federation-v2/pkg/apis/core/common"
+	fedv1a1 "github.com/kubernetes-sigs/federation-v2/pkg/apis/core/v1alpha1"
+	"github.com/kubernetes-sigs/federation-v2/pkg/client/generic"
 )
 
 const (

--- a/pkg/controller/util/genericinformer.go
+++ b/pkg/controller/util/genericinformer.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/kubernetes-sigs/federation-v2/pkg/client/generic/scheme"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	pkgruntime "k8s.io/apimachinery/pkg/runtime"
@@ -29,6 +28,8 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+
+	"github.com/kubernetes-sigs/federation-v2/pkg/client/generic/scheme"
 )
 
 func NewGenericInformer(config *rest.Config, namespace string, obj pkgruntime.Object, resyncPeriod time.Duration, triggerFunc func(pkgruntime.Object)) (cache.Store, cache.Controller, error) {

--- a/pkg/controller/util/handlers_test.go
+++ b/pkg/controller/util/handlers_test.go
@@ -19,12 +19,12 @@ package util
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	pkgruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/cache"
-
-	"github.com/stretchr/testify/assert"
 )
 
 func TestHandlers(t *testing.T) {

--- a/pkg/controller/util/meta_test.go
+++ b/pkg/controller/util/meta_test.go
@@ -19,10 +19,10 @@ package util
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	api_v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"github.com/stretchr/testify/assert"
 )
 
 func TestObjectMeta(t *testing.T) {

--- a/pkg/controller/util/planner/planner_test.go
+++ b/pkg/controller/util/planner/planner_test.go
@@ -19,8 +19,9 @@ package planner
 import (
 	"testing"
 
-	fedschedulingv1a1 "github.com/kubernetes-sigs/federation-v2/pkg/apis/scheduling/v1alpha1"
 	"github.com/stretchr/testify/assert"
+
+	fedschedulingv1a1 "github.com/kubernetes-sigs/federation-v2/pkg/apis/scheduling/v1alpha1"
 )
 
 func doCheck(t *testing.T, pref map[string]fedschedulingv1a1.ClusterPreferences, replicas int64, clusters []string, expected map[string]int64) {

--- a/pkg/controller/util/podanalyzer/pod_helper_test.go
+++ b/pkg/controller/util/podanalyzer/pod_helper_test.go
@@ -21,11 +21,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	api_v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-
-	"github.com/stretchr/testify/assert"
 )
 
 func TestAnalyze(t *testing.T) {

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -17,8 +17,8 @@ limitations under the License.
 package features
 
 import (
-	"github.com/golang/glog"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/klog"
 )
 
 const (
@@ -56,7 +56,7 @@ const (
 
 func init() {
 	if err := utilfeature.DefaultFeatureGate.Add(defaultFederationFeatureGates); err != nil {
-		glog.Fatalf("Unexpected error: %v", err)
+		klog.Fatalf("Unexpected error: %v", err)
 	}
 }
 

--- a/pkg/kubefedctl/disable.go
+++ b/pkg/kubefedctl/disable.go
@@ -23,10 +23,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/golang/glog"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	"k8s.io/klog"
 
 	apiextv1b1client "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -99,12 +99,12 @@ func NewCmdTypeDisable(cmdOut io.Writer, config util.FedConfig) *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			err := opts.Complete(args)
 			if err != nil {
-				glog.Fatalf("Error: %v", err)
+				klog.Fatalf("Error: %v", err)
 			}
 
 			err = opts.Run(cmdOut, config)
 			if err != nil {
-				glog.Fatalf("Error: %v", err)
+				klog.Fatalf("Error: %v", err)
 			}
 		},
 	}
@@ -184,7 +184,7 @@ func DisableFederation(cmdOut io.Writer, config *rest.Config, enableTypeDirectiv
 		}
 
 		if _, err := cmdOut.Write([]byte(data)); err != nil {
-			glog.Fatalf("Unexpected err: %v\n", err)
+			klog.Fatalf("Unexpected err: %v\n", err)
 		}
 	}
 
@@ -282,7 +282,7 @@ func verifyPropagationControllerStopped(client genericclient.Client, typeConfigN
 		typeConfig = &fedv1a1.FederatedTypeConfig{}
 		err := client.Get(context.TODO(), typeConfig, typeConfigName.Namespace, typeConfigName.Name)
 		if err != nil {
-			glog.Errorf("Error retrieving FederatedTypeConfig %q: %v", typeConfigName, err)
+			klog.Errorf("Error retrieving FederatedTypeConfig %q: %v", typeConfigName, err)
 			return false, nil
 		}
 		if typeConfig.Status.PropagationController == fedv1a1.ControllerStatusNotRunning {

--- a/pkg/kubefedctl/disable.go
+++ b/pkg/kubefedctl/disable.go
@@ -26,13 +26,13 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	"k8s.io/klog"
 
 	apiextv1b1client "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/rest"
+	"k8s.io/klog"
 
 	"github.com/kubernetes-sigs/federation-v2/pkg/apis/core/typeconfig"
 	fedv1a1 "github.com/kubernetes-sigs/federation-v2/pkg/apis/core/v1alpha1"

--- a/pkg/kubefedctl/enable/enable.go
+++ b/pkg/kubefedctl/enable/enable.go
@@ -21,11 +21,11 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/golang/glog"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	"k8s.io/klog"
 
 	apiextv1b1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	apiextv1b1client "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1"
@@ -102,12 +102,12 @@ func NewCmdTypeEnable(cmdOut io.Writer, config util.FedConfig) *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			err := opts.Complete(args)
 			if err != nil {
-				glog.Fatalf("Error: %v", err)
+				klog.Fatalf("Error: %v", err)
 			}
 
 			err = opts.Run(cmdOut, config)
 			if err != nil {
-				glog.Fatalf("Error: %v", err)
+				klog.Fatalf("Error: %v", err)
 			}
 		},
 	}
@@ -199,7 +199,7 @@ func GetResources(config *rest.Config, enableTypeDirective *EnableTypeDirective)
 	if err != nil {
 		return nil, err
 	}
-	glog.V(2).Infof("Found type %q", resourceKey(*apiResource))
+	klog.V(2).Infof("Found type %q", resourceKey(*apiResource))
 
 	typeConfig := GenerateTypeConfigForTarget(*apiResource, enableTypeDirective)
 
@@ -228,7 +228,7 @@ func CreateResources(cmdOut io.Writer, config *rest.Config, resources *typeResou
 	write := func(data string) {
 		if cmdOut != nil {
 			if _, err := cmdOut.Write([]byte(data)); err != nil {
-				glog.Fatalf("Unexpected err: %v\n", err)
+				klog.Fatalf("Unexpected err: %v\n", err)
 			}
 		}
 	}

--- a/pkg/kubefedctl/enable/enable.go
+++ b/pkg/kubefedctl/enable/enable.go
@@ -25,7 +25,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	"k8s.io/klog"
 
 	apiextv1b1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	apiextv1b1client "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1"
@@ -34,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	pkgruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
+	"k8s.io/klog"
 
 	"github.com/kubernetes-sigs/federation-v2/pkg/apis/core/typeconfig"
 	fedv1a1 "github.com/kubernetes-sigs/federation-v2/pkg/apis/core/v1alpha1"

--- a/pkg/kubefedctl/federate/federate.go
+++ b/pkg/kubefedctl/federate/federate.go
@@ -24,13 +24,13 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	"k8s.io/klog"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/rest"
+	"k8s.io/klog"
 
 	"github.com/kubernetes-sigs/federation-v2/pkg/apis/core/typeconfig"
 	fedv1a1 "github.com/kubernetes-sigs/federation-v2/pkg/apis/core/v1alpha1"

--- a/pkg/kubefedctl/federate/federate.go
+++ b/pkg/kubefedctl/federate/federate.go
@@ -21,10 +21,10 @@ import (
 	"io"
 	"time"
 
-	"github.com/golang/glog"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	"k8s.io/klog"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -130,12 +130,12 @@ func NewCmdFederateResource(cmdOut io.Writer, config util.FedConfig) *cobra.Comm
 		Run: func(cmd *cobra.Command, args []string) {
 			err := opts.Complete(args)
 			if err != nil {
-				glog.Fatalf("Error: %v", err)
+				klog.Fatalf("Error: %v", err)
 			}
 
 			err = opts.Run(cmdOut, config)
 			if err != nil {
-				glog.Fatalf("Error: %v", err)
+				klog.Fatalf("Error: %v", err)
 			}
 		},
 	}
@@ -208,7 +208,7 @@ func GetFederateArtifacts(hostConfig *rest.Config, typeName, federationNamespace
 	if err != nil {
 		return nil, errors.Wrapf(err, "Failed to find target API resource %s", typeName)
 	}
-	glog.V(2).Infof("API Resource for %s found", typeName)
+	klog.V(2).Infof("API Resource for %s found", typeName)
 
 	typeConfigInstalled, typeConfig, err := getTypeConfig(hostConfig, *apiResource, federationNamespace, enableType, outputYAML)
 	if err != nil {
@@ -250,7 +250,7 @@ func getTypeConfig(hostConfig *rest.Config, apiResource metav1.APIResource, fede
 		return false, generatedTypeConfig, nil
 	}
 	if outputYAML { // Output as yaml does not bother what error happened while accessing typeConfig
-		glog.V(1).Infof("Falling back to a generated type config due to lookup failure: %v", err)
+		klog.V(1).Infof("Falling back to a generated type config due to lookup failure: %v", err)
 		return false, generatedTypeConfig, nil
 	}
 	return false, nil, err
@@ -283,7 +283,7 @@ func getTargetResource(hostConfig *rest.Config, typeConfig typeconfig.Interface,
 		return nil, errors.Wrapf(err, "Error retrieving target %s %q", kind, qualifiedName)
 	}
 
-	glog.V(2).Infof("Target %s %q found", kind, qualifiedName)
+	klog.V(2).Infof("Target %s %q found", kind, qualifiedName)
 	return resource, nil
 }
 
@@ -386,7 +386,7 @@ func CreateFederatedResources(hostConfig *rest.Config, typeConfig typeconfig.Int
 func CreateFederatedResource(hostConfig *rest.Config, typeConfig typeconfig.Interface, federatedResource *unstructured.Unstructured, dryRun bool) error {
 	if typeConfig.GetTarget().Kind == ctlutil.NamespaceKind {
 		// TODO: irfanurrehman: Can a target namespace be federated into another namespace?
-		glog.Infof("Resource to federate is a namespace. Given namespace will itself be the container for the federated namespace")
+		klog.Infof("Resource to federate is a namespace. Given namespace will itself be the container for the federated namespace")
 	}
 
 	fedAPIResource := typeConfig.GetFederatedType()
@@ -415,7 +415,7 @@ func CreateFederatedResource(hostConfig *rest.Config, typeConfig typeconfig.Inte
 		}
 	}
 
-	glog.Infof("Successfully created %s %q from %s", fedKind, qualifiedFedName, typeConfig.GetTarget().Kind)
+	klog.Infof("Successfully created %s %q from %s", fedKind, qualifiedFedName, typeConfig.GetTarget().Kind)
 	return nil
 }
 

--- a/pkg/kubefedctl/join.go
+++ b/pkg/kubefedctl/join.go
@@ -24,8 +24,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/golang/glog"
 	"github.com/pkg/errors"
+	"k8s.io/klog"
 
 	fedv1a1 "github.com/kubernetes-sigs/federation-v2/pkg/apis/core/v1alpha1"
 	genericclient "github.com/kubernetes-sigs/federation-v2/pkg/client/generic"
@@ -120,12 +120,12 @@ func NewCmdJoin(cmdOut io.Writer, config util.FedConfig) *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			err := opts.Complete(args)
 			if err != nil {
-				glog.Fatalf("Error: %v", err)
+				klog.Fatalf("Error: %v", err)
 			}
 
 			err = opts.Run(cmdOut, config)
 			if err != nil {
-				glog.Fatalf("Error: %v", err)
+				klog.Fatalf("Error: %v", err)
 			}
 		},
 	}
@@ -146,7 +146,7 @@ func (j *joinFederation) Complete(args []string) error {
 	}
 
 	if j.ClusterContext == "" {
-		glog.V(2).Infof("Defaulting cluster context to joining cluster name %s", j.ClusterName)
+		klog.V(2).Infof("Defaulting cluster context to joining cluster name %s", j.ClusterName)
 		j.ClusterContext = j.ClusterName
 	}
 
@@ -155,10 +155,10 @@ func (j *joinFederation) Complete(args []string) error {
 	}
 
 	if j.HostClusterName == "" && strings.ContainsAny(j.HostClusterContext, ":/") {
-		glog.Fatal("host-cluster-name must be set if the name of the host cluster context contains one of \":\" or \"/\"")
+		klog.Fatal("host-cluster-name must be set if the name of the host cluster context contains one of \":\" or \"/\"")
 	}
 
-	glog.V(2).Infof("Args and flags: name %s, host: %s, host-system-namespace: %s, kubeconfig: %s, cluster-context: %s, secret-name: %s, dry-run: %v",
+	klog.V(2).Infof("Args and flags: name %s, host: %s, host-system-namespace: %s, kubeconfig: %s, cluster-context: %s, secret-name: %s, dry-run: %v",
 		j.ClusterName, j.HostClusterContext, j.FederationNamespace, j.Kubeconfig, j.ClusterContext,
 		j.secretName, j.DryRun)
 
@@ -171,7 +171,7 @@ func (j *joinFederation) Run(cmdOut io.Writer, config util.FedConfig) error {
 	if err != nil {
 		// TODO(font): Return new error with this same text so it can be output
 		// by caller.
-		glog.V(2).Infof("Failed to get host cluster config: %v", err)
+		klog.V(2).Infof("Failed to get host cluster config: %v", err)
 		return err
 	}
 
@@ -182,7 +182,7 @@ func (j *joinFederation) Run(cmdOut io.Writer, config util.FedConfig) error {
 
 	clusterConfig, err := config.ClusterConfig(j.ClusterContext, j.Kubeconfig)
 	if err != nil {
-		glog.V(2).Infof("Failed to get joining cluster config: %v", err)
+		klog.V(2).Infof("Failed to get joining cluster config: %v", err)
 		return err
 	}
 
@@ -201,23 +201,23 @@ func JoinCluster(hostConfig, clusterConfig *rest.Config, federationNamespace, cl
 	hostClusterName, joiningClusterName, secretName string, addToRegistry bool, Scope apiextv1b1.ResourceScope, dryRun, errorOnExisting bool) error {
 	hostClientset, err := util.HostClientset(hostConfig)
 	if err != nil {
-		glog.V(2).Infof("Failed to get host cluster clientset: %v", err)
+		klog.V(2).Infof("Failed to get host cluster clientset: %v", err)
 		return err
 	}
 
 	clusterClientset, err := util.ClusterClientset(clusterConfig)
 	if err != nil {
-		glog.V(2).Infof("Failed to get joining cluster clientset: %v", err)
+		klog.V(2).Infof("Failed to get joining cluster clientset: %v", err)
 		return err
 	}
 
 	client, err := genericclient.New(hostConfig)
 	if err != nil {
-		glog.V(2).Infof("Failed to get federation clientset: %v", err)
+		klog.V(2).Infof("Failed to get federation clientset: %v", err)
 		return err
 	}
 
-	glog.V(2).Infof("Performing preflight checks.")
+	klog.V(2).Infof("Performing preflight checks.")
 	err = performPreflightChecks(clusterClientset, joiningClusterName, hostClusterName, federationNamespace, errorOnExisting)
 	if err != nil {
 		return err
@@ -238,39 +238,39 @@ func JoinCluster(hostConfig, clusterConfig *rest.Config, federationNamespace, cl
 		}
 	}
 
-	glog.V(2).Infof("Creating %s namespace in joining cluster", federationNamespace)
+	klog.V(2).Infof("Creating %s namespace in joining cluster", federationNamespace)
 	_, err = createFederationNamespace(clusterClientset, federationNamespace,
 		joiningClusterName, dryRun)
 	if err != nil {
-		glog.V(2).Infof("Error creating %s namespace in joining cluster: %v",
+		klog.V(2).Infof("Error creating %s namespace in joining cluster: %v",
 			federationNamespace, err)
 		return err
 	}
-	glog.V(2).Infof("Created %s namespace in joining cluster", federationNamespace)
+	klog.V(2).Infof("Created %s namespace in joining cluster", federationNamespace)
 
 	// Create a service account and use its credentials.
-	glog.V(2).Info("Creating cluster credentials secret")
+	klog.V(2).Info("Creating cluster credentials secret")
 
 	secret, err := createRBACSecret(hostClientset, clusterClientset,
 		federationNamespace, joiningClusterName, hostClusterName,
 		secretName, Scope, dryRun, errorOnExisting)
 	if err != nil {
-		glog.V(2).Infof("Could not create cluster credentials secret: %v", err)
+		klog.V(2).Infof("Could not create cluster credentials secret: %v", err)
 		return err
 	}
 
-	glog.V(2).Info("Cluster credentials secret created")
+	klog.V(2).Info("Cluster credentials secret created")
 
-	glog.V(2).Info("Creating federated cluster resource")
+	klog.V(2).Info("Creating federated cluster resource")
 
 	_, err = createFederatedCluster(client, joiningClusterName, secret.Name,
 		federationNamespace, dryRun, errorOnExisting)
 	if err != nil {
-		glog.V(2).Infof("Failed to create federated cluster resource: %v", err)
+		klog.V(2).Infof("Failed to create federated cluster resource: %v", err)
 		return err
 	}
 
-	glog.V(2).Info("Created federated cluster resource")
+	klog.V(2).Info("Created federated cluster resource")
 	return nil
 }
 
@@ -291,7 +291,7 @@ func performPreflightChecks(clusterClientset kubeclient.Interface, name, hostClu
 	case errorOnExisting:
 		return errors.Errorf("service account: %s already exists in joining cluster: %s", saName, name)
 	default:
-		glog.V(2).Infof("Service account %s already exists in joining cluster %s", saName, name)
+		klog.V(2).Infof("Service account %s already exists in joining cluster %s", saName, name)
 		return nil
 	}
 }
@@ -303,20 +303,20 @@ func addToClusterRegistry(hostConfig *rest.Config, clusterNamespace, host, joini
 	// Get the cluster registry clientset using the host cluster config.
 	client, err := util.ClusterRegistryClientset(hostConfig)
 	if err != nil {
-		glog.V(2).Infof("Failed to get cluster registry clientset: %v", err)
+		klog.V(2).Infof("Failed to get cluster registry clientset: %v", err)
 		return err
 	}
 
-	glog.V(2).Infof("Registering cluster: %s with the cluster registry.", joiningClusterName)
+	klog.V(2).Infof("Registering cluster: %s with the cluster registry.", joiningClusterName)
 
 	err = registerCluster(client, clusterNamespace, host, joiningClusterName, dryRun, errorOnExisting)
 	if err != nil {
-		glog.V(2).Infof("Could not register cluster: %s with the cluster registry: %v",
+		klog.V(2).Infof("Could not register cluster: %s with the cluster registry: %v",
 			joiningClusterName, err)
 		return err
 	}
 
-	glog.V(2).Infof("Registered cluster: %s with the cluster registry.", joiningClusterName)
+	klog.V(2).Infof("Registered cluster: %s with the cluster registry.", joiningClusterName)
 	return nil
 }
 
@@ -325,11 +325,11 @@ func addToClusterRegistry(hostConfig *rest.Config, clusterNamespace, host, joini
 func verifyExistsInClusterRegistry(hostConfig *rest.Config, clusterNamespace, joiningClusterName string) error {
 	client, err := util.ClusterRegistryClientset(hostConfig)
 	if err != nil {
-		glog.V(2).Infof("Failed to get cluster registry clientset: %v", err)
+		klog.V(2).Infof("Failed to get cluster registry clientset: %v", err)
 		return err
 	}
 
-	glog.V(2).Infof("Verifying cluster: %s exists in the cluster registry.",
+	klog.V(2).Infof("Verifying cluster: %s exists in the cluster registry.",
 		joiningClusterName)
 
 	cluster := &crv1a1.Cluster{}
@@ -340,12 +340,12 @@ func verifyExistsInClusterRegistry(hostConfig *rest.Config, clusterNamespace, jo
 				joiningClusterName)
 		}
 
-		glog.V(2).Infof("Could not retrieve cluster %s from the cluster registry: %v",
+		klog.V(2).Infof("Could not retrieve cluster %s from the cluster registry: %v",
 			joiningClusterName, err)
 		return err
 	}
 
-	glog.V(2).Infof("Verified cluster %s exists in the cluster registry.", joiningClusterName)
+	klog.V(2).Infof("Verified cluster %s exists in the cluster registry.", joiningClusterName)
 	return nil
 }
 
@@ -378,16 +378,16 @@ func registerCluster(client genericclient.Client, clusterNamespace, host, joinin
 	err := client.Get(context.TODO(), existingCluster, clusterNamespace, cluster.Name)
 	switch {
 	case err != nil && !apierrors.IsNotFound(err):
-		glog.V(2).Infof("Cannot retrieve cluster registry cluster %s due to %v", cluster.Name, err)
+		klog.V(2).Infof("Cannot retrieve cluster registry cluster %s due to %v", cluster.Name, err)
 		return err
 	case err == nil && errorOnExisting:
 		return errors.Errorf("cluster registry cluster %s already exists", cluster.Name)
 	case err == nil:
 		existingCluster.Spec = cluster.Spec
-		glog.V(2).Infof("Updating existing cluster registry cluster %s", cluster.Name)
+		klog.V(2).Infof("Updating existing cluster registry cluster %s", cluster.Name)
 		return client.Update(context.TODO(), existingCluster)
 	default:
-		glog.V(2).Infof("Creating cluster registry cluster %s", cluster.Name)
+		klog.V(2).Infof("Creating cluster registry cluster %s", cluster.Name)
 		return client.Create(context.TODO(), cluster)
 	}
 }
@@ -419,7 +419,7 @@ func createFederatedCluster(client genericclient.Client, joiningClusterName,
 	err := client.Get(context.TODO(), existingFedCluster, federationNamespace, joiningClusterName)
 	switch {
 	case err != nil && !apierrors.IsNotFound(err):
-		glog.V(2).Infof("Could not retrieve federated cluster %s due to %v", joiningClusterName, err)
+		klog.V(2).Infof("Could not retrieve federated cluster %s due to %v", joiningClusterName, err)
 		return nil, err
 	case err == nil && errorOnExisting:
 		return nil, errors.Errorf("federated cluster %s already exists in host cluster", joiningClusterName)
@@ -427,14 +427,14 @@ func createFederatedCluster(client genericclient.Client, joiningClusterName,
 		existingFedCluster.Spec = fedCluster.Spec
 		err = client.Update(context.TODO(), existingFedCluster)
 		if err != nil {
-			glog.V(2).Infof("Could not update federated cluster %s due to %v", fedCluster.Name, err)
+			klog.V(2).Infof("Could not update federated cluster %s due to %v", fedCluster.Name, err)
 			return nil, err
 		}
 		return existingFedCluster, nil
 	default:
 		err = client.Create(context.TODO(), fedCluster)
 		if err != nil {
-			glog.V(2).Infof("Could not create federated cluster %s due to %v", fedCluster.Name, err)
+			klog.V(2).Infof("Could not create federated cluster %s due to %v", fedCluster.Name, err)
 			return nil, err
 		}
 		return fedCluster, nil
@@ -457,19 +457,19 @@ func createFederationNamespace(clusterClientset kubeclient.Interface, federation
 
 	_, err := clusterClientset.CoreV1().Namespaces().Get(federationNamespace, metav1.GetOptions{})
 	if err != nil && !apierrors.IsNotFound(err) {
-		glog.V(2).Infof("Could not get %s namespace: %v", federationNamespace, err)
+		klog.V(2).Infof("Could not get %s namespace: %v", federationNamespace, err)
 		return nil, err
 	}
 
 	if err == nil {
-		glog.V(2).Infof("Already existing %s namespace", federationNamespace)
+		klog.V(2).Infof("Already existing %s namespace", federationNamespace)
 		return federationNS, nil
 	}
 
 	// Not found, so create.
 	_, err = clusterClientset.CoreV1().Namespaces().Create(federationNS)
 	if err != nil && !apierrors.IsAlreadyExists(err) {
-		glog.V(2).Infof("Could not create %s namespace: %v", federationNamespace, err)
+		klog.V(2).Infof("Could not create %s namespace: %v", federationNamespace, err)
 		return nil, err
 	}
 	return federationNS, nil
@@ -482,67 +482,67 @@ func createRBACSecret(hostClusterClientset, joiningClusterClientset kubeclient.I
 	namespace, joiningClusterName, hostClusterName,
 	secretName string, Scope apiextv1b1.ResourceScope, dryRun, errorOnExisting bool) (*corev1.Secret, error) {
 
-	glog.V(2).Infof("Creating service account in joining cluster: %s", joiningClusterName)
+	klog.V(2).Infof("Creating service account in joining cluster: %s", joiningClusterName)
 
 	saName, err := createServiceAccount(joiningClusterClientset, namespace,
 		joiningClusterName, hostClusterName, dryRun, errorOnExisting)
 	if err != nil {
-		glog.V(2).Infof("Error creating service account: %s in joining cluster: %s due to: %v",
+		klog.V(2).Infof("Error creating service account: %s in joining cluster: %s due to: %v",
 			saName, joiningClusterName, err)
 		return nil, err
 	}
 
-	glog.V(2).Infof("Created service account: %s in joining cluster: %s", saName, joiningClusterName)
+	klog.V(2).Infof("Created service account: %s in joining cluster: %s", saName, joiningClusterName)
 
 	if Scope == apiextv1b1.NamespaceScoped {
-		glog.V(2).Infof("Creating role and binding for service account: %s in joining cluster: %s", saName, joiningClusterName)
+		klog.V(2).Infof("Creating role and binding for service account: %s in joining cluster: %s", saName, joiningClusterName)
 
 		err = createRoleAndBinding(joiningClusterClientset, saName, namespace, joiningClusterName, dryRun, errorOnExisting)
 		if err != nil {
-			glog.V(2).Infof("Error creating role and binding for service account: %s in joining cluster: %s due to: %v", saName, joiningClusterName, err)
+			klog.V(2).Infof("Error creating role and binding for service account: %s in joining cluster: %s due to: %v", saName, joiningClusterName, err)
 			return nil, err
 		}
 
-		glog.V(2).Infof("Created role and binding for service account: %s in joining cluster: %s",
+		klog.V(2).Infof("Created role and binding for service account: %s in joining cluster: %s",
 			saName, joiningClusterName)
 
-		glog.V(2).Infof("Creating health check cluster role and binding for service account: %s in joining cluster: %s", saName, joiningClusterName)
+		klog.V(2).Infof("Creating health check cluster role and binding for service account: %s in joining cluster: %s", saName, joiningClusterName)
 
 		err = createHealthCheckClusterRoleAndBinding(joiningClusterClientset, saName, namespace, joiningClusterName,
 			dryRun, errorOnExisting)
 		if err != nil {
-			glog.V(2).Infof("Error creating health check cluster role and binding for service account: %s in joining cluster: %s due to: %v",
+			klog.V(2).Infof("Error creating health check cluster role and binding for service account: %s in joining cluster: %s due to: %v",
 				saName, joiningClusterName, err)
 			return nil, err
 		}
 
-		glog.V(2).Infof("Created health check cluster role and binding for service account: %s in joining cluster: %s",
+		klog.V(2).Infof("Created health check cluster role and binding for service account: %s in joining cluster: %s",
 			saName, joiningClusterName)
 
 	} else {
-		glog.V(2).Infof("Creating cluster role and binding for service account: %s in joining cluster: %s", saName, joiningClusterName)
+		klog.V(2).Infof("Creating cluster role and binding for service account: %s in joining cluster: %s", saName, joiningClusterName)
 
 		err = createClusterRoleAndBinding(joiningClusterClientset, saName, namespace, joiningClusterName, dryRun, errorOnExisting)
 		if err != nil {
-			glog.V(2).Infof("Error creating cluster role and binding for service account: %s in joining cluster: %s due to: %v",
+			klog.V(2).Infof("Error creating cluster role and binding for service account: %s in joining cluster: %s due to: %v",
 				saName, joiningClusterName, err)
 			return nil, err
 		}
 
-		glog.V(2).Infof("Created cluster role and binding for service account: %s in joining cluster: %s",
+		klog.V(2).Infof("Created cluster role and binding for service account: %s in joining cluster: %s",
 			saName, joiningClusterName)
 	}
 
-	glog.V(2).Infof("Creating secret in host cluster: %s", hostClusterName)
+	klog.V(2).Infof("Creating secret in host cluster: %s", hostClusterName)
 
 	secret, err := populateSecretInHostCluster(joiningClusterClientset, hostClusterClientset,
 		saName, namespace, joiningClusterName, secretName, dryRun)
 	if err != nil {
-		glog.V(2).Infof("Error creating secret in host cluster: %s due to: %v", hostClusterName, err)
+		klog.V(2).Infof("Error creating secret in host cluster: %s due to: %v", hostClusterName, err)
 		return nil, err
 	}
 
-	glog.V(2).Infof("Created secret in host cluster: %s", hostClusterName)
+	klog.V(2).Infof("Created secret in host cluster: %s", hostClusterName)
 
 	return secret, nil
 }
@@ -568,10 +568,10 @@ func createServiceAccount(clusterClientset kubeclient.Interface, namespace,
 	_, err := clusterClientset.CoreV1().ServiceAccounts(namespace).Create(sa)
 	switch {
 	case apierrors.IsAlreadyExists(err) && errorOnExisting:
-		glog.V(2).Infof("Service account %s/%s already exists in target cluster %s", namespace, saName, joiningClusterName)
+		klog.V(2).Infof("Service account %s/%s already exists in target cluster %s", namespace, saName, joiningClusterName)
 		return "", err
 	case err != nil && !apierrors.IsAlreadyExists(err):
-		glog.V(2).Infof("Could not create service account %s/%s in target cluster %s due to: %v", namespace, saName, joiningClusterName, err)
+		klog.V(2).Infof("Could not create service account %s/%s in target cluster %s due to: %v", namespace, saName, joiningClusterName, err)
 		return "", err
 	default:
 		return saName, nil
@@ -608,7 +608,7 @@ func createClusterRoleAndBinding(clientset kubeclient.Interface, saName, namespa
 	existingRole, err := clientset.RbacV1().ClusterRoles().Get(roleName, metav1.GetOptions{})
 	switch {
 	case err != nil && !apierrors.IsNotFound(err):
-		glog.V(2).Infof("Could not get cluster role for service account %s in joining cluster %s due to %v",
+		klog.V(2).Infof("Could not get cluster role for service account %s in joining cluster %s due to %v",
 			saName, clusterName, err)
 		return err
 	case err == nil && errorOnExisting:
@@ -617,14 +617,14 @@ func createClusterRoleAndBinding(clientset kubeclient.Interface, saName, namespa
 		existingRole.Rules = role.Rules
 		_, err := clientset.RbacV1().ClusterRoles().Update(existingRole)
 		if err != nil {
-			glog.V(2).Infof("Could not update cluster role for service account: %s in joining cluster: %s due to: %v",
+			klog.V(2).Infof("Could not update cluster role for service account: %s in joining cluster: %s due to: %v",
 				saName, clusterName, err)
 			return err
 		}
 	default: // role was not found
 		_, err := clientset.RbacV1().ClusterRoles().Create(role)
 		if err != nil {
-			glog.V(2).Infof("Could not create cluster role for service account: %s in joining cluster: %s due to: %v",
+			klog.V(2).Infof("Could not create cluster role for service account: %s in joining cluster: %s due to: %v",
 				saName, clusterName, err)
 			return err
 		}
@@ -645,7 +645,7 @@ func createClusterRoleAndBinding(clientset kubeclient.Interface, saName, namespa
 	existingBinding, err := clientset.RbacV1().ClusterRoleBindings().Get(binding.Name, metav1.GetOptions{})
 	switch {
 	case err != nil && !apierrors.IsNotFound(err):
-		glog.V(2).Infof("Could not get cluster role binding for service account %s in joining cluster %s due to %v",
+		klog.V(2).Infof("Could not get cluster role binding for service account %s in joining cluster %s due to %v",
 			saName, clusterName, err)
 		return err
 	case err == nil && errorOnExisting:
@@ -656,13 +656,13 @@ func createClusterRoleAndBinding(clientset kubeclient.Interface, saName, namespa
 		if !reflect.DeepEqual(existingBinding.RoleRef, binding.RoleRef) {
 			err = clientset.RbacV1().ClusterRoleBindings().Delete(existingBinding.Name, &metav1.DeleteOptions{})
 			if err != nil {
-				glog.V(2).Infof("Could not delete existing cluster role binding for service account %s in joining cluster %s due to: %v",
+				klog.V(2).Infof("Could not delete existing cluster role binding for service account %s in joining cluster %s due to: %v",
 					saName, clusterName, err)
 				return err
 			}
 			_, err = clientset.RbacV1().ClusterRoleBindings().Create(binding)
 			if err != nil {
-				glog.V(2).Infof("Could not create cluster role binding for service account: %s in joining cluster: %s due to: %v",
+				klog.V(2).Infof("Could not create cluster role binding for service account: %s in joining cluster: %s due to: %v",
 					saName, clusterName, err)
 				return err
 			}
@@ -670,7 +670,7 @@ func createClusterRoleAndBinding(clientset kubeclient.Interface, saName, namespa
 			existingBinding.Subjects = binding.Subjects
 			_, err := clientset.RbacV1().ClusterRoleBindings().Update(existingBinding)
 			if err != nil {
-				glog.V(2).Infof("Could not update cluster role binding for service account: %s in joining cluster: %s due to: %v",
+				klog.V(2).Infof("Could not update cluster role binding for service account: %s in joining cluster: %s due to: %v",
 					saName, clusterName, err)
 				return err
 			}
@@ -678,7 +678,7 @@ func createClusterRoleAndBinding(clientset kubeclient.Interface, saName, namespa
 	default:
 		_, err = clientset.RbacV1().ClusterRoleBindings().Create(binding)
 		if err != nil {
-			glog.V(2).Infof("Could not create cluster role binding for service account: %s in joining cluster: %s due to: %v",
+			klog.V(2).Infof("Could not create cluster role binding for service account: %s in joining cluster: %s due to: %v",
 				saName, clusterName, err)
 			return err
 		}
@@ -705,7 +705,7 @@ func createRoleAndBinding(clientset kubeclient.Interface, saName, namespace, clu
 	existingRole, err := clientset.RbacV1().Roles(namespace).Get(roleName, metav1.GetOptions{})
 	switch {
 	case err != nil && !apierrors.IsNotFound(err):
-		glog.V(2).Infof("Could not retrieve role for service account %s in joining cluster %s due to %v", saName, clusterName, err)
+		klog.V(2).Infof("Could not retrieve role for service account %s in joining cluster %s due to %v", saName, clusterName, err)
 		return err
 	case errorOnExisting && err == nil:
 		return errors.Errorf("role for service account %s in joining cluster %s already exists", saName, clusterName)
@@ -713,14 +713,14 @@ func createRoleAndBinding(clientset kubeclient.Interface, saName, namespace, clu
 		existingRole.Rules = role.Rules
 		_, err = clientset.RbacV1().Roles(namespace).Update(existingRole)
 		if err != nil {
-			glog.V(2).Infof("Could not update role for service account: %s in joining cluster: %s due to: %v",
+			klog.V(2).Infof("Could not update role for service account: %s in joining cluster: %s due to: %v",
 				saName, clusterName, err)
 			return err
 		}
 	default:
 		_, err := clientset.RbacV1().Roles(namespace).Create(role)
 		if err != nil {
-			glog.V(2).Infof("Could not create role for service account: %s in joining cluster: %s due to: %v",
+			klog.V(2).Infof("Could not create role for service account: %s in joining cluster: %s due to: %v",
 				saName, clusterName, err)
 			return err
 		}
@@ -741,7 +741,7 @@ func createRoleAndBinding(clientset kubeclient.Interface, saName, namespace, clu
 	existingBinding, err := clientset.RbacV1().RoleBindings(namespace).Get(binding.Name, metav1.GetOptions{})
 	switch {
 	case err != nil && !apierrors.IsNotFound(err):
-		glog.V(2).Infof("Could not retrieve role binding for service account %s in joining cluster %s due to: %v",
+		klog.V(2).Infof("Could not retrieve role binding for service account %s in joining cluster %s due to: %v",
 			saName, clusterName, err)
 		return err
 	case err == nil && errorOnExisting:
@@ -752,13 +752,13 @@ func createRoleAndBinding(clientset kubeclient.Interface, saName, namespace, clu
 		if !reflect.DeepEqual(existingBinding.RoleRef, binding.RoleRef) {
 			err = clientset.RbacV1().RoleBindings(namespace).Delete(existingBinding.Name, &metav1.DeleteOptions{})
 			if err != nil {
-				glog.V(2).Infof("Could not delete existing role binding for service account %s in joining cluster %s due to: %v",
+				klog.V(2).Infof("Could not delete existing role binding for service account %s in joining cluster %s due to: %v",
 					saName, clusterName, err)
 				return err
 			}
 			_, err = clientset.RbacV1().RoleBindings(namespace).Create(binding)
 			if err != nil {
-				glog.V(2).Infof("Could not create role binding for service account: %s in joining cluster: %s due to: %v",
+				klog.V(2).Infof("Could not create role binding for service account: %s in joining cluster: %s due to: %v",
 					saName, clusterName, err)
 				return err
 			}
@@ -766,7 +766,7 @@ func createRoleAndBinding(clientset kubeclient.Interface, saName, namespace, clu
 			existingBinding.Subjects = binding.Subjects
 			_, err = clientset.RbacV1().RoleBindings(namespace).Update(existingBinding)
 			if err != nil {
-				glog.V(2).Infof("Could not update role binding for service account %s in joining cluster %s due to: %v",
+				klog.V(2).Infof("Could not update role binding for service account %s in joining cluster %s due to: %v",
 					saName, clusterName, err)
 				return err
 			}
@@ -774,7 +774,7 @@ func createRoleAndBinding(clientset kubeclient.Interface, saName, namespace, clu
 	default:
 		_, err = clientset.RbacV1().RoleBindings(namespace).Create(binding)
 		if err != nil {
-			glog.V(2).Infof("Could not create role binding for service account: %s in joining cluster: %s due to: %v",
+			klog.V(2).Infof("Could not create role binding for service account: %s in joining cluster: %s due to: %v",
 				saName, clusterName, err)
 			return err
 		}
@@ -814,7 +814,7 @@ func createHealthCheckClusterRoleAndBinding(clientset kubeclient.Interface, saNa
 	existingRole, err := clientset.RbacV1().ClusterRoles().Get(role.Name, metav1.GetOptions{})
 	switch {
 	case err != nil && !apierrors.IsNotFound(err):
-		glog.V(2).Infof("Could not get health check cluster role for service account %s in joining cluster %s due to %v",
+		klog.V(2).Infof("Could not get health check cluster role for service account %s in joining cluster %s due to %v",
 			saName, clusterName, err)
 		return err
 	case err == nil && errorOnExisting:
@@ -823,14 +823,14 @@ func createHealthCheckClusterRoleAndBinding(clientset kubeclient.Interface, saNa
 		existingRole.Rules = role.Rules
 		_, err := clientset.RbacV1().ClusterRoles().Update(existingRole)
 		if err != nil {
-			glog.V(2).Infof("Could not update health check cluster role for service account: %s in joining cluster: %s due to: %v",
+			klog.V(2).Infof("Could not update health check cluster role for service account: %s in joining cluster: %s due to: %v",
 				saName, clusterName, err)
 			return err
 		}
 	default: // role was not found
 		_, err := clientset.RbacV1().ClusterRoles().Create(role)
 		if err != nil {
-			glog.V(2).Infof("Could not create health check cluster role for service account: %s in joining cluster: %s due to: %v",
+			klog.V(2).Infof("Could not create health check cluster role for service account: %s in joining cluster: %s due to: %v",
 				saName, clusterName, err)
 			return err
 		}
@@ -850,7 +850,7 @@ func createHealthCheckClusterRoleAndBinding(clientset kubeclient.Interface, saNa
 	existingBinding, err := clientset.RbacV1().ClusterRoleBindings().Get(binding.Name, metav1.GetOptions{})
 	switch {
 	case err != nil && !apierrors.IsNotFound(err):
-		glog.V(2).Infof("Could not get health check cluster role binding for service account %s in joining cluster %s due to %v",
+		klog.V(2).Infof("Could not get health check cluster role binding for service account %s in joining cluster %s due to %v",
 			saName, clusterName, err)
 		return err
 	case err == nil && errorOnExisting:
@@ -861,13 +861,13 @@ func createHealthCheckClusterRoleAndBinding(clientset kubeclient.Interface, saNa
 		if !reflect.DeepEqual(existingBinding.RoleRef, binding.RoleRef) {
 			err = clientset.RbacV1().ClusterRoleBindings().Delete(existingBinding.Name, &metav1.DeleteOptions{})
 			if err != nil {
-				glog.V(2).Infof("Could not delete existing health check cluster role binding for service account %s in joining cluster %s due to: %v",
+				klog.V(2).Infof("Could not delete existing health check cluster role binding for service account %s in joining cluster %s due to: %v",
 					saName, clusterName, err)
 				return err
 			}
 			_, err = clientset.RbacV1().ClusterRoleBindings().Create(binding)
 			if err != nil {
-				glog.V(2).Infof("Could not create health check cluster role binding for service account: %s in joining cluster: %s due to: %v",
+				klog.V(2).Infof("Could not create health check cluster role binding for service account: %s in joining cluster: %s due to: %v",
 					saName, clusterName, err)
 				return err
 			}
@@ -875,7 +875,7 @@ func createHealthCheckClusterRoleAndBinding(clientset kubeclient.Interface, saNa
 			existingBinding.Subjects = binding.Subjects
 			_, err := clientset.RbacV1().ClusterRoleBindings().Update(existingBinding)
 			if err != nil {
-				glog.V(2).Infof("Could not update health check cluster role binding for service account: %s in joining cluster: %s due to: %v",
+				klog.V(2).Infof("Could not update health check cluster role binding for service account: %s in joining cluster: %s due to: %v",
 					saName, clusterName, err)
 				return err
 			}
@@ -883,7 +883,7 @@ func createHealthCheckClusterRoleAndBinding(clientset kubeclient.Interface, saNa
 	default:
 		_, err = clientset.RbacV1().ClusterRoleBindings().Create(binding)
 		if err != nil {
-			glog.V(2).Infof("Could not create health check cluster role binding for service account: %s in joining cluster: %s due to: %v",
+			klog.V(2).Infof("Could not create health check cluster role binding for service account: %s in joining cluster: %s due to: %v",
 				saName, clusterName, err)
 			return err
 		}
@@ -922,7 +922,7 @@ func populateSecretInHostCluster(clusterClientset, hostClientset kubeclient.Inte
 				return false, nil
 			}
 			if secret.Type == corev1.SecretTypeServiceAccountToken {
-				glog.V(2).Infof("Using secret named: %s", secret.Name)
+				klog.V(2).Infof("Using secret named: %s", secret.Name)
 				return true, nil
 			}
 		}
@@ -930,7 +930,7 @@ func populateSecretInHostCluster(clusterClientset, hostClientset kubeclient.Inte
 	})
 
 	if err != nil {
-		glog.V(2).Infof("Could not get service account secret from joining cluster: %v", err)
+		klog.V(2).Infof("Could not get service account secret from joining cluster: %v", err)
 		return nil, err
 	}
 
@@ -950,10 +950,10 @@ func populateSecretInHostCluster(clusterClientset, hostClientset kubeclient.Inte
 
 	v1SecretResult, err := hostClientset.CoreV1().Secrets(namespace).Create(&v1Secret)
 	if err != nil {
-		glog.V(2).Infof("Could not create secret in host cluster: %v", err)
+		klog.V(2).Infof("Could not create secret in host cluster: %v", err)
 		return nil, err
 	}
 
-	glog.V(2).Infof("Created secret in host cluster named: %s", v1SecretResult.Name)
+	klog.V(2).Infof("Created secret in host cluster named: %s", v1SecretResult.Name)
 	return v1SecretResult, nil
 }

--- a/pkg/kubefedctl/join.go
+++ b/pkg/kubefedctl/join.go
@@ -25,12 +25,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"k8s.io/klog"
 
-	fedv1a1 "github.com/kubernetes-sigs/federation-v2/pkg/apis/core/v1alpha1"
-	genericclient "github.com/kubernetes-sigs/federation-v2/pkg/client/generic"
-	"github.com/kubernetes-sigs/federation-v2/pkg/kubefedctl/options"
-	"github.com/kubernetes-sigs/federation-v2/pkg/kubefedctl/util"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	corev1 "k8s.io/api/core/v1"
@@ -42,6 +37,12 @@ import (
 	kubeclient "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	crv1a1 "k8s.io/cluster-registry/pkg/apis/clusterregistry/v1alpha1"
+	"k8s.io/klog"
+
+	fedv1a1 "github.com/kubernetes-sigs/federation-v2/pkg/apis/core/v1alpha1"
+	genericclient "github.com/kubernetes-sigs/federation-v2/pkg/client/generic"
+	"github.com/kubernetes-sigs/federation-v2/pkg/kubefedctl/options"
+	"github.com/kubernetes-sigs/federation-v2/pkg/kubefedctl/util"
 )
 
 const (

--- a/pkg/kubefedctl/kubefedctl.go
+++ b/pkg/kubefedctl/kubefedctl.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+
 	apiserverflag "k8s.io/apiserver/pkg/util/flag"
 	"k8s.io/client-go/tools/clientcmd"
 

--- a/pkg/kubefedctl/kubefedctl.go
+++ b/pkg/kubefedctl/kubefedctl.go
@@ -41,7 +41,7 @@ func NewKubeFedCtlCommand(out io.Writer) *cobra.Command {
 		RunE: runHelp,
 	}
 
-	// Add the command line flags from other dependencies (e.g., glog), but do not
+	// Add the command line flags from other dependencies (e.g., klog), but do not
 	// warn if they contain underscores.
 	pflag.CommandLine.SetNormalizeFunc(apiserverflag.WordSepNormalizeFunc)
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
@@ -50,7 +50,7 @@ func NewKubeFedCtlCommand(out io.Writer) *cobra.Command {
 	// From this point and forward we get warnings on flags that contain "_" separators
 	rootCmd.SetGlobalNormalizationFunc(apiserverflag.WarnWordSepNormalizeFunc)
 
-	// Prevent glog errors about logging before parsing.
+	// Prevent klog errors about logging before parsing.
 	_ = flag.CommandLine.Parse(nil)
 
 	fedConfig := util.NewFedConfig(clientcmd.NewDefaultPathOptions())

--- a/pkg/kubefedctl/options/options.go
+++ b/pkg/kubefedctl/options/options.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/spf13/pflag"
+
 	apiextv1b1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/client-go/rest"
 

--- a/pkg/kubefedctl/unjoin.go
+++ b/pkg/kubefedctl/unjoin.go
@@ -23,6 +23,14 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubeclient "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	crv1a1 "k8s.io/cluster-registry/pkg/apis/clusterregistry/v1alpha1"
 	"k8s.io/klog"
 
 	fedv1a1 "github.com/kubernetes-sigs/federation-v2/pkg/apis/core/v1alpha1"
@@ -30,13 +38,6 @@ import (
 	controllerutil "github.com/kubernetes-sigs/federation-v2/pkg/controller/util"
 	"github.com/kubernetes-sigs/federation-v2/pkg/kubefedctl/options"
 	"github.com/kubernetes-sigs/federation-v2/pkg/kubefedctl/util"
-	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	kubeclient "k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
-	crv1a1 "k8s.io/cluster-registry/pkg/apis/clusterregistry/v1alpha1"
 )
 
 var (

--- a/pkg/kubefedctl/util/util.go
+++ b/pkg/kubefedctl/util/util.go
@@ -19,10 +19,11 @@ package util
 import (
 	"fmt"
 
-	"github.com/kubernetes-sigs/federation-v2/pkg/client/generic"
 	kubeclient "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/kubernetes-sigs/federation-v2/pkg/client/generic"
 )
 
 // FedConfig provides a rest config based on the filesystem kubeconfig (via

--- a/pkg/kubefedctl/version.go
+++ b/pkg/kubefedctl/version.go
@@ -20,8 +20,9 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/kubernetes-sigs/federation-v2/pkg/version"
 	"github.com/spf13/cobra"
+
+	"github.com/kubernetes-sigs/federation-v2/pkg/version"
 )
 
 var (

--- a/pkg/schedulingtypes/interface.go
+++ b/pkg/schedulingtypes/interface.go
@@ -17,9 +17,10 @@ limitations under the License.
 package schedulingtypes
 
 import (
+	pkgruntime "k8s.io/apimachinery/pkg/runtime"
+
 	"github.com/kubernetes-sigs/federation-v2/pkg/apis/core/typeconfig"
 	. "github.com/kubernetes-sigs/federation-v2/pkg/controller/util"
-	pkgruntime "k8s.io/apimachinery/pkg/runtime"
 )
 
 type Scheduler interface {

--- a/pkg/schedulingtypes/plugin.go
+++ b/pkg/schedulingtypes/plugin.go
@@ -22,9 +22,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/kubernetes-sigs/federation-v2/pkg/apis/core/typeconfig"
-	genericclient "github.com/kubernetes-sigs/federation-v2/pkg/client/generic"
-	"github.com/kubernetes-sigs/federation-v2/pkg/controller/util"
 	"github.com/pkg/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -32,6 +29,10 @@ import (
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog"
+
+	"github.com/kubernetes-sigs/federation-v2/pkg/apis/core/typeconfig"
+	genericclient "github.com/kubernetes-sigs/federation-v2/pkg/client/generic"
+	"github.com/kubernetes-sigs/federation-v2/pkg/controller/util"
 )
 
 const (

--- a/pkg/schedulingtypes/plugin.go
+++ b/pkg/schedulingtypes/plugin.go
@@ -22,7 +22,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/golang/glog"
 	"github.com/kubernetes-sigs/federation-v2/pkg/apis/core/typeconfig"
 	genericclient "github.com/kubernetes-sigs/federation-v2/pkg/client/generic"
 	"github.com/kubernetes-sigs/federation-v2/pkg/controller/util"
@@ -32,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog"
 )
 
 const (
@@ -99,7 +99,7 @@ func (p *Plugin) Stop() {
 
 func (p *Plugin) HasSynced() bool {
 	if !p.targetInformer.ClustersSynced() {
-		glog.V(2).Infof("Cluster list not synced")
+		klog.V(2).Infof("Cluster list not synced")
 		return false
 	}
 
@@ -123,7 +123,7 @@ func (p *Plugin) HasSynced() bool {
 func (p *Plugin) FederatedTypeExists(key string) bool {
 	_, exist, err := p.federatedStore.GetByKey(key)
 	if err != nil {
-		glog.Errorf("Failed to query store while reconciling RSP controller for key %q: %v", key, err)
+		klog.Errorf("Failed to query store while reconciling RSP controller for key %q: %v", key, err)
 		wrappedErr := errors.Wrapf(err, "Failed to query store while reconciling RSP controller for key %q", key)
 		runtime.HandleError(wrappedErr)
 		return false

--- a/pkg/schedulingtypes/replicascheduler.go
+++ b/pkg/schedulingtypes/replicascheduler.go
@@ -22,8 +22,8 @@ import (
 	"sort"
 	"time"
 
-	"github.com/golang/glog"
 	"github.com/pkg/errors"
+	"k8s.io/klog"
 
 	"github.com/kubernetes-sigs/federation-v2/pkg/apis/core/typeconfig"
 	fedschedulingv1a1 "github.com/kubernetes-sigs/federation-v2/pkg/apis/scheduling/v1alpha1"
@@ -135,7 +135,7 @@ func (s *ReplicaScheduler) HasSynced() bool {
 	}
 
 	if !s.podInformer.ClustersSynced() {
-		glog.V(2).Infof("Cluster list not synced")
+		klog.V(2).Infof("Cluster list not synced")
 		return false
 	}
 	clusters, err := s.podInformer.GetReadyClusters()
@@ -285,7 +285,7 @@ func schedule(planner *planner.Planner, key string, clusterNames []string, curre
 		result[clusterName] += replicas
 	}
 
-	if glog.V(4) {
+	if klog.V(4) {
 		buf := bytes.NewBufferString(fmt.Sprintf("Schedule - %q\n", key))
 		sort.Strings(clusterNames)
 		for _, clusterName := range clusterNames {
@@ -300,7 +300,7 @@ func schedule(planner *planner.Planner, key string, clusterNames []string, curre
 			}
 			fmt.Fprintf(buf, "\n")
 		}
-		glog.V(4).Infof(buf.String())
+		klog.V(4).Infof(buf.String())
 	}
 	return result, nil
 }

--- a/pkg/schedulingtypes/replicascheduler.go
+++ b/pkg/schedulingtypes/replicascheduler.go
@@ -23,6 +23,12 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
+	pkgruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/klog"
 
 	"github.com/kubernetes-sigs/federation-v2/pkg/apis/core/typeconfig"
@@ -31,11 +37,6 @@ import (
 	ctlutil "github.com/kubernetes-sigs/federation-v2/pkg/controller/util"
 	"github.com/kubernetes-sigs/federation-v2/pkg/controller/util/planner"
 	"github.com/kubernetes-sigs/federation-v2/pkg/controller/util/podanalyzer"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/labels"
-	pkgruntime "k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/runtime"
 )
 
 const (

--- a/test/common/fixtures.go
+++ b/test/common/fixtures.go
@@ -23,8 +23,9 @@ import (
 
 	"github.com/pkg/errors"
 
-	kfenable "github.com/kubernetes-sigs/federation-v2/pkg/kubefedctl/enable"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	kfenable "github.com/kubernetes-sigs/federation-v2/pkg/kubefedctl/enable"
 )
 
 var fixtures map[string]*unstructured.Unstructured

--- a/test/common/testobjects.go
+++ b/test/common/testobjects.go
@@ -22,11 +22,12 @@ import (
 
 	"github.com/pkg/errors"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
 	"github.com/kubernetes-sigs/federation-v2/pkg/apis/core/typeconfig"
 	"github.com/kubernetes-sigs/federation-v2/pkg/controller/util"
 	"github.com/kubernetes-sigs/federation-v2/pkg/kubefedctl/federate"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 func NewTestObject(typeConfig typeconfig.Interface, namespace string, clusterNames []string, fixture *unstructured.Unstructured) (*unstructured.Unstructured, error) {

--- a/test/e2e/crd.go
+++ b/test/e2e/crd.go
@@ -34,7 +34,6 @@ import (
 	apicommon "github.com/kubernetes-sigs/federation-v2/pkg/apis/core/common"
 	fedv1a1 "github.com/kubernetes-sigs/federation-v2/pkg/apis/core/v1alpha1"
 	"github.com/kubernetes-sigs/federation-v2/pkg/controller/util"
-
 	"github.com/kubernetes-sigs/federation-v2/pkg/kubefedctl"
 	kfenable "github.com/kubernetes-sigs/federation-v2/pkg/kubefedctl/enable"
 	kfenableopts "github.com/kubernetes-sigs/federation-v2/pkg/kubefedctl/options"

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -19,10 +19,10 @@ package e2e
 import (
 	"testing"
 
+	"github.com/golang/glog"
 	"github.com/kubernetes-sigs/federation-v2/test/e2e/framework"
 	"github.com/kubernetes-sigs/federation-v2/test/e2e/framework/ginkgowrapper"
 
-	"github.com/golang/glog"
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/ginkgo/config"
 	"github.com/onsi/gomega"

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -19,13 +19,14 @@ package e2e
 import (
 	"testing"
 
-	"github.com/onsi/ginkgo"
-	"github.com/onsi/ginkgo/config"
-	"github.com/onsi/gomega"
 	"k8s.io/klog"
 
 	"github.com/kubernetes-sigs/federation-v2/test/e2e/framework"
 	"github.com/kubernetes-sigs/federation-v2/test/e2e/framework/ginkgowrapper"
+
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/config"
+	"github.com/onsi/gomega"
 )
 
 // RunE2ETests checks configuration parameters (specified through flags) and then runs

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -19,13 +19,13 @@ package e2e
 import (
 	"testing"
 
-	"github.com/golang/glog"
-	"github.com/kubernetes-sigs/federation-v2/test/e2e/framework"
-	"github.com/kubernetes-sigs/federation-v2/test/e2e/framework/ginkgowrapper"
-
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/ginkgo/config"
 	"github.com/onsi/gomega"
+	"k8s.io/klog"
+
+	"github.com/kubernetes-sigs/federation-v2/test/e2e/framework"
+	"github.com/kubernetes-sigs/federation-v2/test/e2e/framework/ginkgowrapper"
 )
 
 // RunE2ETests checks configuration parameters (specified through flags) and then runs
@@ -33,7 +33,7 @@ import (
 // This function is called on each Ginkgo node in parallel mode.
 func RunE2ETests(t *testing.T) {
 	gomega.RegisterFailHandler(ginkgowrapper.Fail)
-	glog.Infof("Starting e2e run %q on Ginkgo node %d", framework.RunId, config.GinkgoConfig.ParallelNode)
+	klog.Infof("Starting e2e run %q on Ginkgo node %d", framework.RunId, config.GinkgoConfig.ParallelNode)
 	ginkgo.RunSpecs(t, "Federation e2e suite")
 }
 

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -19,8 +19,9 @@ package e2e
 import (
 	"testing"
 
-	"github.com/kubernetes-sigs/federation-v2/test/e2e/framework"
 	_ "k8s.io/client-go/plugin/pkg/client/auth" // Load all client auth plugins for GCP, Azure, etc
+
+	"github.com/kubernetes-sigs/federation-v2/test/e2e/framework"
 )
 
 func init() {

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -20,11 +20,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/kubernetes-sigs/federation-v2/pkg/apis/core/typeconfig"
-	fedv1a1 "github.com/kubernetes-sigs/federation-v2/pkg/apis/core/v1alpha1"
-	genericclient "github.com/kubernetes-sigs/federation-v2/pkg/client/generic"
-	"github.com/kubernetes-sigs/federation-v2/pkg/controller/util"
-	"github.com/kubernetes-sigs/federation-v2/test/common"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -33,6 +28,12 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	kubeclientset "k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
+
+	"github.com/kubernetes-sigs/federation-v2/pkg/apis/core/typeconfig"
+	fedv1a1 "github.com/kubernetes-sigs/federation-v2/pkg/apis/core/v1alpha1"
+	genericclient "github.com/kubernetes-sigs/federation-v2/pkg/client/generic"
+	"github.com/kubernetes-sigs/federation-v2/pkg/controller/util"
+	"github.com/kubernetes-sigs/federation-v2/test/common"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/test/e2e/framework/test_context.go
+++ b/test/e2e/framework/test_context.go
@@ -23,7 +23,6 @@ import (
 	"time"
 
 	"github.com/golang/glog"
-
 	"github.com/kubernetes-sigs/federation-v2/pkg/controller/util"
 )
 

--- a/test/e2e/framework/test_context.go
+++ b/test/e2e/framework/test_context.go
@@ -22,7 +22,8 @@ import (
 	"os"
 	"time"
 
-	"github.com/golang/glog"
+	"k8s.io/klog"
+
 	"github.com/kubernetes-sigs/federation-v2/pkg/controller/util"
 )
 
@@ -66,10 +67,10 @@ func registerFlags(t *TestContextType) {
 
 func validateFlags(t *TestContextType) {
 	if len(t.KubeConfig) == 0 {
-		glog.Fatalf("kubeconfig is required")
+		klog.Fatalf("kubeconfig is required")
 	}
 	if t.InMemoryControllers {
-		glog.Info("in-memory-controllers=true - this will launch the federation controllers outside the cluster hosting the federation control plane.")
+		klog.Info("in-memory-controllers=true - this will launch the federation controllers outside the cluster hosting the federation control plane.")
 	}
 }
 

--- a/test/e2e/framework/unmanaged.go
+++ b/test/e2e/framework/unmanaged.go
@@ -23,11 +23,6 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/kubernetes-sigs/federation-v2/pkg/apis/core/typeconfig"
-	fedv1a1 "github.com/kubernetes-sigs/federation-v2/pkg/apis/core/v1alpha1"
-	genericclient "github.com/kubernetes-sigs/federation-v2/pkg/client/generic"
-	"github.com/kubernetes-sigs/federation-v2/pkg/controller/util"
-	"github.com/kubernetes-sigs/federation-v2/test/common"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -36,6 +31,12 @@ import (
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+
+	"github.com/kubernetes-sigs/federation-v2/pkg/apis/core/typeconfig"
+	fedv1a1 "github.com/kubernetes-sigs/federation-v2/pkg/apis/core/v1alpha1"
+	genericclient "github.com/kubernetes-sigs/federation-v2/pkg/client/generic"
+	"github.com/kubernetes-sigs/federation-v2/pkg/controller/util"
+	"github.com/kubernetes-sigs/federation-v2/test/common"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"


### PR DESCRIPTION
#695 is WIP, but this switch to use `klog` is needed in order to enable webhook dependencies in a follow-up PR.

Posting on behalf of @pmorie who did the work.

Fixes #694 