### PR TITLE
ignore related file for vim and scope development environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,9 @@
 /images/federation-v2/hyperfed
 # temporarily added below file to ignore list to avoid someone pushing this file in a pr by accident.
 /images/federation-v2/controller-manager
+
+# ignore vim generated temporary file
+*.swp
+
+# ignore cscope related files
+cscope.*


### PR DESCRIPTION
This helps vim users in developing federation project without committing temporary files in careless. 

Yes. I use VIM :-).