### PR TITLE
Update Makefile to use TRAVIS_BRANCH env var

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,6 @@ HOST_OS ?= $(shell uname -s | tr A-Z a-z)
 
 GIT_VERSION ?= $(shell git describe --always --dirty)
 GIT_TAG ?= $(shell git describe --tags --exact-match 2>/dev/null)
-GIT_BRANCH = $(shell git symbolic-ref --short -q HEAD)
 GIT_HASH ?= $(shell git rev-parse HEAD)
 BUILDDATE = $(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
 
@@ -125,7 +124,7 @@ push: container
 	elif [ "$(TRAVIS_PULL_REQUEST)" = "false" ]; \
 	then \
 		$(DOCKER) login -u "$(QUAY_USERNAME)" -p "$(QUAY_PASSWORD)" quay.io; \
-		if [ "$(GIT_BRANCH)" = "master" ]; \
+		if [ "$(TRAVIS_BRANCH)" = "master" ]; \
 		then \
 			$(DOCKER) tag $(REGISTRY)/$(TARGET):$(GIT_VERSION) $(REGISTRY)/$(TARGET):canary; \
 			$(DOCKER) push $(REGISTRY)/$(TARGET):canary; \


### PR DESCRIPTION
This should fix travis `master` builds in order to successfully push the `canary` tag.