### PR TITLE
Add timeout to cluster clients used for cluster health checks

### DIFF
--- a/pkg/controller/federatedcluster/clusterclient.go
+++ b/pkg/controller/federatedcluster/clusterclient.go
@@ -18,6 +18,7 @@ package federatedcluster
 
 import (
 	"strings"
+	"time"
 
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
@@ -53,11 +54,12 @@ type ClusterClient struct {
 // The kubeClient and crClient are used to configure the ClusterClient's
 // internal client with information from a kubeconfig stored in a kubernetes
 // secret and an API endpoint from the cluster-registry.
-func NewClusterClientSet(c *fedv1a1.FederatedCluster, client generic.Client, fedNamespace, clusterNamespace string) (*ClusterClient, error) {
+func NewClusterClientSet(c *fedv1a1.FederatedCluster, client generic.Client, fedNamespace, clusterNamespace string, timeout time.Duration) (*ClusterClient, error) {
 	clusterConfig, err := util.BuildClusterConfig(c, client, fedNamespace, clusterNamespace)
 	if err != nil {
 		return nil, err
 	}
+	clusterConfig.Timeout = timeout
 	var clusterClientSet = ClusterClient{clusterName: c.Name}
 	if clusterConfig != nil {
 		clusterClientSet.kubeClient = kubeclientset.NewForConfigOrDie((restclient.AddUserAgent(clusterConfig, UserAgentName)))

--- a/pkg/controller/federatedcluster/controller.go
+++ b/pkg/controller/federatedcluster/controller.go
@@ -131,7 +131,8 @@ func (cc *ClusterController) addToClusterSet(obj interface{}) {
 	}
 	glog.V(1).Infof("ClusterController observed a new cluster: %v", cluster.Name)
 	// create the restclient of cluster
-	restClient, err := NewClusterClientSet(cluster, cc.client, cc.fedNamespace, cc.clusterNamespace)
+	clientTimeout := time.Duration(cc.clusterHealthCheckConfig.TimeoutSeconds) * time.Second
+	restClient, err := NewClusterClientSet(cluster, cc.client, cc.fedNamespace, cc.clusterNamespace, clientTimeout)
 	if err != nil || restClient == nil {
 		glog.Errorf("Failed to create corresponding restclient of kubernetes cluster: %v", err)
 		return


### PR DESCRIPTION
This is one of the step which would improve reliability of cluster health checks. This was missed previously.