### PR TITLE
Switch cluster references in placement from strings to objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Unreleased
+-  [#688](https://github.com/kubernetes-sigs/federation-v2/issues/688)
+   Cluster references in placement are now objects instead of strings
+   to ensure extensibility.
 -  [#832](https://github.com/kubernetes-sigs/federation-v2/issues/832)
    `kubefedctl federate` can take input from a file via `--filename`
    option and stdin via `--filename -` option.

--- a/charts/federation-v2/templates/crds.yaml
+++ b/charts/federation-v2/templates/crds.yaml
@@ -48,10 +48,6 @@ spec:
               type: array
             placement:
               properties:
-                clusterNames:
-                  items:
-                    type: string
-                  type: array
                 clusterSelector:
                   properties:
                     matchExpressions:
@@ -75,6 +71,15 @@ spec:
                         type: string
                       type: object
                   type: object
+                clusters:
+                  items:
+                    properties:
+                      name:
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  type: array
               type: object
             template:
               properties:
@@ -350,10 +355,6 @@ spec:
               type: array
             placement:
               properties:
-                clusterNames:
-                  items:
-                    type: string
-                  type: array
                 clusterSelector:
                   properties:
                     matchExpressions:
@@ -377,6 +378,15 @@ spec:
                         type: string
                       type: object
                   type: object
+                clusters:
+                  items:
+                    properties:
+                      name:
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  type: array
               type: object
             template:
               properties:
@@ -606,10 +616,6 @@ spec:
               type: array
             placement:
               properties:
-                clusterNames:
-                  items:
-                    type: string
-                  type: array
                 clusterSelector:
                   properties:
                     matchExpressions:
@@ -633,6 +639,15 @@ spec:
                         type: string
                       type: object
                   type: object
+                clusters:
+                  items:
+                    properties:
+                      name:
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  type: array
               type: object
             retainReplicas:
               type: boolean
@@ -2908,10 +2923,6 @@ spec:
               type: array
             placement:
               properties:
-                clusterNames:
-                  items:
-                    type: string
-                  type: array
                 clusterSelector:
                   properties:
                     matchExpressions:
@@ -2935,6 +2946,15 @@ spec:
                         type: string
                       type: object
                   type: object
+                clusters:
+                  items:
+                    properties:
+                      name:
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  type: array
               type: object
             template:
               properties:
@@ -3214,10 +3234,6 @@ spec:
               type: array
             placement:
               properties:
-                clusterNames:
-                  items:
-                    type: string
-                  type: array
                 clusterSelector:
                   properties:
                     matchExpressions:
@@ -3241,6 +3257,15 @@ spec:
                         type: string
                       type: object
                   type: object
+                clusters:
+                  items:
+                    properties:
+                      name:
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  type: array
               type: object
             template:
               properties:
@@ -5498,10 +5523,6 @@ spec:
               type: array
             placement:
               properties:
-                clusterNames:
-                  items:
-                    type: string
-                  type: array
                 clusterSelector:
                   properties:
                     matchExpressions:
@@ -5525,6 +5546,15 @@ spec:
                         type: string
                       type: object
                   type: object
+                clusters:
+                  items:
+                    properties:
+                      name:
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  type: array
               type: object
             template:
               properties:
@@ -5752,10 +5782,6 @@ spec:
               type: array
             placement:
               properties:
-                clusterNames:
-                  items:
-                    type: string
-                  type: array
                 clusterSelector:
                   properties:
                     matchExpressions:
@@ -5779,6 +5805,15 @@ spec:
                         type: string
                       type: object
                   type: object
+                clusters:
+                  items:
+                    properties:
+                      name:
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  type: array
               type: object
             retainReplicas:
               type: boolean
@@ -8025,10 +8060,6 @@ spec:
               type: array
             placement:
               properties:
-                clusterNames:
-                  items:
-                    type: string
-                  type: array
                 clusterSelector:
                   properties:
                     matchExpressions:
@@ -8052,6 +8083,15 @@ spec:
                         type: string
                       type: object
                   type: object
+                clusters:
+                  items:
+                    properties:
+                      name:
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  type: array
               type: object
             template:
               properties:
@@ -8283,10 +8323,6 @@ spec:
               type: array
             placement:
               properties:
-                clusterNames:
-                  items:
-                    type: string
-                  type: array
                 clusterSelector:
                   properties:
                     matchExpressions:
@@ -8310,6 +8346,15 @@ spec:
                         type: string
                       type: object
                   type: object
+                clusters:
+                  items:
+                    properties:
+                      name:
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  type: array
               type: object
             template:
               properties:
@@ -8558,10 +8603,6 @@ spec:
               type: array
             placement:
               properties:
-                clusterNames:
-                  items:
-                    type: string
-                  type: array
                 clusterSelector:
                   properties:
                     matchExpressions:
@@ -8585,6 +8626,15 @@ spec:
                         type: string
                       type: object
                   type: object
+                clusters:
+                  items:
+                    properties:
+                      name:
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  type: array
               type: object
             template:
               properties:

--- a/docs/userguide.md
+++ b/docs/userguide.md
@@ -26,10 +26,10 @@
     - [Check Status of Resources](#check-status-of-resources)
     - [Update FederatedNamespace Placement](#update-federatednamespace-placement)
       - [Using Cluster Selector](#using-cluster-selector)
-        - [Neither `spec.placement.clusterNames` nor `spec.placement.clusterSelector` is provided](#neither-specplacementclusternames-nor-specplacementclusterselector-is-provided)
-        - [Both `spec.placement.clusterNames` and `spec.placement.clusterSelector` are provided](#both-specplacementclusternames-and-specplacementclusterselector-are-provided)
-        - [`spec.placement.clusterNames` is not provided, `spec.placement.clusterSelector` is provided but empty](#specplacementclusternames-is-not-provided-specplacementclusterselector-is-provided-but-empty)
-        - [`spec.placement.clusterNames` is not provided, `spec.placement.clusterSelector` is provided and not empty](#specplacementclusternames-is-not-provided-specplacementclusterselector-is-provided-and-not-empty)
+        - [Neither `spec.placement.clusters` nor `spec.placement.clusterSelector` is provided](#neither-specplacementclusters-nor-specplacementclusterselector-is-provided)
+        - [Both `spec.placement.clusters` and `spec.placement.clusterSelector` are provided](#both-specplacementclusters-and-specplacementclusterselector-are-provided)
+        - [`spec.placement.clusters` is not provided, `spec.placement.clusterSelector` is provided but empty](#specplacementclusters-is-not-provided-specplacementclusterselector-is-provided-but-empty)
+        - [`spec.placement.clusters` is not provided, `spec.placement.clusterSelector` is provided and not empty](#specplacementclusters-is-not-provided-specplacementclusterselector-is-provided-and-not-empty)
     - [Example Cleanup](#example-cleanup)
     - [Troubleshooting](#troubleshooting)
   - [Namespaced Federation](#namespaced-federation)
@@ -503,7 +503,7 @@ Remove `cluster2` via a patch command or manually:
 
 ```bash
 kubectl -n test-namespace patch federatednamespace test-namespace \
-    --type=merge -p '{"spec": {"placement": {"clusterNames": ["cluster1"]}}}'
+    --type=merge -p '{"spec": {"placement": {"clusters": [{"name": "cluster1"}]}}}'
 
 kubectl -n test-namespace edit federatednamespace test-namespace
 ```
@@ -526,7 +526,7 @@ manually:
 
 ```bash
 kubectl -n test-namespace patch federatednamespace test-namespace \
-    --type=merge -p '{"spec": {"placement": {"clusterNames": ["cluster1", "cluster2"]}}}'
+    --type=merge -p '{"spec": {"placement": {"clusters": [{"name": "cluster1"}, {"name": "cluster2"}]}}}'
 
 kubectl -n test-namespace edit federatednamespace test-namespace
 ```
@@ -561,7 +561,7 @@ successfully verified a working federation-v2 deployment.
 #### Using Cluster Selector
 
 In addition to specifying an explicit list of clusters that a resource should be propagated
-to via the `spec.placement.clusterNames` field of a federated resource, it is possible to
+to via the `spec.placement.clusters` field of a federated resource, it is possible to
 use the `spec.placement.clusterSelector` field to provide a label selector that determines
 that list of clusters at runtime.
 
@@ -577,11 +577,11 @@ kubectl label federatedclusters -n kube-federation-system cluster1 foo=bar
 Please refer to [Kubernetes label command](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#label)
 to get more detail for how `kubectl label` works.
 
-The following sections detail how `spec.placement.clusterNames` and
+The following sections detail how `spec.placement.clusters` and
 `spec.placement.clusterSelector` are used in determining the clusters that a federated
 resource should be propagated to.
 
-##### Neither `spec.placement.clusterNames` nor `spec.placement.clusterSelector` is provided
+##### Neither `spec.placement.clusters` nor `spec.placement.clusterSelector` is provided
 
 ```yaml
 spec:
@@ -591,24 +591,24 @@ spec:
 In this case, you can either set `spec: {}` as above or remove `spec` field from your
 placement policy. The resource will not be propagated to member clusters.
 
-##### Both `spec.placement.clusterNames` and `spec.placement.clusterSelector` are provided
+##### Both `spec.placement.clusters` and `spec.placement.clusterSelector` are provided
 
 ```yaml
 spec:
   placement:
-    clusterNames:
-      - cluster2
-      - cluster1
+    clusters:
+      - name: cluster2
+      - name: cluster1
     clusterSelector:
       matchLabels:
         foo: bar
 ```
 
 For this case, `spec.placement.clusterSelector` will be ignored as
-`spec.placement.clusterNames` is provided. This ensures that the results of runtime
+`spec.placement.clusters` is provided. This ensures that the results of runtime
 scheduling have priority over manual definition of a cluster selector.
 
-##### `spec.placement.clusterNames` is not provided, `spec.placement.clusterSelector` is provided but empty
+##### `spec.placement.clusters` is not provided, `spec.placement.clusterSelector` is provided but empty
 
 ```yaml
 spec:
@@ -618,7 +618,7 @@ spec:
 
 In this case, the resource will be propagated to all member clusters.
 
-##### `spec.placement.clusterNames` is not provided, `spec.placement.clusterSelector` is provided and not empty
+##### `spec.placement.clusters` is not provided, `spec.placement.clusterSelector` is provided and not empty
 
 ```yaml
 spec:

--- a/example/sample1/federatedclusterrole.yaml
+++ b/example/sample1/federatedclusterrole.yaml
@@ -12,6 +12,6 @@ spec:
       verbs:
       - '*'
   placement:
-    clusterNames:
-    - cluster2
-    - cluster1
+    clusters:
+    - name: cluster2
+    - name: cluster1

--- a/example/sample1/federatedclusterrolebinding.yaml
+++ b/example/sample1/federatedclusterrolebinding.yaml
@@ -13,6 +13,6 @@ spec:
       name: cluster-admin
       apiGroup: rbac.authorization.k8s.io
   placement:
-    clusterNames:
-    - cluster2
-    - cluster1
+    clusters:
+    - name: cluster2
+    - name: cluster1

--- a/example/sample1/federatedconfigmap.yaml
+++ b/example/sample1/federatedconfigmap.yaml
@@ -8,9 +8,9 @@ spec:
     data:
       A: ala ma kota
   placement:
-    clusterNames:
-    - cluster2
-    - cluster1
+    clusters:
+    - name: cluster2
+    - name: cluster1
   overrides:
   - clusterName: cluster2
     clusterOverrides:

--- a/example/sample1/federateddeployment.yaml
+++ b/example/sample1/federateddeployment.yaml
@@ -22,9 +22,9 @@ spec:
           - image: nginx
             name: nginx
   placement:
-    clusterNames:
-    - cluster2
-    - cluster1
+    clusters:
+    - name: cluster2
+    - name: cluster1
   overrides:
   - clusterName: cluster2
     clusterOverrides:

--- a/example/sample1/federatedingress.yaml
+++ b/example/sample1/federatedingress.yaml
@@ -14,6 +14,6 @@ spec:
               serviceName: test-service
               servicePort: 80
   placement:
-    clusterNames:
-    - cluster2
-    - cluster1
+    clusters:
+    - name: cluster2
+    - name: cluster1

--- a/example/sample1/federatedjob.yaml
+++ b/example/sample1/federatedjob.yaml
@@ -23,9 +23,9 @@ spec:
               image: busybox
               command: ["/bin/sh", "-c", "trap : TERM INT; (while true; do sleep 1000; done) & wait"]
   placement:
-    clusterNames:
-    - cluster2
-    - cluster1
+    clusters:
+    - name: cluster2
+    - name: cluster1
   overrides:
   - clusterName: cluster2
     clusterOverrides:

--- a/example/sample1/federatednamespace.yaml
+++ b/example/sample1/federatednamespace.yaml
@@ -5,6 +5,6 @@ metadata:
   namespace: test-namespace
 spec:
   placement:
-    clusterNames:
-    - cluster2
-    - cluster1
+    clusters:
+    - name: cluster2
+    - name: cluster1

--- a/example/sample1/federatedsecret.yaml
+++ b/example/sample1/federatedsecret.yaml
@@ -9,9 +9,9 @@ spec:
       A: YWxhIG1hIGtvdGE=
     type: Opaque
   placement:
-    clusterNames:
-    - cluster2
-    - cluster1
+    clusters:
+    - name: cluster2
+    - name: cluster1
   overrides:
   - clusterName: cluster2
     clusterOverrides:

--- a/example/sample1/federatedservice.yaml
+++ b/example/sample1/federatedservice.yaml
@@ -13,6 +13,6 @@ spec:
         - name: http
           port: 80
   placement:
-    clusterNames:
-    - cluster2
-    - cluster1
+    clusters:
+    - name: cluster2
+    - name: cluster1

--- a/example/sample1/federatedserviceaccount.yaml
+++ b/example/sample1/federatedserviceaccount.yaml
@@ -7,6 +7,6 @@ spec:
   template:
     automountServiceAccountToken: true
   placement:
-    clusterNames:
-    - cluster2
-    - cluster1
+    clusters:
+    - name: cluster2
+    - name: cluster1

--- a/pkg/controller/sync/placement_test.go
+++ b/pkg/controller/sync/placement_test.go
@@ -78,7 +78,7 @@ func TestSelectedClusterNames(t *testing.T) {
 				},
 			}
 			if testCase.clusterNames != nil {
-				if err := unstructured.SetNestedStringSlice(obj.Object, testCase.clusterNames, util.SpecField, util.PlacementField, util.ClusterNamesField); err != nil {
+				if err := util.SetClusterNames(obj, testCase.clusterNames); err != nil {
 					t.Fatalf("Unexpected error: %v", err)
 				}
 			}

--- a/pkg/controller/util/constants.go
+++ b/pkg/controller/util/constants.go
@@ -51,7 +51,6 @@ const (
 
 	// Placement fields
 	PlacementField       = "placement"
-	ClusterNamesField    = "clusterNames"
 	ClusterSelectorField = "clusterSelector"
 	MatchLabelsField     = "matchLabels"
 
@@ -63,13 +62,15 @@ const (
 	ValueField            = "value"
 
 	// Propagation status fields
-	ClustersField           = "clusters"
-	NameField               = "name"
 	ConditionsField         = "conditions"
 	TypeField               = "type"
 	ReasonField             = "reason"
 	LastProbeTimeField      = "lastProbeTime"
 	LastTransitionTimeField = "lastTransitionTime"
+
+	// Cluster reference
+	ClustersField = "clusters"
+	NameField     = "name"
 )
 
 type ReconciliationStatus int

--- a/pkg/kubefedctl/enable/validation.go
+++ b/pkg/kubefedctl/enable/validation.go
@@ -29,14 +29,23 @@ func federatedTypeValidationSchema(templateSchema map[string]v1beta1.JSONSchemaP
 			"placement": {
 				Type: "object",
 				Properties: map[string]v1beta1.JSONSchemaProps{
-					// clusterName allows a scheduling mechanism to explicitly
-					// indicate placement. If clusterName is provided,
-					// labelSelector will be ignored.
-					"clusterNames": {
+					// References to one or more clusters allow a
+					// scheduling mechanism to explicitly indicate
+					// placement. If one or more clusters is provided,
+					// the clusterSelector field will be ignored.
+					"clusters": {
 						Type: "array",
 						Items: &v1beta1.JSONSchemaPropsOrArray{
 							Schema: &v1beta1.JSONSchemaProps{
-								Type: "string",
+								Type: "object",
+								Properties: map[string]v1beta1.JSONSchemaProps{
+									"name": {
+										Type: "string",
+									},
+								},
+								Required: []string{
+									"name",
+								},
 							},
 						},
 					},


### PR DESCRIPTION
This ensures that the addition of fields to cluster references will be backwards compatible.

Fixes #688